### PR TITLE
Extract the input file translation logic into a separate function

### DIFF
--- a/compiler/ecpps/src/Shared/Diagnostics.cpp
+++ b/compiler/ecpps/src/Shared/Diagnostics.cpp
@@ -7,6 +7,7 @@
 
 #include "Linker/PE.h"
 
+
 void ecpps::IssueICE([[maybe_unused]] const TracedException& ex)
 {
 #ifdef _WIN32

--- a/compiler/ecpps/src/Shared/Diagnostics.cpp
+++ b/compiler/ecpps/src/Shared/Diagnostics.cpp
@@ -7,7 +7,6 @@
 
 #include "Linker/PE.h"
 
-
 void ecpps::IssueICE([[maybe_unused]] const TracedException& ex)
 {
 #ifdef _WIN32

--- a/compiler/ecpps/src/cli/main.cpp
+++ b/compiler/ecpps/src/cli/main.cpp
@@ -96,167 +96,173 @@ static void EnableVirtualProcessing(void)
 }
 #endif
 
-
 static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& config, bool isExtraVerbose,
-                          std::vector<std::byte>& generatedMachineCode, bool& hadErrors,
-                          std::vector<std::pair<std::string, std::size_t>>& functions,
-                          ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset) noexcept
+                            std::vector<std::byte>& generatedMachineCode, bool& hadErrors,
+                            std::vector<std::pair<std::string, std::size_t>>& functions,
+                            ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset)
+{
+     if (config.verboseStatus != ecpps::VerboseStatus::Default) std::println("Compiling {}...", source.name);
+     // ECPPS pushed macros (& standard)
+
+     std::vector<ecpps::MacroReplacement> macros{};
+     macros.emplace_back("__cplusplus", std::nullopt, "202302", false); // TODO: 202302L
+     macros.emplace_back("__LINE__", std::nullopt, "1", false);
+     macros.emplace_back("__FILE__", std::nullopt, "\"" + source.name + "\"", false);
+     const auto now = std::chrono::system_clock::now();
+     std::chrono::year_month_day ymd{std::chrono::floor<std::chrono::days>(now)};
+     macros.emplace_back("__DATE__", std::nullopt, std::format("\"{:%b %e %Y}\"", ymd), false);
+     std::chrono::hh_mm_ss hms{
+         std::chrono::floor<std::chrono::seconds>(now - std::chrono::floor<std::chrono::days>(now))};
+     macros.emplace_back("__TIME__", std::nullopt, std::format("\"{:%T}\"", hms), false);
+     // TODO: __STDC_HOSTED__
+     // TODO: __STDCPP_DEFAULT_NEW_ALIGNMENT__
+     // TODO: __STDCPP_FLOAT16_T__
+     // TODO: __STDCPP_FLOAT32_T__
+     // TODO: __STDCPP_FLOAT64_T__
+     // TODO: __STDCPP_FLOAT128_T__
+     // TODO: __STDCPP_BFLOAT16_T__
+     // TODO: feature-test macros
+     // TODO: __STDCPP_THREADS__
+
+     macros.emplace_back("__ecpps_stl_version", std::nullopt, "0", false);
+     macros.emplace_back("__ecpps_stl_version_minor", std::nullopt, "0", false);
+     macros.emplace_back("__ecpps_stl_version_patch", std::nullopt, "1", false);
+     macros.emplace_back("__ecpps_version", std::nullopt, "000001", false);
+     macros.emplace_back("__ecpps_version_minor", std::nullopt, "0", false);
+     macros.emplace_back("__ecpps_version_patch", std::nullopt, "1", false);
+     std::set<std::filesystem::path> includedFiles;
+     ecpps::Preprocessor preprocessor{};
+     const auto ppTokens =
+         preprocessor.Parse(source.contents, macros, source.name, includedFiles, config.includeDirectories);
+     std::ranges::move(preprocessor.diagnostics, std::back_inserter(source.diagnostics.diagnosticsList));
+     const auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
+     if (isExtraVerbose) std::println();
+     if (isExtraVerbose) std::println("Tokens:");
+     if (isExtraVerbose) ecpps::Tokeniser::Print(tokens);
+     ecpps::ast::ASTContext astContext{};
+     ecpps::ast::AST astParser{tokens, source.diagnostics};
+     auto ast = astParser.Parse(astContext);
+     if (isExtraVerbose) std::println();
+     if (isExtraVerbose) std::println("AST:");
+     if (isExtraVerbose)
+          for (const auto& node : ast) std::println("{}", node->ToString(0));
+     ecpps::BumpAllocator irAllocator{};
+     const auto ir = ecpps::ir::IR::Parse(source.diagnostics, irAllocator, ast);
+     if (isExtraVerbose) std::println();
+     if (isExtraVerbose) std::println("IR:");
+     if (isExtraVerbose)
+          for (const auto& node : ir) std::println("{}", node->ToString(0));
+     ast.clear();
+     astContext.Release();
+     ecpps::codegen::Compile(config, source, ir);
+
+     if (isExtraVerbose) std::println();
+     if (isExtraVerbose) std::println("Assembly:");
+
+     std::unordered_map<std::string, std::size_t> routines{};
+     routines.reserve(source.compiledRoutines.size());
+
+     for (const auto& procedure : source.compiledRoutines)
+     {
+          if (isExtraVerbose)
+          {
+               std::println("{}:", procedure.name);
+               for (const auto& instruction : procedure.instructions)
+               {
+                    std::println("     {}", ecpps::codegen::ToString(instruction));
+               }
+          }
+
+          const auto machineCode = emitter.EmitRoutine(procedure, generatedMachineCode.size());
+
+          routines.emplace(procedure.name, generatedMachineCode.size());
+          generatedMachineCode.append_range(machineCode);
+          if (!isExtraVerbose) continue;
+     }
+
+     emitter.PatchCalls(generatedMachineCode, routines);
+
+     for (const auto placemenent : emitter._stringRelocation)
+     {
+          auto bytes = std::span{generatedMachineCode.data() + placemenent, emitter._stringRelocationSize};
+          auto* dword = std::bit_cast<std::uint32_t*>(bytes.data());
+          *dword += 0x4000 - 0x1000;
+          std::memcpy(bytes.data(), dword, sizeof(*dword));
+     }
+
+     for (const auto& [procedureName, procedurOffset] : routines)
+     {
+          if (procedureName == "_EntryPoint") mainOffset = procedurOffset;
+
+          functions.emplace_back(procedureName, procedurOffset);
+     }
+
+     if (isExtraVerbose)
+     {
+          std::vector<std::pair<std::string, std::size_t>> ordered;
+          ordered.reserve(routines.size());
+          for (const auto& r : routines) ordered.emplace_back(r);
+
+          std::ranges::sort(ordered, {}, &std::pair<std::string, std::size_t>::second);
+
+          for (std::size_t i = 0; i < ordered.size(); i++)
+          {
+               const auto& [routineName, routineOffset] = ordered[i];
+               std::println("{}:", routineName);
+
+               std::size_t start = std::min(routineOffset, generatedMachineCode.size());
+               std::size_t end = (i + 1 < ordered.size()) ? std::min(ordered[i + 1].second, generatedMachineCode.size())
+                                                          : generatedMachineCode.size();
+
+               if (start >= end) continue;
+
+               auto machineCode =
+                   std::ranges::subrange(generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(start),
+                                         generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(end));
+
+               constexpr std::size_t RowSize = 8; // in bytes
+               const auto rows = (machineCode.size() + RowSize - 1) / RowSize;
+
+               std::println("Emitted {} bytes:", machineCode.size());
+               for (std::size_t row = 0; row < rows; row++)
+               {
+                    std::print("| ");
+                    const auto offset = row * RowSize;
+                    for (std::size_t column = 0; column < RowSize; column++)
+                    {
+                         const auto byteOffset = offset + column;
+                         if (byteOffset >= machineCode.size()) std::print("   ");
+                         else
+                              std::print("{:02x} ", static_cast<std::size_t>(
+                                                        machineCode[static_cast<std::ptrdiff_t>(byteOffset)]));
+                    }
+                    std::println("|");
+               }
+          }
+     }
+
+     for (const auto& diag : source.diagnostics.diagnosticsList)
+     {
+          ecpps::diagnostics::PrintDiagnostic(source.name, diag);
+
+          if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
+              (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+               break;
+          hadErrors = true;
+     }
+}
+
+static void TryFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& config, bool isExtraVerbose,
+                             std::vector<std::byte>& generatedMachineCode, bool& hadErrors,
+                             std::vector<std::pair<std::string, std::size_t>>& functions,
+                             ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset)
 {
      g_diagnosticsReferences.emplace(source.name, &source.diagnostics);
 
      try
      {
-          if (config.verboseStatus != ecpps::VerboseStatus::Default) std::println("Compiling {}...", source.name);
-          // ECPPS pushed macros (& standard)
-
-          std::vector<ecpps::MacroReplacement> macros{};
-          macros.emplace_back("__cplusplus", std::nullopt, "202302", false); // TODO: 202302L
-          macros.emplace_back("__LINE__", std::nullopt, "1", false);
-          macros.emplace_back("__FILE__", std::nullopt, "\"" + source.name + "\"", false);
-          const auto now = std::chrono::system_clock::now();
-          std::chrono::year_month_day ymd{std::chrono::floor<std::chrono::days>(now)};
-          macros.emplace_back("__DATE__", std::nullopt, std::format("\"{:%b %e %Y}\"", ymd), false);
-          std::chrono::hh_mm_ss hms{
-               std::chrono::floor<std::chrono::seconds>(now - std::chrono::floor<std::chrono::days>(now))};
-          macros.emplace_back("__TIME__", std::nullopt, std::format("\"{:%T}\"", hms), false);
-          // TODO: __STDC_HOSTED__
-          // TODO: __STDCPP_DEFAULT_NEW_ALIGNMENT__
-          // TODO: __STDCPP_FLOAT16_T__
-          // TODO: __STDCPP_FLOAT32_T__
-          // TODO: __STDCPP_FLOAT64_T__
-          // TODO: __STDCPP_FLOAT128_T__
-          // TODO: __STDCPP_BFLOAT16_T__
-          // TODO: feature-test macros
-          // TODO: __STDCPP_THREADS__
-
-          macros.emplace_back("__ecpps_stl_version", std::nullopt, "0", false);
-          macros.emplace_back("__ecpps_stl_version_minor", std::nullopt, "0", false);
-          macros.emplace_back("__ecpps_stl_version_patch", std::nullopt, "1", false);
-          macros.emplace_back("__ecpps_version", std::nullopt, "000001", false);
-          macros.emplace_back("__ecpps_version_minor", std::nullopt, "0", false);
-          macros.emplace_back("__ecpps_version_patch", std::nullopt, "1", false);
-          std::set<std::filesystem::path> includedFiles;
-          ecpps::Preprocessor preprocessor{};
-          const auto ppTokens =
-               preprocessor.Parse(source.contents, macros, source.name, includedFiles, config.includeDirectories);
-          std::ranges::move(preprocessor.diagnostics, std::back_inserter(source.diagnostics.diagnosticsList));
-          const auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-          if (isExtraVerbose) std::println();
-          if (isExtraVerbose) std::println("Tokens:");
-          if (isExtraVerbose) ecpps::Tokeniser::Print(tokens);
-          ecpps::ast::ASTContext astContext{};
-          ecpps::ast::AST astParser{tokens, source.diagnostics};
-          auto ast = astParser.Parse(astContext);
-          if (isExtraVerbose) std::println();
-          if (isExtraVerbose) std::println("AST:");
-          if (isExtraVerbose)
-               for (const auto& node : ast) std::println("{}", node->ToString(0));
-          ecpps::BumpAllocator irAllocator{};
-          const auto ir = ecpps::ir::IR::Parse(source.diagnostics, irAllocator, ast);
-          if (isExtraVerbose) std::println();
-          if (isExtraVerbose) std::println("IR:");
-          if (isExtraVerbose)
-               for (const auto& node : ir) std::println("{}", node->ToString(0));
-          ast.clear();
-          astContext.Release();
-          ecpps::codegen::Compile(config, source, ir);
-
-          if (isExtraVerbose) std::println();
-          if (isExtraVerbose) std::println("Assembly:");
-
-          std::unordered_map<std::string, std::size_t> routines{};
-          routines.reserve(source.compiledRoutines.size());
-
-          for (const auto& procedure : source.compiledRoutines)
-          {
-               if (isExtraVerbose)
-               {
-                    std::println("{}:", procedure.name);
-                    for (const auto& instruction : procedure.instructions)
-                    {
-                         std::println("     {}", ecpps::codegen::ToString(instruction));
-                    }
-               }
-
-               const auto machineCode = emitter.EmitRoutine(procedure, generatedMachineCode.size());
-
-               routines.emplace(procedure.name, generatedMachineCode.size());
-               generatedMachineCode.append_range(machineCode);
-               if (!isExtraVerbose) continue;
-          }
-
-          emitter.PatchCalls(generatedMachineCode, routines);
-
-          for (const auto placemenent : emitter._stringRelocation)
-          {
-               auto bytes = std::span{generatedMachineCode.data() + placemenent, emitter._stringRelocationSize};
-               auto* dword = std::bit_cast<std::uint32_t*>(bytes.data());
-               *dword += 0x4000 - 0x1000;
-               std::memcpy(bytes.data(), dword, sizeof(*dword));
-          }
-
-          for (const auto& [procedureName, procedurOffset] : routines)
-          {
-               if (procedureName == "_EntryPoint") mainOffset = procedurOffset;
-
-               functions.emplace_back(procedureName, procedurOffset);
-          }
-
-          if (isExtraVerbose)
-          {
-               std::vector<std::pair<std::string, std::size_t>> ordered;
-               ordered.reserve(routines.size());
-               for (const auto& r : routines) ordered.emplace_back(r);
-
-               std::ranges::sort(ordered, {}, &std::pair<std::string, std::size_t>::second);
-
-               for (std::size_t i = 0; i < ordered.size(); i++)
-               {
-                    const auto& [routineName, routineOffset] = ordered[i];
-                    std::println("{}:", routineName);
-
-                    std::size_t start = std::min(routineOffset, generatedMachineCode.size());
-                    std::size_t end = (i + 1 < ordered.size())
-                                             ? std::min(ordered[i + 1].second, generatedMachineCode.size())
-                                             : generatedMachineCode.size();
-
-                    if (start >= end) continue;
-
-                    auto machineCode =
-                         std::ranges::subrange(generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(start),
-                                                  generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(end));
-
-                    constexpr std::size_t RowSize = 8; // in bytes
-                    const auto rows = (machineCode.size() + RowSize - 1) / RowSize;
-
-                    std::println("Emitted {} bytes:", machineCode.size());
-                    for (std::size_t row = 0; row < rows; row++)
-                    {
-                         std::print("| ");
-                         const auto offset = row * RowSize;
-                         for (std::size_t column = 0; column < RowSize; column++)
-                         {
-                              const auto byteOffset = offset + column;
-                              if (byteOffset >= machineCode.size()) std::print("   ");
-                              else
-                                   std::print("{:02x} ",
-                                                  static_cast<std::size_t>(
-                                                  machineCode[static_cast<std::ptrdiff_t>(byteOffset)]));
-                         }
-                         std::println("|");
-                    }
-               }
-          }
-
-          for (const auto& diag : source.diagnostics.diagnosticsList)
-          {
-               ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-               if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                    (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                    break;
-               hadErrors = true;
-          }
+          DoFileIteration(source, config, isExtraVerbose, generatedMachineCode, hadErrors, functions, emitter,
+                          mainOffset);
      }
      catch (const ecpps::TracedException& traceException)
      {
@@ -268,8 +274,7 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
                     ecpps::diagnostics::PrintDiagnostic(source.name, diag);
 
                     if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                         (!config.warningsAreErrors ||
-                         diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+                        (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
                          break;
                     hadErrors = true;
                }
@@ -285,7 +290,7 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
 
           ecpps::IssueICE(traceException);
 
-		std::exit(-1);
+          std::exit(-1);
      }
      catch (const std::exception& e)
      {
@@ -298,8 +303,7 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
                     ecpps::diagnostics::PrintDiagnostic(source.name, diag);
 
                     if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                         (!config.warningsAreErrors ||
-                         diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+                        (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
                          break;
                     hadErrors = true;
                }
@@ -315,7 +319,7 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
 
           ecpps::IssueICE(e.what(), nullptr);
 
-		std::exit(-1);      
+          std::exit(-1);
      }
      catch (...)
      {
@@ -327,8 +331,7 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
                     ecpps::diagnostics::PrintDiagnostic(source.name, diag);
 
                     if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                         (!config.warningsAreErrors ||
-                         diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+                        (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
                          break;
                     hadErrors = true;
                }
@@ -406,20 +409,11 @@ int main(int argc, char* argv[])
 
           g_diagnosticsReferences.reserve(sources.files.size());
 
-		
-		for (ecpps::SourceFile &source : sources.files)
-		{
-               DoFileIteration(
-				source,
-				config,
-				isExtraVerbose,
-				generatedMachineCode,
-				hadErrors,
-				functions,
-				*emitter,
-				mainOffset
-			);
-		}
+          for (ecpps::SourceFile& source : sources.files)
+          {
+               TryFileIteration(source, config, isExtraVerbose, generatedMachineCode, hadErrors, functions, *emitter,
+                                mainOffset);
+          }
 
           if (hadErrors)
           {

--- a/compiler/ecpps/src/cli/main.cpp
+++ b/compiler/ecpps/src/cli/main.cpp
@@ -96,10 +96,17 @@ static void EnableVirtualProcessing(void)
 }
 #endif
 
-static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& config, bool isExtraVerbose,
-                            std::vector<std::byte>& generatedMachineCode, bool& hadErrors,
-                            std::vector<std::pair<std::string, std::size_t>>& functions,
-                            ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset)
+enum struct FileIterationStatus : bool
+{
+     Success = true,
+     Failure = false
+};
+
+[[nodiscard]] static FileIterationStatus DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& config,
+                                                         bool isExtraVerbose,
+                                                         std::vector<std::byte>& generatedMachineCode,
+                                                         std::vector<std::pair<std::string, std::size_t>>& functions,
+                                                         ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset)
 {
      g_diagnosticsReferences.emplace(source.name, &source.diagnostics);
 
@@ -246,19 +253,20 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
                }
           }
 
+          bool shouldFail = false;
           for (const auto& diag : source.diagnostics.diagnosticsList)
           {
                ecpps::diagnostics::PrintDiagnostic(source.name, diag);
 
                if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
                    (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                    break;
-               hadErrors = true;
+                    continue;
+               shouldFail = true;
           }
+          if (shouldFail) return FileIterationStatus::Failure;
      }
      catch (const ecpps::TracedException& traceException)
      {
-          hadErrors = true;
           try
           {
                for (const auto& diag : source.diagnostics.diagnosticsList)
@@ -268,7 +276,6 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
                     if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
                         (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
                          break;
-                    hadErrors = true;
                }
           }
           catch (const ecpps::TracedException& nestedTraceException)
@@ -282,12 +289,10 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
 
           ecpps::IssueICE(traceException);
 
-          std::exit(-1);
+          return FileIterationStatus::Failure;
      }
      catch (const std::exception& e)
      {
-          hadErrors = true;
-
           try
           {
                for (const auto& diag : source.diagnostics.diagnosticsList)
@@ -297,7 +302,6 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
                     if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
                         (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
                          break;
-                    hadErrors = true;
                }
           }
           catch (const ecpps::TracedException& nestedTraceException)
@@ -311,11 +315,10 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
 
           ecpps::IssueICE(e.what(), nullptr);
 
-          std::exit(-1);
+          return FileIterationStatus::Failure;
      }
      catch (...)
      {
-          hadErrors = true;
           try
           {
                for (const auto& diag : source.diagnostics.diagnosticsList)
@@ -325,7 +328,6 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
                     if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
                         (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
                          break;
-                    hadErrors = true;
                }
           }
           catch (const ecpps::TracedException& nestedTraceException)
@@ -339,8 +341,9 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
 
           ecpps::IssueICE("unknown", nullptr);
 
-          std::exit(-1);
+          return FileIterationStatus::Failure;
      }
+     return FileIterationStatus::Success;
 }
 
 int main(int argc, char* argv[])
@@ -403,8 +406,8 @@ int main(int argc, char* argv[])
 
           for (ecpps::SourceFile& source : sources.files)
           {
-               DoFileIteration(source, config, isExtraVerbose, generatedMachineCode, hadErrors, functions, *emitter,
-                               mainOffset);
+               hadErrors |= DoFileIteration(source, config, isExtraVerbose, generatedMachineCode, functions, *emitter,
+                                            mainOffset) == FileIterationStatus::Failure;
           }
 
           if (hadErrors)

--- a/compiler/ecpps/src/cli/main.cpp
+++ b/compiler/ecpps/src/cli/main.cpp
@@ -101,168 +101,160 @@ static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& co
                             std::vector<std::pair<std::string, std::size_t>>& functions,
                             ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset)
 {
-     if (config.verboseStatus != ecpps::VerboseStatus::Default) std::println("Compiling {}...", source.name);
-     // ECPPS pushed macros (& standard)
-
-     std::vector<ecpps::MacroReplacement> macros{};
-     macros.emplace_back("__cplusplus", std::nullopt, "202302", false); // TODO: 202302L
-     macros.emplace_back("__LINE__", std::nullopt, "1", false);
-     macros.emplace_back("__FILE__", std::nullopt, "\"" + source.name + "\"", false);
-     const auto now = std::chrono::system_clock::now();
-     std::chrono::year_month_day ymd{std::chrono::floor<std::chrono::days>(now)};
-     macros.emplace_back("__DATE__", std::nullopt, std::format("\"{:%b %e %Y}\"", ymd), false);
-     std::chrono::hh_mm_ss hms{
-         std::chrono::floor<std::chrono::seconds>(now - std::chrono::floor<std::chrono::days>(now))};
-     macros.emplace_back("__TIME__", std::nullopt, std::format("\"{:%T}\"", hms), false);
-     // TODO: __STDC_HOSTED__
-     // TODO: __STDCPP_DEFAULT_NEW_ALIGNMENT__
-     // TODO: __STDCPP_FLOAT16_T__
-     // TODO: __STDCPP_FLOAT32_T__
-     // TODO: __STDCPP_FLOAT64_T__
-     // TODO: __STDCPP_FLOAT128_T__
-     // TODO: __STDCPP_BFLOAT16_T__
-     // TODO: feature-test macros
-     // TODO: __STDCPP_THREADS__
-
-     macros.emplace_back("__ecpps_stl_version", std::nullopt, "0", false);
-     macros.emplace_back("__ecpps_stl_version_minor", std::nullopt, "0", false);
-     macros.emplace_back("__ecpps_stl_version_patch", std::nullopt, "1", false);
-     macros.emplace_back("__ecpps_version", std::nullopt, "000001", false);
-     macros.emplace_back("__ecpps_version_minor", std::nullopt, "0", false);
-     macros.emplace_back("__ecpps_version_patch", std::nullopt, "1", false);
-     std::set<std::filesystem::path> includedFiles;
-     ecpps::Preprocessor preprocessor{};
-     const auto ppTokens =
-         preprocessor.Parse(source.contents, macros, source.name, includedFiles, config.includeDirectories);
-     std::ranges::move(preprocessor.diagnostics, std::back_inserter(source.diagnostics.diagnosticsList));
-     const auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-     if (isExtraVerbose) std::println();
-     if (isExtraVerbose) std::println("Tokens:");
-     if (isExtraVerbose) ecpps::Tokeniser::Print(tokens);
-     ecpps::ast::ASTContext astContext{};
-     ecpps::ast::AST astParser{tokens, source.diagnostics};
-     auto ast = astParser.Parse(astContext);
-     if (isExtraVerbose) std::println();
-     if (isExtraVerbose) std::println("AST:");
-     if (isExtraVerbose)
-          for (const auto& node : ast) std::println("{}", node->ToString(0));
-     ecpps::BumpAllocator irAllocator{};
-     const auto ir = ecpps::ir::IR::Parse(source.diagnostics, irAllocator, ast);
-     if (isExtraVerbose) std::println();
-     if (isExtraVerbose) std::println("IR:");
-     if (isExtraVerbose)
-          for (const auto& node : ir) std::println("{}", node->ToString(0));
-     ast.clear();
-     astContext.Release();
-     ecpps::codegen::Compile(config, source, ir);
-
-     if (isExtraVerbose) std::println();
-     if (isExtraVerbose) std::println("Assembly:");
-
-     std::unordered_map<std::string, std::size_t> routines{};
-     routines.reserve(source.compiledRoutines.size());
-
-     for (const auto& procedure : source.compiledRoutines)
-     {
-          if (isExtraVerbose)
-          {
-               std::println("{}:", procedure.name);
-               for (const auto& instruction : procedure.instructions)
-               {
-                    std::println("     {}", ecpps::codegen::ToString(instruction));
-               }
-          }
-
-          const auto machineCode = emitter.EmitRoutine(procedure, generatedMachineCode.size());
-
-          routines.emplace(procedure.name, generatedMachineCode.size());
-          generatedMachineCode.append_range(machineCode);
-          if (!isExtraVerbose) continue;
-     }
-
-     emitter.PatchCalls(generatedMachineCode, routines);
-
-     for (const auto placemenent : emitter._stringRelocation)
-     {
-          auto bytes = std::span{generatedMachineCode.data() + placemenent, emitter._stringRelocationSize};
-          auto* dword = std::bit_cast<std::uint32_t*>(bytes.data());
-          *dword += 0x4000 - 0x1000;
-          std::memcpy(bytes.data(), dword, sizeof(*dword));
-     }
-
-     for (const auto& [procedureName, procedurOffset] : routines)
-     {
-          if (procedureName == "_EntryPoint") mainOffset = procedurOffset;
-
-          functions.emplace_back(procedureName, procedurOffset);
-     }
-
-     if (isExtraVerbose)
-     {
-          std::vector<std::pair<std::string, std::size_t>> ordered;
-          ordered.reserve(routines.size());
-          for (const auto& r : routines) ordered.emplace_back(r);
-
-          std::ranges::sort(ordered, {}, &std::pair<std::string, std::size_t>::second);
-
-          for (std::size_t i = 0; i < ordered.size(); i++)
-          {
-               const auto& [routineName, routineOffset] = ordered[i];
-               std::println("{}:", routineName);
-
-               std::size_t start = std::min(routineOffset, generatedMachineCode.size());
-               std::size_t end = (i + 1 < ordered.size()) ? std::min(ordered[i + 1].second, generatedMachineCode.size())
-                                                          : generatedMachineCode.size();
-
-               if (start >= end) continue;
-
-               auto machineCode =
-                   std::ranges::subrange(generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(start),
-                                         generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(end));
-
-               constexpr std::size_t RowSize = 8; // in bytes
-               const auto rows = (machineCode.size() + RowSize - 1) / RowSize;
-
-               std::println("Emitted {} bytes:", machineCode.size());
-               for (std::size_t row = 0; row < rows; row++)
-               {
-                    std::print("| ");
-                    const auto offset = row * RowSize;
-                    for (std::size_t column = 0; column < RowSize; column++)
-                    {
-                         const auto byteOffset = offset + column;
-                         if (byteOffset >= machineCode.size()) std::print("   ");
-                         else
-                              std::print("{:02x} ", static_cast<std::size_t>(
-                                                        machineCode[static_cast<std::ptrdiff_t>(byteOffset)]));
-                    }
-                    std::println("|");
-               }
-          }
-     }
-
-     for (const auto& diag : source.diagnostics.diagnosticsList)
-     {
-          ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-          if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-              (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-               break;
-          hadErrors = true;
-     }
-}
-
-static void TryFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& config, bool isExtraVerbose,
-                             std::vector<std::byte>& generatedMachineCode, bool& hadErrors,
-                             std::vector<std::pair<std::string, std::size_t>>& functions,
-                             ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset)
-{
      g_diagnosticsReferences.emplace(source.name, &source.diagnostics);
 
      try
      {
-          DoFileIteration(source, config, isExtraVerbose, generatedMachineCode, hadErrors, functions, emitter,
-                          mainOffset);
+          if (config.verboseStatus != ecpps::VerboseStatus::Default) std::println("Compiling {}...", source.name);
+          // ECPPS pushed macros (& standard)
+
+          std::vector<ecpps::MacroReplacement> macros{};
+          macros.emplace_back("__cplusplus", std::nullopt, "202302", false); // TODO: 202302L
+          macros.emplace_back("__LINE__", std::nullopt, "1", false);
+          macros.emplace_back("__FILE__", std::nullopt, "\"" + source.name + "\"", false);
+          const auto now = std::chrono::system_clock::now();
+          std::chrono::year_month_day ymd{std::chrono::floor<std::chrono::days>(now)};
+          macros.emplace_back("__DATE__", std::nullopt, std::format("\"{:%b %e %Y}\"", ymd), false);
+          std::chrono::hh_mm_ss hms{
+              std::chrono::floor<std::chrono::seconds>(now - std::chrono::floor<std::chrono::days>(now))};
+          macros.emplace_back("__TIME__", std::nullopt, std::format("\"{:%T}\"", hms), false);
+          // TODO: __STDC_HOSTED__
+          // TODO: __STDCPP_DEFAULT_NEW_ALIGNMENT__
+          // TODO: __STDCPP_FLOAT16_T__
+          // TODO: __STDCPP_FLOAT32_T__
+          // TODO: __STDCPP_FLOAT64_T__
+          // TODO: __STDCPP_FLOAT128_T__
+          // TODO: __STDCPP_BFLOAT16_T__
+          // TODO: feature-test macros
+          // TODO: __STDCPP_THREADS__
+
+          macros.emplace_back("__ecpps_stl_version", std::nullopt, "0", false);
+          macros.emplace_back("__ecpps_stl_version_minor", std::nullopt, "0", false);
+          macros.emplace_back("__ecpps_stl_version_patch", std::nullopt, "1", false);
+          macros.emplace_back("__ecpps_version", std::nullopt, "000001", false);
+          macros.emplace_back("__ecpps_version_minor", std::nullopt, "0", false);
+          macros.emplace_back("__ecpps_version_patch", std::nullopt, "1", false);
+          std::set<std::filesystem::path> includedFiles;
+          ecpps::Preprocessor preprocessor{};
+          const auto ppTokens =
+              preprocessor.Parse(source.contents, macros, source.name, includedFiles, config.includeDirectories);
+          std::ranges::move(preprocessor.diagnostics, std::back_inserter(source.diagnostics.diagnosticsList));
+          const auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
+          if (isExtraVerbose) std::println();
+          if (isExtraVerbose) std::println("Tokens:");
+          if (isExtraVerbose) ecpps::Tokeniser::Print(tokens);
+          ecpps::ast::ASTContext astContext{};
+          ecpps::ast::AST astParser{tokens, source.diagnostics};
+          auto ast = astParser.Parse(astContext);
+          if (isExtraVerbose) std::println();
+          if (isExtraVerbose) std::println("AST:");
+          if (isExtraVerbose)
+               for (const auto& node : ast) std::println("{}", node->ToString(0));
+          ecpps::BumpAllocator irAllocator{};
+          const auto ir = ecpps::ir::IR::Parse(source.diagnostics, irAllocator, ast);
+          if (isExtraVerbose) std::println();
+          if (isExtraVerbose) std::println("IR:");
+          if (isExtraVerbose)
+               for (const auto& node : ir) std::println("{}", node->ToString(0));
+          ast.clear();
+          astContext.Release();
+          ecpps::codegen::Compile(config, source, ir);
+
+          if (isExtraVerbose) std::println();
+          if (isExtraVerbose) std::println("Assembly:");
+
+          std::unordered_map<std::string, std::size_t> routines{};
+          routines.reserve(source.compiledRoutines.size());
+
+          for (const auto& procedure : source.compiledRoutines)
+          {
+               if (isExtraVerbose)
+               {
+                    std::println("{}:", procedure.name);
+                    for (const auto& instruction : procedure.instructions)
+                    {
+                         std::println("     {}", ecpps::codegen::ToString(instruction));
+                    }
+               }
+
+               const auto machineCode = emitter.EmitRoutine(procedure, generatedMachineCode.size());
+
+               routines.emplace(procedure.name, generatedMachineCode.size());
+               generatedMachineCode.append_range(machineCode);
+               if (!isExtraVerbose) continue;
+          }
+
+          emitter.PatchCalls(generatedMachineCode, routines);
+
+          for (const auto placemenent : emitter._stringRelocation)
+          {
+               auto bytes = std::span{generatedMachineCode.data() + placemenent, emitter._stringRelocationSize};
+               auto* dword = std::bit_cast<std::uint32_t*>(bytes.data());
+               *dword += 0x4000 - 0x1000;
+               std::memcpy(bytes.data(), dword, sizeof(*dword));
+          }
+
+          for (const auto& [procedureName, procedurOffset] : routines)
+          {
+               if (procedureName == "_EntryPoint") mainOffset = procedurOffset;
+
+               functions.emplace_back(procedureName, procedurOffset);
+          }
+
+          if (isExtraVerbose)
+          {
+               std::vector<std::pair<std::string, std::size_t>> ordered;
+               ordered.reserve(routines.size());
+               for (const auto& r : routines) ordered.emplace_back(r);
+
+               std::ranges::sort(ordered, {}, &std::pair<std::string, std::size_t>::second);
+
+               for (std::size_t i = 0; i < ordered.size(); i++)
+               {
+                    const auto& [routineName, routineOffset] = ordered[i];
+                    std::println("{}:", routineName);
+
+                    std::size_t start = std::min(routineOffset, generatedMachineCode.size());
+                    std::size_t end = (i + 1 < ordered.size())
+                                          ? std::min(ordered[i + 1].second, generatedMachineCode.size())
+                                          : generatedMachineCode.size();
+
+                    if (start >= end) continue;
+
+                    auto machineCode =
+                        std::ranges::subrange(generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(start),
+                                              generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(end));
+
+                    constexpr std::size_t RowSize = 8; // in bytes
+                    const auto rows = (machineCode.size() + RowSize - 1) / RowSize;
+
+                    std::println("Emitted {} bytes:", machineCode.size());
+                    for (std::size_t row = 0; row < rows; row++)
+                    {
+                         std::print("| ");
+                         const auto offset = row * RowSize;
+                         for (std::size_t column = 0; column < RowSize; column++)
+                         {
+                              const auto byteOffset = offset + column;
+                              if (byteOffset >= machineCode.size()) std::print("   ");
+                              else
+                                   std::print("{:02x} ", static_cast<std::size_t>(
+                                                             machineCode[static_cast<std::ptrdiff_t>(byteOffset)]));
+                         }
+                         std::println("|");
+                    }
+               }
+          }
+
+          for (const auto& diag : source.diagnostics.diagnosticsList)
+          {
+               ecpps::diagnostics::PrintDiagnostic(source.name, diag);
+
+               if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
+                   (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+                    break;
+               hadErrors = true;
+          }
      }
      catch (const ecpps::TracedException& traceException)
      {
@@ -411,8 +403,8 @@ int main(int argc, char* argv[])
 
           for (ecpps::SourceFile& source : sources.files)
           {
-               TryFileIteration(source, config, isExtraVerbose, generatedMachineCode, hadErrors, functions, *emitter,
-                                mainOffset);
+               DoFileIteration(source, config, isExtraVerbose, generatedMachineCode, hadErrors, functions, *emitter,
+                               mainOffset);
           }
 
           if (hadErrors)

--- a/compiler/ecpps/src/cli/main.cpp
+++ b/compiler/ecpps/src/cli/main.cpp
@@ -102,6 +102,13 @@ enum struct FileIterationStatus : bool
      Failure = false
 };
 
+[[nodiscard]] static bool IsDiagnosticsCritical(const ecpps::diagnostics::DiagnosticsMessage& diagnostic,
+                                                const ecpps::CompilerConfig& config)
+{
+     return diagnostic->Level() == ecpps::diagnostics::DiagnosticsLevel::Error ||
+            (config.warningsAreErrors && diagnostic->Level() == ecpps::diagnostics::DiagnosticsLevel::Warning);
+}
+
 [[nodiscard]] static FileIterationStatus DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& config,
                                                          bool isExtraVerbose,
                                                          std::vector<std::byte>& generatedMachineCode,
@@ -254,14 +261,11 @@ enum struct FileIterationStatus : bool
           }
 
           bool shouldFail = false;
-          for (const auto& diag : source.diagnostics.diagnosticsList)
+          for (const auto& diagnostic : source.diagnostics.diagnosticsList)
           {
-               ecpps::diagnostics::PrintDiagnostic(source.name, diag);
+               ecpps::diagnostics::PrintDiagnostic(source.name, diagnostic);
 
-               if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                   (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                    continue;
-               shouldFail = true;
+               if (IsDiagnosticsCritical(diagnostic, config)) shouldFail = true;
           }
           if (shouldFail) return FileIterationStatus::Failure;
      }
@@ -270,13 +274,7 @@ enum struct FileIterationStatus : bool
           try
           {
                for (const auto& diag : source.diagnostics.diagnosticsList)
-               {
                     ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-                    if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                        (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                         break;
-               }
           }
           catch (const ecpps::TracedException& nestedTraceException)
           {
@@ -296,13 +294,7 @@ enum struct FileIterationStatus : bool
           try
           {
                for (const auto& diag : source.diagnostics.diagnosticsList)
-               {
                     ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-                    if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                        (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                         break;
-               }
           }
           catch (const ecpps::TracedException& nestedTraceException)
           {
@@ -321,14 +313,8 @@ enum struct FileIterationStatus : bool
      {
           try
           {
-               for (const auto& diag : source.diagnostics.diagnosticsList)
-               {
-                    ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-                    if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                        (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                         break;
-               }
+               for (const auto& diagnostic : source.diagnostics.diagnosticsList)
+                    ecpps::diagnostics::PrintDiagnostic(source.name, diagnostic);
           }
           catch (const ecpps::TracedException& nestedTraceException)
           {

--- a/compiler/ecpps/src/cli/main.cpp
+++ b/compiler/ecpps/src/cli/main.cpp
@@ -96,6 +96,258 @@ static void EnableVirtualProcessing(void)
 }
 #endif
 
+
+static void DoFileIteration(ecpps::SourceFile& source, ecpps::CompilerConfig& config, bool isExtraVerbose,
+                          std::vector<std::byte>& generatedMachineCode, bool& hadErrors,
+                          std::vector<std::pair<std::string, std::size_t>>& functions,
+                          ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset) noexcept
+{
+     g_diagnosticsReferences.emplace(source.name, &source.diagnostics);
+
+     try
+     {
+          if (config.verboseStatus != ecpps::VerboseStatus::Default) std::println("Compiling {}...", source.name);
+          // ECPPS pushed macros (& standard)
+
+          std::vector<ecpps::MacroReplacement> macros{};
+          macros.emplace_back("__cplusplus", std::nullopt, "202302", false); // TODO: 202302L
+          macros.emplace_back("__LINE__", std::nullopt, "1", false);
+          macros.emplace_back("__FILE__", std::nullopt, "\"" + source.name + "\"", false);
+          const auto now = std::chrono::system_clock::now();
+          std::chrono::year_month_day ymd{std::chrono::floor<std::chrono::days>(now)};
+          macros.emplace_back("__DATE__", std::nullopt, std::format("\"{:%b %e %Y}\"", ymd), false);
+          std::chrono::hh_mm_ss hms{
+               std::chrono::floor<std::chrono::seconds>(now - std::chrono::floor<std::chrono::days>(now))};
+          macros.emplace_back("__TIME__", std::nullopt, std::format("\"{:%T}\"", hms), false);
+          // TODO: __STDC_HOSTED__
+          // TODO: __STDCPP_DEFAULT_NEW_ALIGNMENT__
+          // TODO: __STDCPP_FLOAT16_T__
+          // TODO: __STDCPP_FLOAT32_T__
+          // TODO: __STDCPP_FLOAT64_T__
+          // TODO: __STDCPP_FLOAT128_T__
+          // TODO: __STDCPP_BFLOAT16_T__
+          // TODO: feature-test macros
+          // TODO: __STDCPP_THREADS__
+
+          macros.emplace_back("__ecpps_stl_version", std::nullopt, "0", false);
+          macros.emplace_back("__ecpps_stl_version_minor", std::nullopt, "0", false);
+          macros.emplace_back("__ecpps_stl_version_patch", std::nullopt, "1", false);
+          macros.emplace_back("__ecpps_version", std::nullopt, "000001", false);
+          macros.emplace_back("__ecpps_version_minor", std::nullopt, "0", false);
+          macros.emplace_back("__ecpps_version_patch", std::nullopt, "1", false);
+          std::set<std::filesystem::path> includedFiles;
+          ecpps::Preprocessor preprocessor{};
+          const auto ppTokens =
+               preprocessor.Parse(source.contents, macros, source.name, includedFiles, config.includeDirectories);
+          std::ranges::move(preprocessor.diagnostics, std::back_inserter(source.diagnostics.diagnosticsList));
+          const auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
+          if (isExtraVerbose) std::println();
+          if (isExtraVerbose) std::println("Tokens:");
+          if (isExtraVerbose) ecpps::Tokeniser::Print(tokens);
+          ecpps::ast::ASTContext astContext{};
+          ecpps::ast::AST astParser{tokens, source.diagnostics};
+          auto ast = astParser.Parse(astContext);
+          if (isExtraVerbose) std::println();
+          if (isExtraVerbose) std::println("AST:");
+          if (isExtraVerbose)
+               for (const auto& node : ast) std::println("{}", node->ToString(0));
+          ecpps::BumpAllocator irAllocator{};
+          const auto ir = ecpps::ir::IR::Parse(source.diagnostics, irAllocator, ast);
+          if (isExtraVerbose) std::println();
+          if (isExtraVerbose) std::println("IR:");
+          if (isExtraVerbose)
+               for (const auto& node : ir) std::println("{}", node->ToString(0));
+          ast.clear();
+          astContext.Release();
+          ecpps::codegen::Compile(config, source, ir);
+
+          if (isExtraVerbose) std::println();
+          if (isExtraVerbose) std::println("Assembly:");
+
+          std::unordered_map<std::string, std::size_t> routines{};
+          routines.reserve(source.compiledRoutines.size());
+
+          for (const auto& procedure : source.compiledRoutines)
+          {
+               if (isExtraVerbose)
+               {
+                    std::println("{}:", procedure.name);
+                    for (const auto& instruction : procedure.instructions)
+                    {
+                         std::println("     {}", ecpps::codegen::ToString(instruction));
+                    }
+               }
+
+               const auto machineCode = emitter.EmitRoutine(procedure, generatedMachineCode.size());
+
+               routines.emplace(procedure.name, generatedMachineCode.size());
+               generatedMachineCode.append_range(machineCode);
+               if (!isExtraVerbose) continue;
+          }
+
+          emitter.PatchCalls(generatedMachineCode, routines);
+
+          for (const auto placemenent : emitter._stringRelocation)
+          {
+               auto bytes = std::span{generatedMachineCode.data() + placemenent, emitter._stringRelocationSize};
+               auto* dword = std::bit_cast<std::uint32_t*>(bytes.data());
+               *dword += 0x4000 - 0x1000;
+               std::memcpy(bytes.data(), dword, sizeof(*dword));
+          }
+
+          for (const auto& [procedureName, procedurOffset] : routines)
+          {
+               if (procedureName == "_EntryPoint") mainOffset = procedurOffset;
+
+               functions.emplace_back(procedureName, procedurOffset);
+          }
+
+          if (isExtraVerbose)
+          {
+               std::vector<std::pair<std::string, std::size_t>> ordered;
+               ordered.reserve(routines.size());
+               for (const auto& r : routines) ordered.emplace_back(r);
+
+               std::ranges::sort(ordered, {}, &std::pair<std::string, std::size_t>::second);
+
+               for (std::size_t i = 0; i < ordered.size(); i++)
+               {
+                    const auto& [routineName, routineOffset] = ordered[i];
+                    std::println("{}:", routineName);
+
+                    std::size_t start = std::min(routineOffset, generatedMachineCode.size());
+                    std::size_t end = (i + 1 < ordered.size())
+                                             ? std::min(ordered[i + 1].second, generatedMachineCode.size())
+                                             : generatedMachineCode.size();
+
+                    if (start >= end) continue;
+
+                    auto machineCode =
+                         std::ranges::subrange(generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(start),
+                                                  generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(end));
+
+                    constexpr std::size_t RowSize = 8; // in bytes
+                    const auto rows = (machineCode.size() + RowSize - 1) / RowSize;
+
+                    std::println("Emitted {} bytes:", machineCode.size());
+                    for (std::size_t row = 0; row < rows; row++)
+                    {
+                         std::print("| ");
+                         const auto offset = row * RowSize;
+                         for (std::size_t column = 0; column < RowSize; column++)
+                         {
+                              const auto byteOffset = offset + column;
+                              if (byteOffset >= machineCode.size()) std::print("   ");
+                              else
+                                   std::print("{:02x} ",
+                                                  static_cast<std::size_t>(
+                                                  machineCode[static_cast<std::ptrdiff_t>(byteOffset)]));
+                         }
+                         std::println("|");
+                    }
+               }
+          }
+
+          for (const auto& diag : source.diagnostics.diagnosticsList)
+          {
+               ecpps::diagnostics::PrintDiagnostic(source.name, diag);
+
+               if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
+                    (!config.warningsAreErrors || diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+                    break;
+               hadErrors = true;
+          }
+     }
+     catch (const ecpps::TracedException& traceException)
+     {
+          hadErrors = true;
+          try
+          {
+               for (const auto& diag : source.diagnostics.diagnosticsList)
+               {
+                    ecpps::diagnostics::PrintDiagnostic(source.name, diag);
+
+                    if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
+                         (!config.warningsAreErrors ||
+                         diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+                         break;
+                    hadErrors = true;
+               }
+          }
+          catch (const ecpps::TracedException& nestedTraceException)
+          {
+               ecpps::IssueICE(nestedTraceException);
+          }
+          catch (const std::exception& nestedException)
+          {
+               ecpps::IssueICE(nestedException.what(), nullptr);
+          }
+
+          ecpps::IssueICE(traceException);
+
+		std::exit(-1);
+     }
+     catch (const std::exception& e)
+     {
+          hadErrors = true;
+
+          try
+          {
+               for (const auto& diag : source.diagnostics.diagnosticsList)
+               {
+                    ecpps::diagnostics::PrintDiagnostic(source.name, diag);
+
+                    if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
+                         (!config.warningsAreErrors ||
+                         diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+                         break;
+                    hadErrors = true;
+               }
+          }
+          catch (const ecpps::TracedException& nestedTraceException)
+          {
+               ecpps::IssueICE(nestedTraceException);
+          }
+          catch (const std::exception& nestedException)
+          {
+               ecpps::IssueICE(nestedException.what(), nullptr);
+          }
+
+          ecpps::IssueICE(e.what(), nullptr);
+
+		std::exit(-1);      
+     }
+     catch (...)
+     {
+          hadErrors = true;
+          try
+          {
+               for (const auto& diag : source.diagnostics.diagnosticsList)
+               {
+                    ecpps::diagnostics::PrintDiagnostic(source.name, diag);
+
+                    if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
+                         (!config.warningsAreErrors ||
+                         diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
+                         break;
+                    hadErrors = true;
+               }
+          }
+          catch (const ecpps::TracedException& nestedTraceException)
+          {
+               ecpps::IssueICE(nestedTraceException);
+          }
+          catch (const std::exception& nestedException)
+          {
+               ecpps::IssueICE(nestedException.what(), nullptr);
+          }
+
+          ecpps::IssueICE("unknown", nullptr);
+
+          std::exit(-1);
+     }
+}
+
 int main(int argc, char* argv[])
 {
 #ifdef _WIN32
@@ -154,251 +406,20 @@ int main(int argc, char* argv[])
 
           g_diagnosticsReferences.reserve(sources.files.size());
 
-          for (auto& source : sources.files)
-          {
-               g_diagnosticsReferences.emplace(source.name, &source.diagnostics);
-
-               try
-               {
-                    if (config.verboseStatus != ecpps::VerboseStatus::Default)
-                         std::println("Compiling {}...", source.name);
-                    // ECPPS pushed macros (& standard)
-
-                    std::vector<ecpps::MacroReplacement> macros{};
-                    macros.emplace_back("__cplusplus", std::nullopt, "202302", false); // TODO: 202302L
-                    macros.emplace_back("__LINE__", std::nullopt, "1", false);
-                    macros.emplace_back("__FILE__", std::nullopt, "\"" + source.name + "\"", false);
-                    const auto now = std::chrono::system_clock::now();
-                    std::chrono::year_month_day ymd{std::chrono::floor<std::chrono::days>(now)};
-                    macros.emplace_back("__DATE__", std::nullopt, std::format("\"{:%b %e %Y}\"", ymd), false);
-                    std::chrono::hh_mm_ss hms{
-                        std::chrono::floor<std::chrono::seconds>(now - std::chrono::floor<std::chrono::days>(now))};
-                    macros.emplace_back("__TIME__", std::nullopt, std::format("\"{:%T}\"", hms), false);
-                    // TODO: __STDC_HOSTED__
-                    // TODO: __STDCPP_DEFAULT_NEW_ALIGNMENT__
-                    // TODO: __STDCPP_FLOAT16_T__
-                    // TODO: __STDCPP_FLOAT32_T__
-                    // TODO: __STDCPP_FLOAT64_T__
-                    // TODO: __STDCPP_FLOAT128_T__
-                    // TODO: __STDCPP_BFLOAT16_T__
-                    // TODO: feature-test macros
-                    // TODO: __STDCPP_THREADS__
-
-                    macros.emplace_back("__ecpps_stl_version", std::nullopt, "0", false);
-                    macros.emplace_back("__ecpps_stl_version_minor", std::nullopt, "0", false);
-                    macros.emplace_back("__ecpps_stl_version_patch", std::nullopt, "1", false);
-                    macros.emplace_back("__ecpps_version", std::nullopt, "000001", false);
-                    macros.emplace_back("__ecpps_version_minor", std::nullopt, "0", false);
-                    macros.emplace_back("__ecpps_version_patch", std::nullopt, "1", false);
-                    std::set<std::filesystem::path> includedFiles;
-                    ecpps::Preprocessor preprocessor{};
-                    const auto ppTokens = preprocessor.Parse(source.contents, macros, source.name, includedFiles,
-                                                             config.includeDirectories);
-                    std::ranges::move(preprocessor.diagnostics, std::back_inserter(source.diagnostics.diagnosticsList));
-                    const auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-                    if (isExtraVerbose) std::println();
-                    if (isExtraVerbose) std::println("Tokens:");
-                    if (isExtraVerbose) ecpps::Tokeniser::Print(tokens);
-                    ecpps::ast::ASTContext astContext{};
-                    ecpps::ast::AST astParser{tokens, source.diagnostics};
-                    auto ast = astParser.Parse(astContext);
-                    if (isExtraVerbose) std::println();
-                    if (isExtraVerbose) std::println("AST:");
-                    if (isExtraVerbose)
-                         for (const auto& node : ast) std::println("{}", node->ToString(0));
-                    ecpps::BumpAllocator irAllocator{};
-                    const auto ir = ecpps::ir::IR::Parse(source.diagnostics, irAllocator, ast);
-                    if (isExtraVerbose) std::println();
-                    if (isExtraVerbose) std::println("IR:");
-                    if (isExtraVerbose)
-                         for (const auto& node : ir) std::println("{}", node->ToString(0));
-                    ast.clear();
-                    astContext.Release();
-                    ecpps::codegen::Compile(config, source, ir);
-
-                    if (isExtraVerbose) std::println();
-                    if (isExtraVerbose) std::println("Assembly:");
-
-                    std::unordered_map<std::string, std::size_t> routines{};
-                    routines.reserve(source.compiledRoutines.size());
-
-                    for (const auto& procedure : source.compiledRoutines)
-                    {
-                         if (isExtraVerbose)
-                         {
-                              std::println("{}:", procedure.name);
-                              for (const auto& instruction : procedure.instructions)
-                              {
-                                   std::println("     {}", ecpps::codegen::ToString(instruction));
-                              }
-                         }
-
-                         const auto machineCode = emitter->EmitRoutine(procedure, generatedMachineCode.size());
-
-                         routines.emplace(procedure.name, generatedMachineCode.size());
-                         generatedMachineCode.append_range(machineCode);
-                         if (!isExtraVerbose) continue;
-                    }
-
-                    emitter->PatchCalls(generatedMachineCode, routines);
-                    for (const auto placemenent : emitter->_stringRelocation)
-                    {
-                         auto bytes =
-                             std::span{generatedMachineCode.data() + placemenent, emitter->_stringRelocationSize};
-                         auto* dword = std::bit_cast<std::uint32_t*>(bytes.data());
-                         *dword += 0x4000 - 0x1000;
-                         std::memcpy(bytes.data(), dword, sizeof(*dword));
-                    }
-
-                    for (const auto& [procedureName, procedurOffset] : routines)
-                    {
-                         if (procedureName == "_EntryPoint") mainOffset = procedurOffset;
-
-                         functions.emplace_back(procedureName, procedurOffset);
-                    }
-
-                    if (isExtraVerbose)
-                    {
-                         std::vector<std::pair<std::string, std::size_t>> ordered;
-                         ordered.reserve(routines.size());
-                         for (const auto& r : routines) ordered.emplace_back(r);
-
-                         std::ranges::sort(ordered, {}, &std::pair<std::string, std::size_t>::second);
-
-                         for (std::size_t i = 0; i < ordered.size(); i++)
-                         {
-                              const auto& [routineName, routineOffset] = ordered[i];
-                              std::println("{}:", routineName);
-
-                              std::size_t start = std::min(routineOffset, generatedMachineCode.size());
-                              std::size_t end = (i + 1 < ordered.size())
-                                                    ? std::min(ordered[i + 1].second, generatedMachineCode.size())
-                                                    : generatedMachineCode.size();
-
-                              if (start >= end) continue;
-
-                              auto machineCode = std::ranges::subrange(
-                                  generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(start),
-                                  generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(end));
-
-                              constexpr std::size_t RowSize = 8; // in bytes
-                              const auto rows = (machineCode.size() + RowSize - 1) / RowSize;
-
-                              std::println("Emitted {} bytes:", machineCode.size());
-                              for (std::size_t row = 0; row < rows; row++)
-                              {
-                                   std::print("| ");
-                                   const auto offset = row * RowSize;
-                                   for (std::size_t column = 0; column < RowSize; column++)
-                                   {
-                                        const auto byteOffset = offset + column;
-                                        if (byteOffset >= machineCode.size()) std::print("   ");
-                                        else
-                                             std::print("{:02x} ",
-                                                        static_cast<std::size_t>(
-                                                            machineCode[static_cast<std::ptrdiff_t>(byteOffset)]));
-                                   }
-                                   std::println("|");
-                              }
-                         }
-                    }
-
-                    for (const auto& diag : source.diagnostics.diagnosticsList)
-                    {
-                         ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-                         if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                             (!config.warningsAreErrors ||
-                              diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                              break;
-                         hadErrors = true;
-                    }
-               }
-               catch (const ecpps::TracedException& traceException)
-               {
-                    hadErrors = true;
-                    try
-                    {
-                         for (const auto& diag : source.diagnostics.diagnosticsList)
-                         {
-                              ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-                              if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                                  (!config.warningsAreErrors ||
-                                   diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                                   break;
-                              hadErrors = true;
-                         }
-                    }
-                    catch (const ecpps::TracedException& nestedTraceException)
-                    {
-                         ecpps::IssueICE(nestedTraceException);
-                    }
-                    catch (const std::exception& nestedException)
-                    {
-                         ecpps::IssueICE(nestedException.what(), nullptr);
-                    }
-
-                    ecpps::IssueICE(traceException);
-                    return -1;
-               }
-               catch (const std::exception& e)
-               {
-                    hadErrors = true;
-                    try
-                    {
-                         for (const auto& diag : source.diagnostics.diagnosticsList)
-                         {
-                              ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-                              if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                                  (!config.warningsAreErrors ||
-                                   diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                                   break;
-                              hadErrors = true;
-                         }
-                    }
-                    catch (const ecpps::TracedException& nestedTraceException)
-                    {
-                         ecpps::IssueICE(nestedTraceException);
-                    }
-                    catch (const std::exception& nestedException)
-                    {
-                         ecpps::IssueICE(nestedException.what(), nullptr);
-                    }
-
-                    ecpps::IssueICE(e.what(), nullptr);
-                    return -1;
-               }
-               catch (...)
-               {
-                    hadErrors = true;
-                    try
-                    {
-                         for (const auto& diag : source.diagnostics.diagnosticsList)
-                         {
-                              ecpps::diagnostics::PrintDiagnostic(source.name, diag);
-
-                              if (diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Error &&
-                                  (!config.warningsAreErrors ||
-                                   diag->Level() != ecpps::diagnostics::DiagnosticsLevel::Warning))
-                                   break;
-                              hadErrors = true;
-                         }
-                    }
-                    catch (const ecpps::TracedException& nestedTraceException)
-                    {
-                         ecpps::IssueICE(nestedTraceException);
-                    }
-                    catch (const std::exception& nestedException)
-                    {
-                         ecpps::IssueICE(nestedException.what(), nullptr);
-                    }
-
-                    ecpps::IssueICE("unknown", nullptr);
-                    return -1;
-               }
-          }
+		
+		for (ecpps::SourceFile &source : sources.files)
+		{
+               DoFileIteration(
+				source,
+				config,
+				isExtraVerbose,
+				generatedMachineCode,
+				hadErrors,
+				functions,
+				*emitter,
+				mainOffset
+			);
+		}
 
           if (hadErrors)
           {


### PR DESCRIPTION
Extract the input file translation logic into a function called iteratively by the main function.
This needs a follow-up PR abstracting out the driver itself.