### PR TITLE
Use C++23 stacktrace and modularise EH logic

### DIFF
--- a/compiler/ecpps/libecpps.cmake
+++ b/compiler/ecpps/libecpps.cmake
@@ -64,6 +64,9 @@ target_link_libraries(parserlib PRIVATE ecpps_defaults platformlib utilitieslib)
 target_link_libraries(typesystemlib PRIVATE ecpps_defaults platformlib utilitieslib backendlib)
 target_link_libraries(backendlib PRIVATE ecpps_defaults platformlib utilitieslib typesystemlib)
 target_link_libraries(libecpps PRIVATE ecpps_defaults platformlib utilitieslib)
+if (LINUX)
+    target_link_libraries(libecpps PRIVATE stdc++exp)
+endif()
 
 target_link_libraries(libecpps PUBLIC platformlib utilitieslib parserlib
                       typesystemlib backendlib)

--- a/compiler/ecpps/src/CodeGeneration/Nodes.h
+++ b/compiler/ecpps/src/CodeGeneration/Nodes.h
@@ -84,13 +84,9 @@ namespace ecpps::codegen
      struct ErrorOperand
      {
           [[nodiscard]] std::size_t Size(void) const noexcept
-          {
-               return 0;
-          } // NOLINT(readability-convert-member-functions-to-static)
+          { return 0; } // NOLINT(readability-convert-member-functions-to-static)
           [[nodiscard]] std::string ToString(void) const
-          {
-               return "";
-          } // NOLINT(readability-convert-member-functions-to-static)
+          { return ""; } // NOLINT(readability-convert-member-functions-to-static)
      };
 
      using Operand = std::variant<std::monostate, ErrorOperand, RegisterOperand, IntegerOperand, MemoryLocationOperand,
@@ -331,14 +327,10 @@ namespace ecpps::codegen
           }
 
           static Routine WhileLoop(std::vector<Instruction>&& instructions, const RoutineCondition condition)
-          {
-               return Routine{std::move(instructions), RoutineCondition::Procedure, condition};
-          }
+          { return Routine{std::move(instructions), RoutineCondition::Procedure, condition}; }
 
           static Routine Branch(std::vector<Instruction>&& instructions, const RoutineCondition condition)
-          {
-               return Routine{std::move(instructions), condition, RoutineCondition::Procedure};
-          }
+          { return Routine{std::move(instructions), condition, RoutineCondition::Procedure}; }
 
      private:
           explicit Routine(std::vector<Instruction> instructions, const RoutineCondition skipCondition,

--- a/compiler/ecpps/src/CodeGeneration/Nodes.h
+++ b/compiler/ecpps/src/CodeGeneration/Nodes.h
@@ -84,9 +84,13 @@ namespace ecpps::codegen
      struct ErrorOperand
      {
           [[nodiscard]] std::size_t Size(void) const noexcept
-          { return 0; } // NOLINT(readability-convert-member-functions-to-static)
+          {
+               return 0;
+          } // NOLINT(readability-convert-member-functions-to-static)
           [[nodiscard]] std::string ToString(void) const
-          { return ""; } // NOLINT(readability-convert-member-functions-to-static)
+          {
+               return "";
+          } // NOLINT(readability-convert-member-functions-to-static)
      };
 
      using Operand = std::variant<std::monostate, ErrorOperand, RegisterOperand, IntegerOperand, MemoryLocationOperand,
@@ -327,10 +331,14 @@ namespace ecpps::codegen
           }
 
           static Routine WhileLoop(std::vector<Instruction>&& instructions, const RoutineCondition condition)
-          { return Routine{std::move(instructions), RoutineCondition::Procedure, condition}; }
+          {
+               return Routine{std::move(instructions), RoutineCondition::Procedure, condition};
+          }
 
           static Routine Branch(std::vector<Instruction>&& instructions, const RoutineCondition condition)
-          { return Routine{std::move(instructions), condition, RoutineCondition::Procedure}; }
+          {
+               return Routine{std::move(instructions), condition, RoutineCondition::Procedure};
+          }
 
      private:
           explicit Routine(std::vector<Instruction> instructions, const RoutineCondition skipCondition,

--- a/compiler/ecpps/src/Execution/IR.cpp
+++ b/compiler/ecpps/src/Execution/IR.cpp
@@ -1545,9 +1545,7 @@ struct CompareByPriority
 {
      bool operator()(const std::pair<ecpps::ir::MatchingScore, std::shared_ptr<ecpps::ir::FunctionScope>>& a,
                      const std::pair<ecpps::ir::MatchingScore, std::shared_ptr<ecpps::ir::FunctionScope>>& b) const
-     {
-          return a.first < b.first;
-     }
+     { return a.first < b.first; }
 };
 
 Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
@@ -2122,9 +2120,7 @@ Expression ecpps::ir::IR::ParseListInitialisation(const ast::NodePointer& expres
 
 bool ecpps::ir::IR::IsNarrowingConversion([[maybe_unused]] const Expression& expression,
                                           [[maybe_unused]] typeSystem::NonowningTypePointer toType) const
-{
-     return false;
-}
+{ return false; }
 
 [[nodiscard]] ecpps::ir::TypeRequest ecpps::ir::IR::TypeASTToRequest(const ast::NodePointer& type)
 {
@@ -2280,7 +2276,6 @@ bool ecpps::ir::IR::IsNarrowingConversion([[maybe_unused]] const Expression& exp
                if (dynamic_cast<const ast::BasicType*>(unqualified))
                     return TypeASTToRequest(qualifiedType->UnqualifiedType());
           }
-
           throw TracedException("Qualified types with namespaces not yet implemented");
      }
 
@@ -2412,9 +2407,7 @@ Expression ecpps::ir::IR::ConvertTo(Expression expression, typeSystem::Nonowning
 }
 
 bool ecpps::ir::IR::IsEligibleForStringLiteralInitialisation(typeSystem::NonowningTypePointer type) const
-{
-     return IsCharacter(type);
-}
+{ return IsCharacter(type); }
 
 Expression ecpps::ir::IR::ConvertIntegral(Expression expression, const typeSystem::IntegralType* type) const
 {

--- a/compiler/ecpps/src/Execution/IR.cpp
+++ b/compiler/ecpps/src/Execution/IR.cpp
@@ -1545,7 +1545,9 @@ struct CompareByPriority
 {
      bool operator()(const std::pair<ecpps::ir::MatchingScore, std::shared_ptr<ecpps::ir::FunctionScope>>& a,
                      const std::pair<ecpps::ir::MatchingScore, std::shared_ptr<ecpps::ir::FunctionScope>>& b) const
-     { return a.first < b.first; }
+     {
+          return a.first < b.first;
+     }
 };
 
 Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
@@ -2120,7 +2122,9 @@ Expression ecpps::ir::IR::ParseListInitialisation(const ast::NodePointer& expres
 
 bool ecpps::ir::IR::IsNarrowingConversion([[maybe_unused]] const Expression& expression,
                                           [[maybe_unused]] typeSystem::NonowningTypePointer toType) const
-{ return false; }
+{
+     return false;
+}
 
 [[nodiscard]] ecpps::ir::TypeRequest ecpps::ir::IR::TypeASTToRequest(const ast::NodePointer& type)
 {
@@ -2407,7 +2411,9 @@ Expression ecpps::ir::IR::ConvertTo(Expression expression, typeSystem::Nonowning
 }
 
 bool ecpps::ir::IR::IsEligibleForStringLiteralInitialisation(typeSystem::NonowningTypePointer type) const
-{ return IsCharacter(type); }
+{
+     return IsCharacter(type);
+}
 
 Expression ecpps::ir::IR::ConvertIntegral(Expression expression, const typeSystem::IntegralType* type) const
 {

--- a/compiler/ecpps/src/Machine/ABI.cpp
+++ b/compiler/ecpps/src/Machine/ABI.cpp
@@ -1,5 +1,6 @@
 #include "ABI.h"
 #include <RuntimeAssert.h>
+#include <array>
 #include <climits>
 #include <cstdint>
 #include <format>

--- a/compiler/ecpps/src/Shared/Diagnostics.cpp
+++ b/compiler/ecpps/src/Shared/Diagnostics.cpp
@@ -260,7 +260,9 @@ static LONG WINAPI WinExceptionHandler(EXCEPTION_POINTERS* exceptionInfo)
 
 static void LinuxFatalSignalHandler([[maybe_unused]] int signalNumber, siginfo_t* action,
                                     [[maybe_unused]] void* oldAction) noexcept
-{ ecpps::IssueICE("Unhandled Linux signal", action); }
+{
+     ecpps::IssueICE("Unhandled Linux signal", action);
+}
 
 [[noreturn]] void ecpps::IssueICE(std::string_view message, [[maybe_unused]] void* implementationDefined)
 {

--- a/compiler/ecpps/src/Shared/Diagnostics.cpp
+++ b/compiler/ecpps/src/Shared/Diagnostics.cpp
@@ -6,8 +6,9 @@
 std::unordered_map<std::string, ecpps::Diagnostics*> ecpps::g_diagnosticsReferences{};
 
 #ifdef _WIN32
-#include <dbghelp.h>
 #include <windows.h>
+
+#include <dbghelp.h>
 
 #pragma comment(lib, "dbghelp.lib")
 

--- a/compiler/ecpps/src/Shared/Diagnostics.cpp
+++ b/compiler/ecpps/src/Shared/Diagnostics.cpp
@@ -252,8 +252,6 @@ static LONG WINAPI WinExceptionHandler(EXCEPTION_POINTERS* exceptionInfo)
               std::format("Unhandled exception has occurred: {}", exceptionInfo->ExceptionRecord->ExceptionCode),
               exceptionInfo->ContextRecord);
      }
-
-     return EXCEPTION_EXECUTE_HANDLER;
 }
 
 #elifdef __linux__ // ^^^ _WIN32 / __linux__ vvv

--- a/compiler/ecpps/src/Shared/Diagnostics.cpp
+++ b/compiler/ecpps/src/Shared/Diagnostics.cpp
@@ -1,105 +1,310 @@
 #include "Diagnostics.h"
+#include <array>
+#include <print>
+#include <stacktrace>
+
+std::unordered_map<std::string, ecpps::Diagnostics*> ecpps::g_diagnosticsReferences{};
+
 #ifdef _WIN32
 #include <dbghelp.h>
-#endif
+#include <windows.h>
 
-#include <print>
+#pragma comment(lib, "dbghelp.lib")
 
-#include "Linker/PE.h"
-
-void ecpps::IssueICE([[maybe_unused]] const TracedException& ex)
-{
-#ifdef _WIN32
-     HANDLE hProcess = GetCurrentProcess();
-     SymSetOptions(SYMOPT_DEFERRED_LOADS | SYMOPT_UNDNAME | SYMOPT_LOAD_LINES);
-     SymInitialize(hProcess, nullptr, TRUE);
-
-     void* storage = operator new(sizeof(SYMBOL_INFO) + MAX_PATH);
-     std::println("\x1b[41mInternal Compiler Error:\x1b[0m {}", ex.what());
-     for (auto* i : ex.trace)
-     {
-          auto address = reinterpret_cast<std::uint64_t>(i);
-          std::uint64_t displacement = 0;
-          std::memset(storage, 0, sizeof(SYMBOL_INFO) + MAX_PATH);
-          auto* symbol = new (storage) SYMBOL_INFO{};
-          symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
-          symbol->MaxNameLen = MAX_PATH;
-
-          if (SymFromAddr(hProcess, address, &displacement, symbol) != 0)
-          {
-               IMAGEHLP_LINE64 line{};
-               line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
-               std::uint32_t lineDisp = 0;
-               // honestly, I don't care it's undefined, had enough of Windows bullshit / vvv
-               if (SymGetLineFromAddr64(hProcess, address, reinterpret_cast<DWORD*>(&lineDisp), &line) != 0)
-                    std::println("  at \x1b[34m{}:{}\x1b[0m <\x1b[32m{}\x1b[0m>", line.FileName, line.LineNumber,
-                                 symbol->Name);
-               else
-                    std::println("  at \x1b[32m{}\x1b[0m @{:x}", symbol->Name, address);
-          }
-     }
-
-     operator delete(storage);
-
-     SymCleanup(hProcess);
-     ExitProcess(~0u);
 #elifdef __linux__
-     std::exit(-1);
+#include <execinfo.h>
+#include <unistd.h>
+#include <csignal>
+#include <cstdlib>
 #endif
-}
 
-void ecpps::IssueICE([[maybe_unused]] std::string_view message,
-                     [[maybe_unused]] platformlib::DebuggerContext* defaultContext)
+struct NativeStackFrame
 {
-#ifdef _WIN32
-     HANDLE hProcess = GetCurrentProcess();
+     std::uintptr_t instruction{};
+     std::uintptr_t moduleBase{};
+     std::string module;
+     std::string function;
+     std::string sourceFile;
+     std::uint32_t sourceLine{};
+     std::uint64_t displacement{};
+};
 
-     const auto stack = platformlib::debugger::WalkTrace(defaultContext);
+using NativeStackTrace = std::vector<NativeStackFrame>;
 
+[[noreturn]] static void TerminatePostICE(void)
+{
+     std::fflush(stderr);
+     std::exit(EXIT_FAILURE);
+}
+static void ReportICE(std::string_view message, const std::stacktrace& trace)
+{
      std::println("\x1b[41mInternal Compiler Error:\x1b[0m {}", message);
-     for (const auto& i : stack)
+
+     for (const auto& frame : trace) std::println("  {}", frame);
+
+     std::print("\x1b[0m");
+}
+[[maybe_unused]] static void ReportICE(std::string_view message, const NativeStackTrace& trace)
+{
+     std::println("\x1b[41mInternal Compiler Error:\x1b[0m {}", message);
+
+     for (const auto& frame : trace)
      {
-          const auto address = reinterpret_cast<std::uint64_t>(i);
-          std::uint64_t displacement = 0;
-          void* symbolInfoStorage = operator new(sizeof(SYMBOL_INFO) + MAX_PATH);
-          if (symbolInfoStorage == nullptr) break;
-          auto* symbol = new (symbolInfoStorage) SYMBOL_INFO{};
-          symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
-          symbol->MaxNameLen = MAX_PATH;
+          std::print("  0x{:016x}", frame.instruction);
 
-          if (SymFromAddr(hProcess, address, &displacement, symbol) != 0)
-          {
-               IMAGEHLP_LINE64 line{};
-               line.SizeOfStruct = sizeof(linker::win::ImageHelpLine64);
-               std::uint32_t lineDisplacement = 0;
-               auto* moduleHandle = reinterpret_cast<HMODULE>(SymGetModuleBase64(hProcess, address));
-               std::string moduleName{};
-               moduleName.resize(MAX_PATH);
-               if (moduleHandle != nullptr) GetModuleFileNameA(moduleHandle, moduleName.data(), MAX_PATH);
+          if (!frame.function.empty()) { std::print(" {}+0x{:x}", frame.function, frame.displacement); }
+          if (!frame.sourceFile.empty()) { std::print(" ({}:{})", frame.sourceFile, frame.sourceLine); }
+          if (!frame.module.empty()) { std::print(" [{}]", frame.module); }
 
-               if (SymGetLineFromAddr64(hProcess, address, reinterpret_cast<DWORD*>(&lineDisplacement), &line) != 0)
-               {
-                    std::println("\x1b[37m[{:02}] \x1b[34m{}:{}\x1b[0m", i, line.FileName, line.LineNumber);
-                    std::println("       [\x1b[35m{}+0x{:X}\x1b[0m <\x1b[32m{}\x1b[0m>] @\x1b[35m{:x}\x1b[0m",
-                                 symbol->Name, displacement, moduleName[0] != '\0' ? moduleName : "?", line.Address);
-               }
-               else
-               {
-                    std::println("\x1b[37m[{:02}] \x1b[35m{}\x1b[0m", i, symbol->Name);
-                    std::println("       +0x{:X} <\x1b[32m{}\x1b[0m> @\x1b[35m{:x}\x1b[0m", displacement,
-                                 moduleName[0] == '\0' ? moduleName : "?", address);
-               }
-          }
-          else
-               std::println("\x1b[37m[{:02}] \x1b[35m{}", i, address);
-
-          operator delete(symbolInfoStorage);
+          std::println("");
      }
 
      std::print("\x1b[0m");
-     SymCleanup(hProcess);
-     ExitProcess(~0u);
+}
+
+#ifdef _WIN32
+
+static HANDLE GetCurrentProcessHandle(void) noexcept { return ::GetCurrentProcess(); }
+
+static bool InitialiseSymbols(void)
+{
+     static const bool isInitialised = []
+     {
+          const HANDLE process = GetCurrentProcessHandle();
+
+          ::SymSetOptions(SYMOPT_UNDNAME | SYMOPT_LOAD_LINES | SYMOPT_DEFERRED_LOADS | SYMOPT_FAIL_CRITICAL_ERRORS |
+                          SYMOPT_NO_PROMPTS);
+
+          return ::SymInitialize(process, nullptr, TRUE) != FALSE;
+     }();
+
+     return isInitialised;
+}
+
+constexpr DWORD GetMachineType(void) noexcept
+{
+#if defined(_M_X64) || defined(__x86_64__)
+     return IMAGE_FILE_MACHINE_AMD64;
+#elif defined(_M_IX86)
+     return IMAGE_FILE_MACHINE_I386;
+#elif defined(_M_ARM64)
+     return IMAGE_FILE_MACHINE_ARM64;
+#else
+#error Unsupported Windows architecture
+#endif
+}
+
+static void InitialiseStackFrame(STACKFRAME64& frame, const CONTEXT& context) noexcept
+{
+     frame = {};
+
+#if defined(_M_X64) || defined(__x86_64__)
+
+     frame.AddrPC.Offset = context.Rip;
+     frame.AddrPC.Mode = AddrModeFlat;
+     frame.AddrStack.Offset = context.Rsp;
+     frame.AddrStack.Mode = AddrModeFlat;
+     frame.AddrFrame.Offset = context.Rbp;
+     frame.AddrFrame.Mode = AddrModeFlat;
+
+#elif defined(_M_IX86)
+
+     frame.AddrPC.Offset = context.Eip;
+     frame.AddrPC.Mode = AddrModeFlat;
+     frame.AddrStack.Offset = context.Esp;
+     frame.AddrStack.Mode = AddrModeFlat;
+     frame.AddrFrame.Offset = context.Ebp;
+     frame.AddrFrame.Mode = AddrModeFlat;
+
+#elif defined(_M_ARM64)
+
+     frame.AddrPC.Offset = context.Pc;
+     frame.AddrPC.Mode = AddrModeFlat;
+     frame.AddrStack.Offset = context.Sp;
+     frame.AddrStack.Mode = AddrModeFlat;
+     frame.AddrFrame.Offset = context.Fp;
+     frame.AddrFrame.Mode = AddrModeFlat;
+
+#endif
+}
+
+static NativeStackFrame ResolveSymbol(HANDLE process, DWORD64 address)
+{
+     NativeStackFrame frame{};
+
+     frame.instruction = static_cast<std::uintptr_t>(address);
+
+     std::array<std::byte, sizeof(SYMBOL_INFO) + MAX_SYM_NAME> storage{};
+
+     auto* symbol = reinterpret_cast<PSYMBOL_INFO>(storage.data());
+
+     symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+
+     symbol->MaxNameLen = MAX_SYM_NAME;
+
+     DWORD64 displacement = 0;
+
+     if (::SymFromAddr(process, address, &displacement, symbol))
+     {
+          frame.function = symbol->Name;
+          frame.displacement = displacement;
+          frame.moduleBase = static_cast<std::uintptr_t>(symbol->ModBase);
+     }
+
+     IMAGEHLP_LINE64 line{};
+     line.SizeOfStruct = sizeof(line);
+
+     DWORD lineDisplacement = 0;
+
+     if (::SymGetLineFromAddr64(process, address, &lineDisplacement, &line))
+     {
+          if (line.FileName) frame.sourceFile = line.FileName;
+
+          frame.sourceLine = line.LineNumber;
+     }
+
+     IMAGEHLP_MODULE64 module{};
+     module.SizeOfStruct = sizeof(module);
+
+     if (::SymGetModuleInfo64(process, address, &module))
+     {
+          frame.module = module.ImageName;
+
+          if (frame.moduleBase == 0) frame.moduleBase = static_cast<std::uintptr_t>(module.BaseOfImage);
+     }
+
+     return frame;
+}
+
+static NativeStackTrace WalkContext(CONTEXT context)
+{
+     NativeStackTrace trace{};
+     trace.reserve(64);
+
+     if (!InitialiseSymbols()) return trace;
+
+     const HANDLE process = GetCurrentProcessHandle();
+
+     STACKFRAME64 frame{};
+     InitialiseStackFrame(frame, context);
+
+     constexpr std::size_t MaximumFrames = 128;
+
+     for (std::size_t i = 0; i < MaximumFrames; i++)
+     {
+          const DWORD64 address = frame.AddrPC.Offset;
+
+          if (address == 0) break;
+
+          trace.emplace_back(ResolveSymbol(process, address));
+
+          if (!::StackWalk64(GetMachineType(), process, ::GetCurrentThread(), &frame, &context, nullptr,
+                             ::SymFunctionTableAccess64, ::SymGetModuleBase64, nullptr))
+               break;
+     }
+
+     return trace;
+}
+
+[[noreturn]] void ecpps::IssueICE(std::string_view message, void* implementationDefined)
+{
+     const auto* context = static_cast<const CONTEXT*>(implementationDefined);
+
+     NativeStackTrace trace;
+
+     if (context) trace = WalkContext(*context);
+
+     ReportICE(message, trace);
+
+     TerminatePostICE();
+}
+
+static void IssueDiagnostics(void)
+{
+     for (const auto& [sourceName, lpDiagnostics] : ecpps::g_diagnosticsReferences)
+     {
+          const auto& diagnostics = *lpDiagnostics;
+
+          for (const auto& diag : diagnostics.diagnosticsList) ecpps::diagnostics::PrintDiagnostic(sourceName, diag);
+     }
+}
+
+static LONG WINAPI WinExceptionHandler(EXCEPTION_POINTERS* exceptionInfo)
+{
+     IssueDiagnostics();
+
+     switch (exceptionInfo->ExceptionRecord->ExceptionCode)
+     {
+     case EXCEPTION_ACCESS_VIOLATION:
+     {
+          void* faultingAddress = reinterpret_cast<void*>(exceptionInfo->ExceptionRecord->ExceptionInformation[1]);
+          bool isWrite = exceptionInfo->ExceptionRecord->ExceptionInformation[0] == 1;
+          std::string built;
+          if (isWrite) built = std::format("Access violation writing to {}", faultingAddress);
+          else
+               built = std::format("Access violation reading {}", faultingAddress);
+
+          ecpps::IssueICE(built, exceptionInfo->ContextRecord);
+     }
+     case EXCEPTION_INT_DIVIDE_BY_ZERO: ecpps::IssueICE("Divide by zero", exceptionInfo->ContextRecord);
+     default:
+          ecpps::IssueICE(
+              std::format("Unhandled exception has occurred: {}", exceptionInfo->ExceptionRecord->ExceptionCode),
+              exceptionInfo->ContextRecord);
+     }
+
+     return EXCEPTION_EXECUTE_HANDLER;
+}
+
+#elifdef __linux__ // ^^^ _WIN32 / __linux__ vvv
+
+static void LinuxFatalSignalHandler([[maybe_unused]] int signalNumber, siginfo_t* action,
+                                    [[maybe_unused]] void* oldAction) noexcept
+{ ecpps::IssueICE("Unhandled Linux signal", action); }
+
+[[noreturn]] void ecpps::IssueICE(std::string_view message, [[maybe_unused]] void* implementationDefined)
+{
+     ReportICE(message, std::stacktrace::current());
+     TerminatePostICE();
+}
+
+#endif // ^^^ __linux__
+
+ecpps::TracedException::TracedException(std::string message)
+    : _message(std::move(message)), _trace(std::stacktrace::current(1))
+{
+}
+ecpps::TracedException::TracedException(std::string message, const std::exception_ptr& inner)
+    : _message(std::move(message)), _trace(std::stacktrace::current(1)), _inner(inner)
+{
+}
+[[noreturn]] void ecpps::IssueICE(const TracedException& exception)
+{
+     ReportICE(exception.what(), exception.Trace());
+     TerminatePostICE();
+}
+
+[[noreturn]] void ecpps::IssueICE(std::string_view message) { IssueICE(message, std::stacktrace::current(1)); }
+
+[[noreturn]] void ecpps::IssueICE(std::string_view message, const std::stacktrace& trace)
+{
+     ReportICE(message, trace);
+     TerminatePostICE();
+}
+#undef sa_sigaction
+void ecpps::RegisterErrorCallbacks(void)
+{
+#ifdef _WIN32
+     SetUnhandledExceptionFilter(WinExceptionHandler);
 #elifdef __linux__
-     std::exit(-1);
+     struct sigaction action{}; // I hate that sigaction refers to both a function and a class...
+     action.__sigaction_handler.sa_sigaction = &LinuxFatalSignalHandler;
+     ::sigemptyset(&action.sa_mask);
+
+     action.sa_flags = static_cast<int>(SA_SIGINFO | SA_RESETHAND);
+
+     constexpr auto signals = std::to_array({SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTRAP});
+
+     for (const int signal : signals) ::sigaction(signal, &action, nullptr);
 #endif
 }

--- a/compiler/ecpps/src/Shared/Diagnostics.h
+++ b/compiler/ecpps/src/Shared/Diagnostics.h
@@ -1,12 +1,8 @@
 #pragma once
 
-#ifdef _WIN32
-#include <Windows.h>
-#elifdef __linux__
-#include <execinfo.h>
-#endif
 #include <platformlib/platformlib.h>
-#include <array>
+#include <exception>
+#include <stacktrace>
 #include <string>
 #include <vector>
 #include "Error.h"
@@ -22,44 +18,35 @@ namespace ecpps
           std::vector<diagnostics::DiagnosticsMessage> diagnosticsList{};
      };
 
-     struct TracedException : std::exception
+     class TracedException final : public std::exception
      {
-          std::string msg;
-          std::vector<void*> trace;
-          std::shared_ptr<std::exception> inner;
-
-          explicit TracedException(std::string message) : msg(std::move(message)) { CaptureStack(); }
-
-          explicit TracedException(const std::exception& ex)
-              : msg(ex.what()), inner(std::make_unique<std::decay_t<decltype(ex)>>(ex))
+     public:
+          explicit TracedException(std::string message);
+          explicit TracedException(std::string message, const std::exception_ptr& inner);
+          explicit TracedException(const std::exception& exception)
+              : _message(exception.what()), _trace(std::stacktrace::current(1)),
+                _inner(std::make_exception_ptr(exception))
           {
-               CaptureStack();
           }
 
-          [[nodiscard]] const char* what(void) const noexcept override { return msg.c_str(); }
+          [[nodiscard]] const char* what(void) const noexcept override { return this->_message.c_str(); }
+          [[nodiscard]] const std::stacktrace& Trace(void) const noexcept { return this->_trace; }
+          [[nodiscard]] const std::exception_ptr& Inner(void) const noexcept { return this->_inner; }
 
      private:
-          void CaptureStack(void)
-          {
-               constexpr std::size_t MaxFrames = 64;
-               std::array<void*, MaxFrames> frames{};
-
-#ifdef _WIN32
-               const USHORT captured = CaptureStackBackTrace(0, static_cast<ULONG>(MaxFrames), frames.data(), nullptr);
-               trace.assign(frames.data(), frames.data() + captured);
-#elifdef __linux__
-               const int captured = ::backtrace(frames.data(), static_cast<int>(MaxFrames));
-               if (captured > 0) trace.assign(frames.data(), frames.data() + captured);
-               else
-                    trace.clear();
-#else
-               trace.clear();
-#endif
-          }
+          std::string _message;
+          std::stacktrace _trace;
+          std::exception_ptr _inner;
      };
 
-     void IssueICE(const TracedException& ex);
-     void IssueICE(std::string_view message, platformlib::DebuggerContext* defaultContext);
+     [[noreturn]] void IssueICE(const TracedException& exception);
+     [[noreturn]] void IssueICE(std::string_view message);
+     [[noreturn]] void IssueICE(std::string_view message, const std::stacktrace& trace);
+     [[noreturn]] void IssueICE(std::string_view message, void* implementationDefined);
+
+     extern std::unordered_map<std::string, ecpps::Diagnostics*> g_diagnosticsReferences;
+
+     void RegisterErrorCallbacks(void);
 } // namespace ecpps
 
 using ecpps::TracedException;

--- a/compiler/ecpps/src/Shared/Diagnostics.h
+++ b/compiler/ecpps/src/Shared/Diagnostics.h
@@ -4,6 +4,7 @@
 #include <exception>
 #include <stacktrace>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "Error.h"
 

--- a/compiler/ecpps/src/cli/main.cpp
+++ b/compiler/ecpps/src/cli/main.cpp
@@ -31,61 +31,7 @@
 #include <Shared/Config.h>
 #include <Shared/Diagnostics.h>
 
-#ifdef min
-#undef min
-#undef max
-#endif
-
-static std::unordered_map<std::string, ecpps::Diagnostics*> g_diagnosticsReferences{};
-
 #ifdef _WIN32
-
-template <> struct ecpps::platformlib::PointerInterconvertibility<ecpps::platformlib::DebuggerContext, CONTEXT>
-{
-     constexpr static bool IsValid = true;
-};
-
-static void IssueDiagnostics(void)
-{
-     for (const auto& [sourceName, lpDiagnostics] : g_diagnosticsReferences)
-     {
-          const auto& diagnostics = *lpDiagnostics;
-
-          for (const auto& diag : diagnostics.diagnosticsList) ecpps::diagnostics::PrintDiagnostic(sourceName, diag);
-     }
-}
-
-static LONG WINAPI WinExceptionHandler(EXCEPTION_POINTERS* exceptionInfo)
-{
-     IssueDiagnostics();
-
-     switch (exceptionInfo->ExceptionRecord->ExceptionCode)
-     {
-     case EXCEPTION_ACCESS_VIOLATION:
-     {
-          void* faultingAddress = reinterpret_cast<void*>(exceptionInfo->ExceptionRecord->ExceptionInformation[1]);
-          bool isWrite = exceptionInfo->ExceptionRecord->ExceptionInformation[0] == 1;
-          std::string built;
-          if (isWrite) built = std::format("Access violation writing to {}", faultingAddress);
-          else
-               built = std::format("Access violation reading {}", faultingAddress);
-
-          ecpps::IssueICE(built, &ecpps::platformlib::DebuggerContext::From(*exceptionInfo->ContextRecord));
-     }
-     break;
-     case EXCEPTION_INT_DIVIDE_BY_ZERO:
-          ecpps::IssueICE("Divide by zero", &ecpps::platformlib::DebuggerContext::From(*exceptionInfo->ContextRecord));
-          break;
-     default:
-          ecpps::IssueICE(
-              std::format("Unhandled exception has occurred: {}", exceptionInfo->ExceptionRecord->ExceptionCode),
-              &ecpps::platformlib::DebuggerContext::From(*exceptionInfo->ContextRecord));
-          break;
-     }
-
-     return EXCEPTION_EXECUTE_HANDLER;
-}
-
 static void EnableVirtualProcessing(void)
 {
      auto* const hConsoleOutput = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -115,7 +61,7 @@ enum struct FileIterationStatus : bool
                                                          std::vector<std::pair<std::string, std::size_t>>& functions,
                                                          ecpps::codegen::CodeEmitter& emitter, std::size_t& mainOffset)
 {
-     g_diagnosticsReferences.emplace(source.name, &source.diagnostics);
+     ecpps::g_diagnosticsReferences.emplace(source.name, &source.diagnostics);
 
      try
      {
@@ -282,12 +228,10 @@ enum struct FileIterationStatus : bool
           }
           catch (const std::exception& nestedException)
           {
-               ecpps::IssueICE(nestedException.what(), nullptr);
+               ecpps::IssueICE(nestedException.what());
           }
 
           ecpps::IssueICE(traceException);
-
-          return FileIterationStatus::Failure;
      }
      catch (const std::exception& e)
      {
@@ -302,12 +246,10 @@ enum struct FileIterationStatus : bool
           }
           catch (const std::exception& nestedException)
           {
-               ecpps::IssueICE(nestedException.what(), nullptr);
+               ecpps::IssueICE(nestedException.what());
           }
 
-          ecpps::IssueICE(e.what(), nullptr);
-
-          return FileIterationStatus::Failure;
+          ecpps::IssueICE(e.what());
      }
      catch (...)
      {
@@ -322,12 +264,10 @@ enum struct FileIterationStatus : bool
           }
           catch (const std::exception& nestedException)
           {
-               ecpps::IssueICE(nestedException.what(), nullptr);
+               ecpps::IssueICE(nestedException.what());
           }
 
-          ecpps::IssueICE("unknown", nullptr);
-
-          return FileIterationStatus::Failure;
+          ecpps::IssueICE("unknown");
      }
      return FileIterationStatus::Success;
 }
@@ -336,8 +276,8 @@ int main(int argc, char* argv[])
 {
 #ifdef _WIN32
      EnableVirtualProcessing();
-     SetUnhandledExceptionFilter(WinExceptionHandler);
 #endif
+     ecpps::RegisterErrorCallbacks();
 
      try
      {
@@ -388,7 +328,7 @@ int main(int argc, char* argv[])
                                  config.verboseStatus == ecpps::VerboseStatus::ExtraVerbose;
           const bool isExtraVerbose = config.verboseStatus == ecpps::VerboseStatus::ExtraVerbose;
 
-          g_diagnosticsReferences.reserve(sources.files.size());
+          ecpps::g_diagnosticsReferences.reserve(sources.files.size());
 
           for (ecpps::SourceFile& source : sources.files)
           {
@@ -539,11 +479,10 @@ int main(int argc, char* argv[])
      }
      catch (const std::exception& e)
      {
-          ecpps::IssueICE(e.what(), nullptr);
+          ecpps::IssueICE(e.what());
      }
      catch (...)
      {
-          ecpps::IssueICE("unknown", nullptr);
-          return -1;
+          ecpps::IssueICE("unknown");
      }
 }


### PR DESCRIPTION
Use C++23 `std::stacktrace` for the stacktrace, abstract out exception filters and modularise/extract EH from main.

Signed-off-by: TymianekPL [tymi@tymi.org](mailto:tymi@tymi.org)

