### PR TITLE
Change clang-format rules to break all functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,13 +1,18 @@
 ---
 Language: Cpp
 BasedOnStyle: Microsoft
+ReferenceAlignment: Left
 PointerAlignment: Left
 QualifierAlignment: Left
-NamespaceIndentation: All
 BreakBeforeBraces: Allman
 SpaceAfterTemplateKeyword: true
-TabWidth: 5
 IndentWidth: 5
+TabWidth: 5
+UseTab: Never
+AccessModifierOffset: -5
+NamespaceIndentation: All
+IndentRequires: true
+ContinuationIndentWidth: 5
 AllowShortEnumsOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: None
@@ -15,7 +20,6 @@ AllowShortLambdasOnASingleLine: None
 AllowShortBlocksOnASingleLine: Never
 AllowShortIfStatementsOnASingleLine: Always
 AllowShortLoopsOnASingleLine: true
-IndentRequires: true
 IncludeCategories:
     # Headers in <> with .h extension.
     - Regex: '<([A-Za-z0-9\/-_])+\.h>'
@@ -29,4 +33,6 @@ IncludeCategories:
 
 Cpp11BracedListStyle: true
 SpaceBeforeParens: ControlStatements
-AccessModifierOffset: -5
+BreakBeforeTernaryOperators: true
+AlignOperands: Align
+ColumnLimit: 120

--- a/.clang-format
+++ b/.clang-format
@@ -10,9 +10,9 @@ TabWidth: 5
 IndentWidth: 5
 AllowShortEnumsOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All
-AllowShortLambdasOnASingleLine: All
-AllowShortBlocksOnASingleLine: Always
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: None
+AllowShortBlocksOnASingleLine: Never
 AllowShortIfStatementsOnASingleLine: Always
 AllowShortLoopsOnASingleLine: true
 IndentRequires: true

--- a/compiler/ecpps/src/CodeGeneration/CodeEmitter.cpp
+++ b/compiler/ecpps/src/CodeGeneration/CodeEmitter.cpp
@@ -34,14 +34,41 @@ std::unique_ptr<ecpps::codegen::CodeEmitter> ecpps::codegen::CodeEmitter::New(ab
 
 std::vector<std::byte> ecpps::codegen::CodeEmitter::EmitInstruction(const Instruction& instruction)
 {
-     return std::visit(
-         OverloadedVisitor{
-             [this](const MovInstruction& mov) { return this->EmitMov(mov); }, [this](const AddInstruction& add)
-             { return this->EmitAdd(add); }, [this](const SubInstruction& sub) { return this->EmitSub(sub); },
-             [this](const MulInstruction& mul) { return this->EmitMul(mul); }, [this](const DivInstruction& div)
-             { return this->EmitDiv(div); }, [this](const CallInstruction& call) { return this->EmitCall(call); },
-             [this](const TakeAddressInstruction& lea) { return this->EmitLea(lea); },
-             [this](const ReturnInstruction&) { return this->EmitReturn(); },
-             [](auto&&) -> std::vector<std::byte> { throw TracedException("invalid instruction"); }},
-         instruction);
+     return std::visit(OverloadedVisitor{[this](const MovInstruction& mov)
+                                         {
+                                              return this->EmitMov(mov);
+                                         },
+                                         [this](const AddInstruction& add)
+                                         {
+                                              return this->EmitAdd(add);
+                                         },
+                                         [this](const SubInstruction& sub)
+                                         {
+                                              return this->EmitSub(sub);
+                                         },
+                                         [this](const MulInstruction& mul)
+                                         {
+                                              return this->EmitMul(mul);
+                                         },
+                                         [this](const DivInstruction& div)
+                                         {
+                                              return this->EmitDiv(div);
+                                         },
+                                         [this](const CallInstruction& call)
+                                         {
+                                              return this->EmitCall(call);
+                                         },
+                                         [this](const TakeAddressInstruction& lea)
+                                         {
+                                              return this->EmitLea(lea);
+                                         },
+                                         [this](const ReturnInstruction&)
+                                         {
+                                              return this->EmitReturn();
+                                         },
+                                         [](auto&&) -> std::vector<std::byte>
+                                         {
+                                              throw TracedException("invalid instruction");
+                                         }},
+                       instruction);
 }

--- a/compiler/ecpps/src/CodeGeneration/CodeEmitter.h
+++ b/compiler/ecpps/src/CodeGeneration/CodeEmitter.h
@@ -46,7 +46,10 @@ namespace ecpps::codegen
      public:
           virtual ~CodeEmitter(void);
           [[nodiscard]] std::vector<std::byte> EmitRoutine(const Routine& routine, std::size_t displacement);
-          [[nodiscard]] const std::string& Name(void) const noexcept { return this->_name; }
+          [[nodiscard]] const std::string& Name(void) const noexcept
+          {
+               return this->_name;
+          }
 
           virtual void PatchCalls(std::vector<std::byte>& source,
                                   std::unordered_map<std::string, std::size_t>& routines) = 0;
@@ -58,7 +61,9 @@ namespace ecpps::codegen
           std::vector<std::size_t> _stringRelocation{};
 
      protected:
-          explicit CodeEmitter(std::string name) : _name(std::move(name)) {}
+          explicit CodeEmitter(std::string name) : _name(std::move(name))
+          {
+          }
 
           std::size_t _currentInstructionBase{};
           // PRE emitting: used to store locations of calls to be patched later

--- a/compiler/ecpps/src/CodeGeneration/CodeEmitter.h
+++ b/compiler/ecpps/src/CodeGeneration/CodeEmitter.h
@@ -20,8 +20,8 @@ namespace ecpps::codegen
      {
           std::string symbolName;
           std::function<std::vector<std::byte>(
-              Address, std::unordered_map<std::string, std::vector<std::byte>>& thunkProcedures)>
-              apply;
+               Address, std::unordered_map<std::string, std::vector<std::byte>>& thunkProcedures)>
+               apply;
           std::size_t applyOutputSize;
      };
      struct StringRelocation
@@ -87,7 +87,7 @@ namespace ecpps::codegen
           /// Custom instruction emitter. By default a no-op.
           /// </summary>
           [[nodiscard]] virtual std::vector<std::byte> EmitCustomInstruction(
-              [[maybe_unused]] const CustomInstruction& instruction)
+               [[maybe_unused]] const CustomInstruction& instruction)
           {
                return {};
           }

--- a/compiler/ecpps/src/CodeGeneration/Emitters/x86_64.cpp
+++ b/compiler/ecpps/src/CodeGeneration/Emitters/x86_64.cpp
@@ -1,7 +1,6 @@
 // NOLINT(readability-identifier-length)
 
 #include "x86_64.h"
-#include <cmath>
 #include <format>
 #include <mutex>
 #include <stdexcept>
@@ -15,8 +14,9 @@ void ecpps::codegen::emitters::X8664Emitter::PatchCalls(std::vector<std::byte>& 
                                                         std::unordered_map<std::string, std::size_t>& routines)
 {
      constexpr static auto ApplyImportLambda =
-         [](Address resolved, [[maybe_unused]] std::unordered_map<std::string, std::vector<std::byte>>& thunkProcedures)
-         -> std::vector<std::byte>
+          [](Address resolved,
+             [[maybe_unused]] std::unordered_map<std::string, std::vector<std::byte>>& thunkProcedures)
+          -> std::vector<std::byte>
      {
           return x86_64::GenerateIndirectCall2(static_cast<std::int32_t>(resolved.Value()));
      };
@@ -26,9 +26,9 @@ void ecpps::codegen::emitters::X8664Emitter::PatchCalls(std::vector<std::byte>& 
           if (ecpps::codegen::g_functionImports.contains(name))
           {
                this->linkerForwardedRelocations.emplace(
-                   ByteOffset{index}, Relocation{.symbolName = name,
-                                                 .apply = ApplyImportLambda,
-                                                 .applyOutputSize = 6}); // Linker pass handles that, hopefully
+                    ByteOffset{index}, Relocation{.symbolName = name,
+                                                  .apply = ApplyImportLambda,
+                                                  .applyOutputSize = 6}); // Linker pass handles that, hopefully
                continue;
           }
 
@@ -50,395 +50,417 @@ void ecpps::codegen::emitters::X8664Emitter::PatchCalls(std::vector<std::byte>& 
 std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMov(const MovInstruction& mov)
 {
      return mov.isConversion
-                ? std::visit(
-                      OverloadedVisitor{
-                          [&mov, this](const RegisterOperand&)
-                          {
-                               return std::visit(
-                                   OverloadedVisitor{
-                                       [](std::monostate)
-                                       {
-                                            return std::vector<std::byte>{};
-                                       },
-                                       [](const ErrorOperand&)
-                                       {
-                                            return std::vector<std::byte>{};
-                                       },
-                                       [&mov, this](const RegisterOperand&)
-                                       {
-                                            return this->EmitSpecificConversion<OperandCombination::RegisterToRegister>(
-                                                mov);
-                                       },
-                                       [&mov, this](const IntegerOperand&)
-                                       {
-                                            return this
-                                                ->EmitSpecificConversion<OperandCombination::ImmediateToRegister>(mov);
-                                       },
-                                       [&mov, this](const MemoryLocationOperand&)
-                                       {
-                                            return this->EmitSpecificConversion<OperandCombination::MemoryToRegister>(
-                                                mov);
-                                       },
-                                       [](auto&&) -> std::vector<std::byte>
-                                       {
-                                            throw TracedException(std::logic_error(
-                                                "Invalid conversion mov operation: unsupported source operand type"));
-                                       }},
-                                   mov.source);
-                          },
-                          [&mov, this](const MemoryLocationOperand&)
-                          {
-                               return std::visit(
-                                   OverloadedVisitor{
-                                       [](std::monostate)
-                                       {
-                                            return std::vector<std::byte>{};
-                                       },
-                                       [](const ErrorOperand&)
-                                       {
-                                            return std::vector<std::byte>{};
-                                       },
-                                       [&mov, this](const RegisterOperand&)
-                                       {
-                                            return this->EmitSpecificConversion<OperandCombination::RegisterToMemory>(
-                                                mov);
-                                       },
-                                       [&mov, this](const IntegerOperand&)
-                                       {
-                                            return this->EmitSpecificConversion<OperandCombination::ImmediateToMemory>(
-                                                mov);
-                                       },
-                                       [&mov, this](const MemoryLocationOperand&) -> std::vector<std::byte>
-                                       {
-                                            auto& abi = ecpps::abi::ABI::Current();
-                                            auto tempReg = abi.AllocateRegister(mov.width);
+                 ? std::visit(
+                        OverloadedVisitor{
+                             [&mov, this](const RegisterOperand&)
+                             {
+                                  return std::visit(
+                                       OverloadedVisitor{
+                                            [](std::monostate)
+                                            {
+                                                 return std::vector<std::byte>{};
+                                            },
+                                            [](const ErrorOperand&)
+                                            {
+                                                 return std::vector<std::byte>{};
+                                            },
+                                            [&mov, this](const RegisterOperand&)
+                                            {
+                                                 return this
+                                                      ->EmitSpecificConversion<OperandCombination::RegisterToRegister>(
+                                                           mov);
+                                            },
+                                            [&mov, this](const IntegerOperand&)
+                                            {
+                                                 return this
+                                                      ->EmitSpecificConversion<OperandCombination::ImmediateToRegister>(
+                                                           mov);
+                                            },
+                                            [&mov, this](const MemoryLocationOperand&)
+                                            {
+                                                 return this
+                                                      ->EmitSpecificConversion<OperandCombination::MemoryToRegister>(
+                                                           mov);
+                                            },
+                                            [](auto&&) -> std::vector<std::byte>
+                                            {
+                                                 throw TracedException(
+                                                      std::logic_error("Invalid conversion mov operation: unsupported "
+                                                                       "source operand type"));
+                                            }},
+                                       mov.source);
+                             },
+                             [&mov, this](const MemoryLocationOperand&)
+                             {
+                                  return std::visit(
+                                       OverloadedVisitor{
+                                            [](std::monostate)
+                                            {
+                                                 return std::vector<std::byte>{};
+                                            },
+                                            [](const ErrorOperand&)
+                                            {
+                                                 return std::vector<std::byte>{};
+                                            },
+                                            [&mov, this](const RegisterOperand&)
+                                            {
+                                                 return this
+                                                      ->EmitSpecificConversion<OperandCombination::RegisterToMemory>(
+                                                           mov);
+                                            },
+                                            [&mov, this](const IntegerOperand&)
+                                            {
+                                                 return this
+                                                      ->EmitSpecificConversion<OperandCombination::ImmediateToMemory>(
+                                                           mov);
+                                            },
+                                            [&mov, this](const MemoryLocationOperand&) -> std::vector<std::byte>
+                                            {
+                                                 auto& abi = ecpps::abi::ABI::Current();
+                                                 auto tempReg = abi.AllocateRegister(mov.width);
 
-                                            MovInstruction loadMov = mov;
-                                            loadMov.destination = RegisterOperand{tempReg.Ptr()};
-                                            auto loadInstructions =
-                                                this->EmitSpecificConversion<OperandCombination::MemoryToRegister>(
-                                                    loadMov);
+                                                 MovInstruction loadMov = mov;
+                                                 loadMov.destination = RegisterOperand{tempReg.Ptr()};
+                                                 auto loadInstructions = this->EmitSpecificConversion<
+                                                      OperandCombination::MemoryToRegister>(loadMov);
 
-                                            MovInstruction storeMov = mov;
-                                            storeMov.source = RegisterOperand{tempReg.Ptr()};
-                                            auto storeInstructions =
-                                                this->EmitSpecificConversion<OperandCombination::RegisterToMemory>(
-                                                    storeMov);
+                                                 MovInstruction storeMov = mov;
+                                                 storeMov.source = RegisterOperand{tempReg.Ptr()};
+                                                 auto storeInstructions = this->EmitSpecificConversion<
+                                                      OperandCombination::RegisterToMemory>(storeMov);
 
-                                            tempReg.Release();
+                                                 tempReg.Release();
 
-                                            loadInstructions.insert(loadInstructions.end(), storeInstructions.begin(),
-                                                                    storeInstructions.end());
-                                            return loadInstructions;
-                                       },
-                                       [](auto&&) -> std::vector<std::byte>
-                                       {
-                                            throw TracedException(std::logic_error(
-                                                "Invalid conversion mov operation: unsupported operand combination"));
-                                       }},
-                                   mov.source);
-                          },
-                          [](const ErrorOperand&) -> std::vector<std::byte>
-                          {
-                               return std::vector<std::byte>{};
-                          },
-                          [](const std::monostate&) -> std::vector<std::byte>
-                          {
-                               return std::vector<std::byte>{};
-                          },
-                          [](auto&&) -> std::vector<std::byte>
-                          {
-                               throw TracedException(std::logic_error(
-                                   "Invalid conversion mov operation: unsupported destination operand type"));
-                          }},
-                      mov.destination)
-                : std::visit(
-                      OverloadedVisitor{
-                          [&mov, this](const RegisterOperand&)
-                          {
-                               return std::visit(
-                                   OverloadedVisitor{
-                                       [](std::monostate)
-                                       {
-                                            return std::vector<std::byte>{};
-                                       },
-                                       [](const ErrorOperand&)
-                                       {
-                                            return std::vector<std::byte>{};
-                                       },
-                                       [&mov, this](const RegisterOperand&)
-                                       {
-                                            return this->EmitSpecificMov<OperandCombination::RegisterToRegister>(mov);
-                                       },
-                                       [&mov, this](const IntegerOperand&)
-                                       {
-                                            return this->EmitSpecificMov<OperandCombination::ImmediateToRegister>(mov);
-                                       },
-                                       [&mov, this](const MemoryLocationOperand&)
-                                       {
-                                            return this->EmitSpecificMov<OperandCombination::MemoryToRegister>(mov);
-                                       },
-                                       [](auto&&) -> std::vector<std::byte>
-                                       {
-                                            throw TracedException(std::logic_error(
-                                                "Invalid mov operation: unsupported source operand type"));
-                                       }},
-                                   mov.source);
-                          },
-                          [&mov, this](const MemoryLocationOperand&)
-                          {
-                               return std::visit(
-                                   OverloadedVisitor{
-                                       [](std::monostate)
-                                       {
-                                            return std::vector<std::byte>{};
-                                       },
-                                       [](const ErrorOperand&)
-                                       {
-                                            return std::vector<std::byte>{};
-                                       },
-                                       [&mov, this](const RegisterOperand&)
-                                       {
-                                            return this->EmitSpecificMov<OperandCombination::RegisterToMemory>(mov);
-                                       },
-                                       [&mov, this](const IntegerOperand&)
-                                       {
-                                            return this->EmitSpecificMov<OperandCombination::ImmediateToMemory>(mov);
-                                       },
-                                       [&mov, this](const MemoryLocationOperand&) -> std::vector<std::byte>
-                                       {
-                                            auto& abi = ecpps::abi::ABI::Current();
-                                            auto tempReg = abi.AllocateRegister(mov.width);
+                                                 loadInstructions.insert(loadInstructions.end(),
+                                                                         storeInstructions.begin(),
+                                                                         storeInstructions.end());
+                                                 return loadInstructions;
+                                            },
+                                            [](auto&&) -> std::vector<std::byte>
+                                            {
+                                                 throw TracedException(
+                                                      std::logic_error("Invalid conversion mov operation: unsupported "
+                                                                       "operand combination"));
+                                            }},
+                                       mov.source);
+                             },
+                             [](const ErrorOperand&) -> std::vector<std::byte>
+                             {
+                                  return std::vector<std::byte>{};
+                             },
+                             [](const std::monostate&) -> std::vector<std::byte>
+                             {
+                                  return std::vector<std::byte>{};
+                             },
+                             [](auto&&) -> std::vector<std::byte>
+                             {
+                                  throw TracedException(std::logic_error(
+                                       "Invalid conversion mov operation: unsupported destination operand type"));
+                             }},
+                        mov.destination)
+                 : std::visit(
+                        OverloadedVisitor{
+                             [&mov, this](const RegisterOperand&)
+                             {
+                                  return std::visit(
+                                       OverloadedVisitor{
+                                            [](std::monostate)
+                                            {
+                                                 return std::vector<std::byte>{};
+                                            },
+                                            [](const ErrorOperand&)
+                                            {
+                                                 return std::vector<std::byte>{};
+                                            },
+                                            [&mov, this](const RegisterOperand&)
+                                            {
+                                                 return this->EmitSpecificMov<OperandCombination::RegisterToRegister>(
+                                                      mov);
+                                            },
+                                            [&mov, this](const IntegerOperand&)
+                                            {
+                                                 return this->EmitSpecificMov<OperandCombination::ImmediateToRegister>(
+                                                      mov);
+                                            },
+                                            [&mov, this](const MemoryLocationOperand&)
+                                            {
+                                                 return this->EmitSpecificMov<OperandCombination::MemoryToRegister>(
+                                                      mov);
+                                            },
+                                            [](auto&&) -> std::vector<std::byte>
+                                            {
+                                                 throw TracedException(std::logic_error(
+                                                      "Invalid mov operation: unsupported source operand type"));
+                                            }},
+                                       mov.source);
+                             },
+                             [&mov, this](const MemoryLocationOperand&)
+                             {
+                                  return std::visit(
+                                       OverloadedVisitor{
+                                            [](std::monostate)
+                                            {
+                                                 return std::vector<std::byte>{};
+                                            },
+                                            [](const ErrorOperand&)
+                                            {
+                                                 return std::vector<std::byte>{};
+                                            },
+                                            [&mov, this](const RegisterOperand&)
+                                            {
+                                                 return this->EmitSpecificMov<OperandCombination::RegisterToMemory>(
+                                                      mov);
+                                            },
+                                            [&mov, this](const IntegerOperand&)
+                                            {
+                                                 return this->EmitSpecificMov<OperandCombination::ImmediateToMemory>(
+                                                      mov);
+                                            },
+                                            [&mov, this](const MemoryLocationOperand&) -> std::vector<std::byte>
+                                            {
+                                                 auto& abi = ecpps::abi::ABI::Current();
+                                                 auto tempReg = abi.AllocateRegister(mov.width);
 
-                                            MovInstruction loadMov = mov;
-                                            loadMov.destination = RegisterOperand{tempReg.Ptr()};
-                                            auto loadInstructions =
-                                                this->EmitSpecificMov<OperandCombination::MemoryToRegister>(loadMov);
+                                                 MovInstruction loadMov = mov;
+                                                 loadMov.destination = RegisterOperand{tempReg.Ptr()};
+                                                 auto loadInstructions =
+                                                      this->EmitSpecificMov<OperandCombination::MemoryToRegister>(
+                                                           loadMov);
 
-                                            MovInstruction storeMov = mov;
-                                            storeMov.source = RegisterOperand{tempReg.Ptr()};
-                                            auto storeInstructions =
-                                                this->EmitSpecificMov<OperandCombination::RegisterToMemory>(storeMov);
+                                                 MovInstruction storeMov = mov;
+                                                 storeMov.source = RegisterOperand{tempReg.Ptr()};
+                                                 auto storeInstructions =
+                                                      this->EmitSpecificMov<OperandCombination::RegisterToMemory>(
+                                                           storeMov);
 
-                                            tempReg.Release();
+                                                 tempReg.Release();
 
-                                            loadInstructions.insert(loadInstructions.end(), storeInstructions.begin(),
-                                                                    storeInstructions.end());
-                                            return loadInstructions;
-                                       },
-                                       [](auto&&) -> std::vector<std::byte>
-                                       {
-                                            throw TracedException(std::logic_error(
-                                                "Invalid mov operation: unsupported operand combination"));
-                                       }},
-                                   mov.source);
-                          },
-                          [](const ErrorOperand&) -> std::vector<std::byte>
-                          {
-                               return std::vector<std::byte>{};
-                          },
-                          [](const std::monostate&) -> std::vector<std::byte>
-                          {
-                               return std::vector<std::byte>{};
-                          },
-                          [](auto&&) -> std::vector<std::byte>
-                          {
-                               throw TracedException(
-                                   std::logic_error("Invalid mov operation: unsupported destination operand type"));
-                          }},
-                      mov.destination);
+                                                 loadInstructions.insert(loadInstructions.end(),
+                                                                         storeInstructions.begin(),
+                                                                         storeInstructions.end());
+                                                 return loadInstructions;
+                                            },
+                                            [](auto&&) -> std::vector<std::byte>
+                                            {
+                                                 throw TracedException(std::logic_error(
+                                                      "Invalid mov operation: unsupported operand combination"));
+                                            }},
+                                       mov.source);
+                             },
+                             [](const ErrorOperand&) -> std::vector<std::byte>
+                             {
+                                  return std::vector<std::byte>{};
+                             },
+                             [](const std::monostate&) -> std::vector<std::byte>
+                             {
+                                  return std::vector<std::byte>{};
+                             },
+                             [](auto&&) -> std::vector<std::byte>
+                             {
+                                  throw TracedException(
+                                       std::logic_error("Invalid mov operation: unsupported destination operand type"));
+                             }},
+                        mov.destination);
 }
 
 std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitAdd(const AddInstruction& add)
 {
      return std::visit(
-         OverloadedVisitor{
-             [&add, this](const RegisterOperand&)
-             {
-                  return std::visit(
-                      OverloadedVisitor{[&add, this](const RegisterOperand&)
-                                        {
-                                             return this->EmitSpecificAdd<OperandCombination::RegisterToRegister>(add);
-                                        },
-                                        [&add, this](const IntegerOperand&)
-                                        {
-                                             return this->EmitSpecificAdd<OperandCombination::ImmediateToRegister>(add);
-                                        },
-                                        [&add, this](const MemoryLocationOperand&)
-                                        {
-                                             return this->EmitSpecificAdd<OperandCombination::MemoryToRegister>(add);
-                                        },
-                                        [](auto&&) -> std::vector<std::byte>
-                                        {
-                                             throw ecpps::TracedException(std::logic_error("Invalid add operation"));
-                                        }},
-                      add.from);
-             },
-             [&add, this](const MemoryLocationOperand&)
-             {
-                  return std::visit(
-                      OverloadedVisitor{[&add, this](const RegisterOperand&)
-                                        {
-                                             return this->EmitSpecificAdd<OperandCombination::RegisterToMemory>(add);
-                                        },
-                                        [&add, this](const IntegerOperand&)
-                                        {
-                                             return this->EmitSpecificAdd<OperandCombination::ImmediateToMemory>(add);
-                                        },
-                                        [](auto&&) -> std::vector<std::byte>
-                                        {
-                                             throw ecpps::TracedException(std::logic_error("Invalid add operation"));
-                                        }},
-                      add.from);
-             },
-             [](auto&&) -> std::vector<std::byte>
-             {
-                  throw ecpps::TracedException(std::logic_error("Invalid add operation"));
-             }},
-         add.to);
+          OverloadedVisitor{
+               [&add, this](const RegisterOperand&)
+               {
+                    return std::visit(
+                         OverloadedVisitor{
+                              [&add, this](const RegisterOperand&)
+                              {
+                                   return this->EmitSpecificAdd<OperandCombination::RegisterToRegister>(add);
+                              },
+                              [&add, this](const IntegerOperand&)
+                              {
+                                   return this->EmitSpecificAdd<OperandCombination::ImmediateToRegister>(add);
+                              },
+                              [&add, this](const MemoryLocationOperand&)
+                              {
+                                   return this->EmitSpecificAdd<OperandCombination::MemoryToRegister>(add);
+                              },
+                              [](auto&&) -> std::vector<std::byte>
+                              {
+                                   throw ecpps::TracedException(std::logic_error("Invalid add operation"));
+                              }},
+                         add.from);
+               },
+               [&add, this](const MemoryLocationOperand&)
+               {
+                    return std::visit(
+                         OverloadedVisitor{[&add, this](const RegisterOperand&)
+                                           {
+                                                return this->EmitSpecificAdd<OperandCombination::RegisterToMemory>(add);
+                                           },
+                                           [&add, this](const IntegerOperand&)
+                                           {
+                                                return this->EmitSpecificAdd<OperandCombination::ImmediateToMemory>(
+                                                     add);
+                                           },
+                                           [](auto&&) -> std::vector<std::byte>
+                                           {
+                                                throw ecpps::TracedException(std::logic_error("Invalid add operation"));
+                                           }},
+                         add.from);
+               },
+               [](auto&&) -> std::vector<std::byte>
+               {
+                    throw ecpps::TracedException(std::logic_error("Invalid add operation"));
+               }},
+          add.to);
 }
 
 std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitSub(const SubInstruction& sub)
 {
      return std::visit(
-         OverloadedVisitor{
-             [&sub, this](const RegisterOperand&)
-             {
-                  return std::visit(
-                      OverloadedVisitor{[&sub, this](const RegisterOperand&)
-                                        {
-                                             return this->EmitSpecificSub<OperandCombination::RegisterToRegister>(sub);
-                                        },
-                                        [&sub, this](const IntegerOperand&)
-                                        {
-                                             return this->EmitSpecificSub<OperandCombination::ImmediateToRegister>(sub);
-                                        },
-                                        [&sub, this](const MemoryLocationOperand&)
-                                        {
-                                             return this->EmitSpecificSub<OperandCombination::MemoryToRegister>(sub);
-                                        },
-                                        [](auto&&) -> std::vector<std::byte>
-                                        {
-                                             throw TracedException(std::logic_error("Invalid sub operation"));
-                                        }},
-                      sub.from);
-             },
-             [&sub, this](const MemoryLocationOperand&)
-             {
-                  return std::visit(
-                      OverloadedVisitor{[&sub, this](const RegisterOperand&)
-                                        {
-                                             return this->EmitSpecificSub<OperandCombination::RegisterToMemory>(sub);
-                                        },
-                                        [&sub, this](const IntegerOperand&)
-                                        {
-                                             return this->EmitSpecificSub<OperandCombination::ImmediateToMemory>(sub);
-                                        },
-                                        [](auto&&) -> std::vector<std::byte>
-                                        {
-                                             throw TracedException(std::logic_error("Invalid sub operation"));
-                                        }},
-                      sub.from);
-             },
-             [](auto&&) -> std::vector<std::byte>
-             {
-                  throw ecpps::TracedException(std::logic_error("Invalid sub operation"));
-             }},
-         sub.to);
+          OverloadedVisitor{
+               [&sub, this](const RegisterOperand&)
+               {
+                    return std::visit(
+                         OverloadedVisitor{
+                              [&sub, this](const RegisterOperand&)
+                              {
+                                   return this->EmitSpecificSub<OperandCombination::RegisterToRegister>(sub);
+                              },
+                              [&sub, this](const IntegerOperand&)
+                              {
+                                   return this->EmitSpecificSub<OperandCombination::ImmediateToRegister>(sub);
+                              },
+                              [&sub, this](const MemoryLocationOperand&)
+                              {
+                                   return this->EmitSpecificSub<OperandCombination::MemoryToRegister>(sub);
+                              },
+                              [](auto&&) -> std::vector<std::byte>
+                              {
+                                   throw TracedException(std::logic_error("Invalid sub operation"));
+                              }},
+                         sub.from);
+               },
+               [&sub, this](const MemoryLocationOperand&)
+               {
+                    return std::visit(
+                         OverloadedVisitor{[&sub, this](const RegisterOperand&)
+                                           {
+                                                return this->EmitSpecificSub<OperandCombination::RegisterToMemory>(sub);
+                                           },
+                                           [&sub, this](const IntegerOperand&)
+                                           {
+                                                return this->EmitSpecificSub<OperandCombination::ImmediateToMemory>(
+                                                     sub);
+                                           },
+                                           [](auto&&) -> std::vector<std::byte>
+                                           {
+                                                throw TracedException(std::logic_error("Invalid sub operation"));
+                                           }},
+                         sub.from);
+               },
+               [](auto&&) -> std::vector<std::byte>
+               {
+                    throw ecpps::TracedException(std::logic_error("Invalid sub operation"));
+               }},
+          sub.to);
 }
 
 std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMul(const MulInstruction& mul)
 {
      return std::visit(
-         OverloadedVisitor{
-             [&mul, this](const RegisterOperand&)
-             {
-                  return std::visit(
-                      OverloadedVisitor{[&mul, this](const RegisterOperand&)
-                                        {
-                                             return this->EmitSpecificMul<OperandCombination::RegisterToRegister>(mul);
-                                        },
-                                        [&mul, this](const IntegerOperand&)
-                                        {
-                                             return this->EmitSpecificMul<OperandCombination::ImmediateToRegister>(mul);
-                                        },
-                                        [&mul, this](const MemoryLocationOperand&)
-                                        {
-                                             return this->EmitSpecificMul<OperandCombination::MemoryToRegister>(mul);
-                                        },
-                                        [](auto&&) -> std::vector<std::byte>
-                                        {
-                                             throw TracedException(std::logic_error("Invalid mul operation"));
-                                        }},
-                      mul.from);
-             },
-             [&mul, this](const MemoryLocationOperand&)
-             {
-                  return std::visit(
-                      OverloadedVisitor{[&mul, this](const RegisterOperand&)
-                                        {
-                                             return this->EmitSpecificMul<OperandCombination::RegisterToMemory>(mul);
-                                        },
-                                        [&mul, this](const IntegerOperand&)
-                                        {
-                                             return this->EmitSpecificMul<OperandCombination::ImmediateToMemory>(mul);
-                                        },
-                                        [](auto&&) -> std::vector<std::byte>
-                                        {
-                                             throw TracedException(std::logic_error("Invalid mul operation"));
-                                        }},
-                      mul.from);
-             },
-             [](auto&&) -> std::vector<std::byte>
-             {
-                  throw TracedException(std::logic_error("Invalid mul operation"));
-             }},
-         mul.to);
+          OverloadedVisitor{
+               [&mul, this](const RegisterOperand&)
+               {
+                    return std::visit(
+                         OverloadedVisitor{
+                              [&mul, this](const RegisterOperand&)
+                              {
+                                   return this->EmitSpecificMul<OperandCombination::RegisterToRegister>(mul);
+                              },
+                              [&mul, this](const IntegerOperand&)
+                              {
+                                   return this->EmitSpecificMul<OperandCombination::ImmediateToRegister>(mul);
+                              },
+                              [&mul, this](const MemoryLocationOperand&)
+                              {
+                                   return this->EmitSpecificMul<OperandCombination::MemoryToRegister>(mul);
+                              },
+                              [](auto&&) -> std::vector<std::byte>
+                              {
+                                   throw TracedException(std::logic_error("Invalid mul operation"));
+                              }},
+                         mul.from);
+               },
+               [&mul, this](const MemoryLocationOperand&)
+               {
+                    return std::visit(
+                         OverloadedVisitor{[&mul, this](const RegisterOperand&)
+                                           {
+                                                return this->EmitSpecificMul<OperandCombination::RegisterToMemory>(mul);
+                                           },
+                                           [&mul, this](const IntegerOperand&)
+                                           {
+                                                return this->EmitSpecificMul<OperandCombination::ImmediateToMemory>(
+                                                     mul);
+                                           },
+                                           [](auto&&) -> std::vector<std::byte>
+                                           {
+                                                throw TracedException(std::logic_error("Invalid mul operation"));
+                                           }},
+                         mul.from);
+               },
+               [](auto&&) -> std::vector<std::byte>
+               {
+                    throw TracedException(std::logic_error("Invalid mul operation"));
+               }},
+          mul.to);
 }
 
 std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitDiv(const DivInstruction& div)
 {
      return std::visit(
-         OverloadedVisitor{
-             [&div, this](const RegisterOperand&)
-             {
-                  return std::visit(
-                      OverloadedVisitor{[&div, this](const RegisterOperand&)
-                                        {
-                                             return this->EmitSpecificDiv<OperandCombination::RegisterToRegister>(div);
-                                        },
-                                        [&div, this](const IntegerOperand&)
-                                        {
-                                             return this->EmitSpecificDiv<OperandCombination::ImmediateToRegister>(div);
-                                        },
-                                        [](auto&&) -> std::vector<std::byte>
-                                        {
-                                             throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
-                                        }},
-                      div.from);
-             },
-             [&div, this](const MemoryLocationOperand&)
-             {
-                  return std::visit(
-                      OverloadedVisitor{[&div, this](const RegisterOperand&)
-                                        {
-                                             return this->EmitSpecificDiv<OperandCombination::RegisterToMemory>(div);
-                                        },
-                                        [&div, this](const IntegerOperand&)
-                                        {
-                                             return this->EmitSpecificDiv<OperandCombination::ImmediateToMemory>(div);
-                                        },
-                                        [](auto&&) -> std::vector<std::byte>
-                                        {
-                                             throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
-                                        }},
-                      div.from);
-             },
-             [](auto&&) -> std::vector<std::byte>
-             {
-                  throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
-             }},
-         div.to);
+          OverloadedVisitor{
+               [&div, this](const RegisterOperand&)
+               {
+                    return std::visit(
+                         OverloadedVisitor{
+                              [&div, this](const RegisterOperand&)
+                              {
+                                   return this->EmitSpecificDiv<OperandCombination::RegisterToRegister>(div);
+                              },
+                              [&div, this](const IntegerOperand&)
+                              {
+                                   return this->EmitSpecificDiv<OperandCombination::ImmediateToRegister>(div);
+                              },
+                              [](auto&&) -> std::vector<std::byte>
+                              {
+                                   throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
+                              }},
+                         div.from);
+               },
+               [&div, this](const MemoryLocationOperand&)
+               {
+                    return std::visit(
+                         OverloadedVisitor{[&div, this](const RegisterOperand&)
+                                           {
+                                                return this->EmitSpecificDiv<OperandCombination::RegisterToMemory>(div);
+                                           },
+                                           [&div, this](const IntegerOperand&)
+                                           {
+                                                return this->EmitSpecificDiv<OperandCombination::ImmediateToMemory>(
+                                                     div);
+                                           },
+                                           [](auto&&) -> std::vector<std::byte>
+                                           {
+                                                throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
+                                           }},
+                         div.from);
+               },
+               [](auto&&) -> std::vector<std::byte>
+               {
+                    throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
+               }},
+          div.to);
 }
 
 std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitLea(const TakeAddressInstruction& lea)
@@ -450,7 +472,7 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitLea(const Tak
                                          [](auto&&) -> std::vector<std::byte>
                                          {
                                               throw ecpps::TracedException(
-                                                  std::logic_error("Invalid address-of operation"));
+                                                   std::logic_error("Invalid address-of operation"));
                                          }},
                        lea.to);
 }
@@ -474,11 +496,11 @@ std::size_t ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(const Regist
 {
      const auto registerName = register_.Index()->physical->friendlyName;
      const static std::unordered_map<std::string, std::size_t> GeneralRegisterMap{
-         {"rax", x86_64::Rax}, {"rcx", x86_64::Rcx}, {"rdx", x86_64::Rdx}, {"rbx", x86_64::Rbx},
-         {"rsp", x86_64::Rsp}, {"rbp", x86_64::Rbp}, {"rsi", x86_64::Rsi}, {"rdi", x86_64::Rdi},
+          {"rax", x86_64::Rax}, {"rcx", x86_64::Rcx}, {"rdx", x86_64::Rdx}, {"rbx", x86_64::Rbx},
+          {"rsp", x86_64::Rsp}, {"rbp", x86_64::Rbp}, {"rsi", x86_64::Rsi}, {"rdi", x86_64::Rdi},
 
-         {"r8", x86_64::R8},   {"r9", x86_64::R9},   {"r10", x86_64::R10}, {"r11", x86_64::R11},
-         {"r12", x86_64::R12}, {"r13", x86_64::R13}, {"r14", x86_64::R14}, {"r15", x86_64::R15},
+          {"r8", x86_64::R8},   {"r9", x86_64::R9},   {"r10", x86_64::R10}, {"r11", x86_64::R11},
+          {"r12", x86_64::R12}, {"r13", x86_64::R13}, {"r14", x86_64::R14}, {"r15", x86_64::R15},
      };
      if (GeneralRegisterMap.contains(registerName)) return GeneralRegisterMap.at(registerName);
 
@@ -499,7 +521,7 @@ struct ecpps::codegen::emitters::EmitSpecificMovImpl<ecpps::codegen::emitters::O
 
           const auto sourceImmediate = source.Value();
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (mov.width)
@@ -556,7 +578,7 @@ struct ecpps::codegen::emitters::EmitSpecificMovImpl<ecpps::codegen::emitters::O
 
           const auto sourceRegister = ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(source);
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (mov.width)
@@ -603,7 +625,7 @@ struct ecpps::codegen::emitters::EmitSpecificMovImpl<ecpps::codegen::emitters::O
 
 template <>
 struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
-    ecpps::codegen::emitters::OperandCombination::ImmediateToMemory>
+     ecpps::codegen::emitters::OperandCombination::ImmediateToMemory>
 {
      static std::vector<std::byte> operator()([[maybe_unused]] X8664Emitter* self, const MovInstruction& mov)
      {
@@ -612,7 +634,7 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
 
           const auto sourceImmediate = source.Value();
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (mov.width)
@@ -636,7 +658,7 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
 
 template <>
 struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
-    ecpps::codegen::emitters::OperandCombination::ImmediateToRegister>
+     ecpps::codegen::emitters::OperandCombination::ImmediateToRegister>
 {
      static std::vector<std::byte> operator()([[maybe_unused]] X8664Emitter* self, const MovInstruction& mov)
      {
@@ -663,7 +685,7 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
 
 template <>
 struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
-    ecpps::codegen::emitters::OperandCombination::RegisterToMemory>
+     ecpps::codegen::emitters::OperandCombination::RegisterToMemory>
 {
      static std::vector<std::byte> operator()([[maybe_unused]] X8664Emitter* self, const MovInstruction& mov)
      {
@@ -677,7 +699,7 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
 
           const auto sourceRegister = ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(source);
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           const auto fromSize = source.Size();
@@ -686,7 +708,7 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
           if (toSize > fromSize)
           {
                throw TracedException(std::logic_error(
-                   std::format("Cannot extend {} bits to {} bits when moving to memory", fromSize, toSize)));
+                    std::format("Cannot extend {} bits to {} bits when moving to memory", fromSize, toSize)));
           }
 
           switch (toSize)
@@ -706,7 +728,7 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
 
 template <>
 struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
-    ecpps::codegen::emitters::OperandCombination::RegisterToRegister>
+     ecpps::codegen::emitters::OperandCombination::RegisterToRegister>
 {
      static std::vector<std::byte> operator()([[maybe_unused]] X8664Emitter* self,
                                               [[maybe_unused]] const MovInstruction& mov)
@@ -752,25 +774,25 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
                {
                case wordSize:
                     return fromSize == byteSize
-                               ? x86_64::GenerateMovZeroExtendReg8ToReg16(destinationRegister, sourceRegister)
-                               : throw TracedException(std::logic_error(
-                                     std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
+                                ? x86_64::GenerateMovZeroExtendReg8ToReg16(destinationRegister, sourceRegister)
+                                : throw TracedException(std::logic_error(
+                                       std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
                case dwordSize:
                     return fromSize == byteSize
-                               ? x86_64::GenerateMovZeroExtendReg8ToReg32(destinationRegister, sourceRegister)
+                                ? x86_64::GenerateMovZeroExtendReg8ToReg32(destinationRegister, sourceRegister)
                            : fromSize == wordSize
-                               ? x86_64::GenerateMovZeroExtendReg16ToReg32(destinationRegister, sourceRegister)
-                               : throw TracedException(std::logic_error(
-                                     std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
+                                ? x86_64::GenerateMovZeroExtendReg16ToReg32(destinationRegister, sourceRegister)
+                                : throw TracedException(std::logic_error(
+                                       std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
                case qwordSize:
                     return fromSize == byteSize
-                               ? x86_64::GenerateMovZeroExtendReg8ToReg64(destinationRegister, sourceRegister)
+                                ? x86_64::GenerateMovZeroExtendReg8ToReg64(destinationRegister, sourceRegister)
                            : fromSize == wordSize
-                               ? x86_64::GenerateMovZeroExtendReg16ToReg64(destinationRegister, sourceRegister)
+                                ? x86_64::GenerateMovZeroExtendReg16ToReg64(destinationRegister, sourceRegister)
                            : fromSize == dwordSize
-                               ? x86_64::GenerateMovZeroExtendReg32ToReg64(destinationRegister, sourceRegister)
-                               : throw TracedException(std::logic_error(
-                                     std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
+                                ? x86_64::GenerateMovZeroExtendReg32ToReg64(destinationRegister, sourceRegister)
+                                : throw TracedException(std::logic_error(
+                                       std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
                }
           }
           break;
@@ -782,7 +804,7 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
 
 template <>
 struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
-    ecpps::codegen::emitters::OperandCombination::MemoryToRegister>
+     ecpps::codegen::emitters::OperandCombination::MemoryToRegister>
 {
      static std::vector<std::byte> operator()([[maybe_unused]] X8664Emitter* self, const MovInstruction& mov)
      {
@@ -831,28 +853,28 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
                {
                case wordSize:
                     return fromSize == byteSize
-                               ? x86_64::GenerateMovZeroExtendMem8ToReg16(destinationRegister, sourceRegisterOffset,
-                                                                          sourceRegister)
-                               : throw TracedException(std::logic_error(
-                                     std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
+                                ? x86_64::GenerateMovZeroExtendMem8ToReg16(destinationRegister, sourceRegisterOffset,
+                                                                           sourceRegister)
+                                : throw TracedException(std::logic_error(
+                                       std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
                case dwordSize:
                     return fromSize == byteSize ? x86_64::GenerateMovZeroExtendMem8ToReg32(
-                                                      destinationRegister, sourceRegisterOffset, sourceRegister)
+                                                       destinationRegister, sourceRegisterOffset, sourceRegister)
                            : fromSize == wordSize
-                               ? x86_64::GenerateMovZeroExtendMem16ToReg32(destinationRegister, sourceRegisterOffset,
-                                                                           sourceRegister)
-                               : throw TracedException(std::logic_error(
-                                     std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
+                                ? x86_64::GenerateMovZeroExtendMem16ToReg32(destinationRegister, sourceRegisterOffset,
+                                                                            sourceRegister)
+                                : throw TracedException(std::logic_error(
+                                       std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
                case qwordSize:
                     return fromSize == byteSize   ? x86_64::GenerateMovZeroExtendMem8ToReg64(
-                                                        destinationRegister, sourceRegisterOffset, sourceRegister)
+                                                         destinationRegister, sourceRegisterOffset, sourceRegister)
                            : fromSize == wordSize ? x86_64::GenerateMovZeroExtendMem16ToReg64(
-                                                        destinationRegister, sourceRegisterOffset, sourceRegister)
+                                                         destinationRegister, sourceRegisterOffset, sourceRegister)
                            : fromSize == dwordSize
-                               ? x86_64::GenerateMovZeroExtendMem32ToReg64(destinationRegister, sourceRegisterOffset,
-                                                                           sourceRegister)
-                               : throw TracedException(std::logic_error(
-                                     std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
+                                ? x86_64::GenerateMovZeroExtendMem32ToReg64(destinationRegister, sourceRegisterOffset,
+                                                                            sourceRegister)
+                                : throw TracedException(std::logic_error(
+                                       std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
                }
           }
           break;
@@ -876,7 +898,7 @@ struct ecpps::codegen::emitters::EmitSpecificAddImpl<ecpps::codegen::emitters::O
 
           const auto sourceImmediate = source.Value();
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (add.width)
@@ -961,7 +983,7 @@ struct ecpps::codegen::emitters::EmitSpecificAddImpl<ecpps::codegen::emitters::O
 
           const auto sourceRegister = ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(source);
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (add.width)
@@ -1042,7 +1064,7 @@ struct ecpps::codegen::emitters::EmitSpecificSubImpl<ecpps::codegen::emitters::O
 
           const auto sourceImmediate = source.Value();
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (sub.width)
@@ -1101,7 +1123,7 @@ struct ecpps::codegen::emitters::EmitSpecificSubImpl<ecpps::codegen::emitters::O
 
           const auto sourceRegister = ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(source);
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (sub.width)
@@ -1185,7 +1207,7 @@ struct ecpps::codegen::emitters::EmitSpecificMulImpl<ecpps::codegen::emitters::O
 
           const auto sourceImmediate = source.Value();
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (mul.width)
@@ -1249,7 +1271,7 @@ struct ecpps::codegen::emitters::EmitSpecificMulImpl<ecpps::codegen::emitters::O
 
           const auto sourceRegister = ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(source);
           const auto destinationRegister =
-              ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
+               ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(destination.Register());
           const auto destinationDisplacement = destination.Displacement();
 
           switch (mul.width)
@@ -1362,16 +1384,16 @@ struct ecpps::codegen::emitters::EmitSpecificDivImpl<ecpps::codegen::emitters::O
 
           UnsignedT initialThreshold = twoToThe31 + (UnsignedT(divisor) >> (BitCount - 1));
           UnsignedT adjustedThreshold =
-              initialThreshold - 1 - (initialThreshold % static_cast<UnsignedT>(absoluteDivisor));
+               initialThreshold - 1 - (initialThreshold % static_cast<UnsignedT>(absoluteDivisor));
 
           UnsignedT shiftCounter = BitCount - 1;
           UnsignedT quotientEstimateForAdjustedThreshold = twoToThe31 / adjustedThreshold;
           UnsignedT remainderEstimateForAdjustedThreshold =
-              twoToThe31 - (quotientEstimateForAdjustedThreshold * adjustedThreshold);
+               twoToThe31 - (quotientEstimateForAdjustedThreshold * adjustedThreshold);
 
           UnsignedT quotientEstimateForDivisor = twoToThe31 / static_cast<UnsignedT>(absoluteDivisor);
           UnsignedT remainderEstimateForDivisor =
-              twoToThe31 - (quotientEstimateForDivisor * static_cast<UnsignedT>(absoluteDivisor));
+               twoToThe31 - (quotientEstimateForDivisor * static_cast<UnsignedT>(absoluteDivisor));
 
           UnsignedT deltaThreshold{};
 
@@ -1401,8 +1423,8 @@ struct ecpps::codegen::emitters::EmitSpecificDivImpl<ecpps::codegen::emitters::O
 
                deltaThreshold = static_cast<UnsignedT>(absoluteDivisor) - remainderEstimateForDivisor;
           } while (
-              quotientEstimateForAdjustedThreshold < deltaThreshold ||
-              (quotientEstimateForAdjustedThreshold == deltaThreshold && remainderEstimateForAdjustedThreshold == 0));
+               quotientEstimateForAdjustedThreshold < deltaThreshold ||
+               (quotientEstimateForAdjustedThreshold == deltaThreshold && remainderEstimateForAdjustedThreshold == 0));
 
           SignedT magicMultiplier = static_cast<SignedT>(quotientEstimateForDivisor + 1);
 
@@ -1533,7 +1555,7 @@ struct ecpps::codegen::emitters::EmitSpecificDivImpl<ecpps::codegen::emitters::O
                code.append_range(x86_64::GenerateSignedSarImmToReg32(x86_64::Rcx, 31));
                code.append_range(x86_64::GenerateMovZeroExtendReg16ToReg32(x86_64::Rax, destReg));
                code.append_range(
-                   x86_64::GenerateSignedMulImmToReg64(x86_64::Rax, static_cast<std::uint64_t>(magic.magic)));
+                    x86_64::GenerateSignedMulImmToReg64(x86_64::Rax, static_cast<std::uint64_t>(magic.magic)));
                code.append_range(x86_64::GenerateSignedShrImmToReg64(x86_64::Rax, 32));
 
                if (magic.shift)

--- a/compiler/ecpps/src/CodeGeneration/Emitters/x86_64.cpp
+++ b/compiler/ecpps/src/CodeGeneration/Emitters/x86_64.cpp
@@ -17,7 +17,9 @@ void ecpps::codegen::emitters::X8664Emitter::PatchCalls(std::vector<std::byte>& 
      constexpr static auto ApplyImportLambda =
          [](Address resolved, [[maybe_unused]] std::unordered_map<std::string, std::vector<std::byte>>& thunkProcedures)
          -> std::vector<std::byte>
-     { return x86_64::GenerateIndirectCall2(static_cast<std::int32_t>(resolved.Value())); };
+     {
+          return x86_64::GenerateIndirectCall2(static_cast<std::int32_t>(resolved.Value()));
+     };
 
      for (const auto& [index, name] : this->_relocationTable)
      {
@@ -54,8 +56,14 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMov(const Mov
                           {
                                return std::visit(
                                    OverloadedVisitor{
-                                       [](std::monostate) { return std::vector<std::byte>{}; },
-                                       [](const ErrorOperand&) { return std::vector<std::byte>{}; },
+                                       [](std::monostate)
+                                       {
+                                            return std::vector<std::byte>{};
+                                       },
+                                       [](const ErrorOperand&)
+                                       {
+                                            return std::vector<std::byte>{};
+                                       },
                                        [&mov, this](const RegisterOperand&)
                                        {
                                             return this->EmitSpecificConversion<OperandCombination::RegisterToRegister>(
@@ -82,8 +90,14 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMov(const Mov
                           {
                                return std::visit(
                                    OverloadedVisitor{
-                                       [](std::monostate) { return std::vector<std::byte>{}; },
-                                       [](const ErrorOperand&) { return std::vector<std::byte>{}; },
+                                       [](std::monostate)
+                                       {
+                                            return std::vector<std::byte>{};
+                                       },
+                                       [](const ErrorOperand&)
+                                       {
+                                            return std::vector<std::byte>{};
+                                       },
                                        [&mov, this](const RegisterOperand&)
                                        {
                                             return this->EmitSpecificConversion<OperandCombination::RegisterToMemory>(
@@ -124,8 +138,14 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMov(const Mov
                                        }},
                                    mov.source);
                           },
-                          [](const ErrorOperand&) -> std::vector<std::byte> { return std::vector<std::byte>{}; },
-                          [](const std::monostate&) -> std::vector<std::byte> { return std::vector<std::byte>{}; },
+                          [](const ErrorOperand&) -> std::vector<std::byte>
+                          {
+                               return std::vector<std::byte>{};
+                          },
+                          [](const std::monostate&) -> std::vector<std::byte>
+                          {
+                               return std::vector<std::byte>{};
+                          },
                           [](auto&&) -> std::vector<std::byte>
                           {
                                throw TracedException(std::logic_error(
@@ -138,13 +158,26 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMov(const Mov
                           {
                                return std::visit(
                                    OverloadedVisitor{
-                                       [](std::monostate) { return std::vector<std::byte>{}; }, [](const ErrorOperand&)
-                                       { return std::vector<std::byte>{}; }, [&mov, this](const RegisterOperand&)
-                                       { return this->EmitSpecificMov<OperandCombination::RegisterToRegister>(mov); },
+                                       [](std::monostate)
+                                       {
+                                            return std::vector<std::byte>{};
+                                       },
+                                       [](const ErrorOperand&)
+                                       {
+                                            return std::vector<std::byte>{};
+                                       },
+                                       [&mov, this](const RegisterOperand&)
+                                       {
+                                            return this->EmitSpecificMov<OperandCombination::RegisterToRegister>(mov);
+                                       },
                                        [&mov, this](const IntegerOperand&)
-                                       { return this->EmitSpecificMov<OperandCombination::ImmediateToRegister>(mov); },
+                                       {
+                                            return this->EmitSpecificMov<OperandCombination::ImmediateToRegister>(mov);
+                                       },
                                        [&mov, this](const MemoryLocationOperand&)
-                                       { return this->EmitSpecificMov<OperandCombination::MemoryToRegister>(mov); },
+                                       {
+                                            return this->EmitSpecificMov<OperandCombination::MemoryToRegister>(mov);
+                                       },
                                        [](auto&&) -> std::vector<std::byte>
                                        {
                                             throw TracedException(std::logic_error(
@@ -156,11 +189,22 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMov(const Mov
                           {
                                return std::visit(
                                    OverloadedVisitor{
-                                       [](std::monostate) { return std::vector<std::byte>{}; }, [](const ErrorOperand&)
-                                       { return std::vector<std::byte>{}; }, [&mov, this](const RegisterOperand&)
-                                       { return this->EmitSpecificMov<OperandCombination::RegisterToMemory>(mov); },
+                                       [](std::monostate)
+                                       {
+                                            return std::vector<std::byte>{};
+                                       },
+                                       [](const ErrorOperand&)
+                                       {
+                                            return std::vector<std::byte>{};
+                                       },
+                                       [&mov, this](const RegisterOperand&)
+                                       {
+                                            return this->EmitSpecificMov<OperandCombination::RegisterToMemory>(mov);
+                                       },
                                        [&mov, this](const IntegerOperand&)
-                                       { return this->EmitSpecificMov<OperandCombination::ImmediateToMemory>(mov); },
+                                       {
+                                            return this->EmitSpecificMov<OperandCombination::ImmediateToMemory>(mov);
+                                       },
                                        [&mov, this](const MemoryLocationOperand&) -> std::vector<std::byte>
                                        {
                                             auto& abi = ecpps::abi::ABI::Current();
@@ -189,8 +233,14 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMov(const Mov
                                        }},
                                    mov.source);
                           },
-                          [](const ErrorOperand&) -> std::vector<std::byte> { return std::vector<std::byte>{}; },
-                          [](const std::monostate&) -> std::vector<std::byte> { return std::vector<std::byte>{}; },
+                          [](const ErrorOperand&) -> std::vector<std::byte>
+                          {
+                               return std::vector<std::byte>{};
+                          },
+                          [](const std::monostate&) -> std::vector<std::byte>
+                          {
+                               return std::vector<std::byte>{};
+                          },
                           [](auto&&) -> std::vector<std::byte>
                           {
                                throw TracedException(
@@ -207,28 +257,44 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitAdd(const Add
              {
                   return std::visit(
                       OverloadedVisitor{[&add, this](const RegisterOperand&)
-                                        { return this->EmitSpecificAdd<OperandCombination::RegisterToRegister>(add); },
+                                        {
+                                             return this->EmitSpecificAdd<OperandCombination::RegisterToRegister>(add);
+                                        },
                                         [&add, this](const IntegerOperand&)
-                                        { return this->EmitSpecificAdd<OperandCombination::ImmediateToRegister>(add); },
+                                        {
+                                             return this->EmitSpecificAdd<OperandCombination::ImmediateToRegister>(add);
+                                        },
                                         [&add, this](const MemoryLocationOperand&)
-                                        { return this->EmitSpecificAdd<OperandCombination::MemoryToRegister>(add); },
+                                        {
+                                             return this->EmitSpecificAdd<OperandCombination::MemoryToRegister>(add);
+                                        },
                                         [](auto&&) -> std::vector<std::byte>
-                                        { throw ecpps::TracedException(std::logic_error("Invalid add operation")); }},
+                                        {
+                                             throw ecpps::TracedException(std::logic_error("Invalid add operation"));
+                                        }},
                       add.from);
              },
              [&add, this](const MemoryLocationOperand&)
              {
                   return std::visit(
                       OverloadedVisitor{[&add, this](const RegisterOperand&)
-                                        { return this->EmitSpecificAdd<OperandCombination::RegisterToMemory>(add); },
+                                        {
+                                             return this->EmitSpecificAdd<OperandCombination::RegisterToMemory>(add);
+                                        },
                                         [&add, this](const IntegerOperand&)
-                                        { return this->EmitSpecificAdd<OperandCombination::ImmediateToMemory>(add); },
+                                        {
+                                             return this->EmitSpecificAdd<OperandCombination::ImmediateToMemory>(add);
+                                        },
                                         [](auto&&) -> std::vector<std::byte>
-                                        { throw ecpps::TracedException(std::logic_error("Invalid add operation")); }},
+                                        {
+                                             throw ecpps::TracedException(std::logic_error("Invalid add operation"));
+                                        }},
                       add.from);
              },
              [](auto&&) -> std::vector<std::byte>
-             { throw ecpps::TracedException(std::logic_error("Invalid add operation")); }},
+             {
+                  throw ecpps::TracedException(std::logic_error("Invalid add operation"));
+             }},
          add.to);
 }
 
@@ -240,28 +306,44 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitSub(const Sub
              {
                   return std::visit(
                       OverloadedVisitor{[&sub, this](const RegisterOperand&)
-                                        { return this->EmitSpecificSub<OperandCombination::RegisterToRegister>(sub); },
+                                        {
+                                             return this->EmitSpecificSub<OperandCombination::RegisterToRegister>(sub);
+                                        },
                                         [&sub, this](const IntegerOperand&)
-                                        { return this->EmitSpecificSub<OperandCombination::ImmediateToRegister>(sub); },
+                                        {
+                                             return this->EmitSpecificSub<OperandCombination::ImmediateToRegister>(sub);
+                                        },
                                         [&sub, this](const MemoryLocationOperand&)
-                                        { return this->EmitSpecificSub<OperandCombination::MemoryToRegister>(sub); },
+                                        {
+                                             return this->EmitSpecificSub<OperandCombination::MemoryToRegister>(sub);
+                                        },
                                         [](auto&&) -> std::vector<std::byte>
-                                        { throw TracedException(std::logic_error("Invalid sub operation")); }},
+                                        {
+                                             throw TracedException(std::logic_error("Invalid sub operation"));
+                                        }},
                       sub.from);
              },
              [&sub, this](const MemoryLocationOperand&)
              {
                   return std::visit(
                       OverloadedVisitor{[&sub, this](const RegisterOperand&)
-                                        { return this->EmitSpecificSub<OperandCombination::RegisterToMemory>(sub); },
+                                        {
+                                             return this->EmitSpecificSub<OperandCombination::RegisterToMemory>(sub);
+                                        },
                                         [&sub, this](const IntegerOperand&)
-                                        { return this->EmitSpecificSub<OperandCombination::ImmediateToMemory>(sub); },
+                                        {
+                                             return this->EmitSpecificSub<OperandCombination::ImmediateToMemory>(sub);
+                                        },
                                         [](auto&&) -> std::vector<std::byte>
-                                        { throw TracedException(std::logic_error("Invalid sub operation")); }},
+                                        {
+                                             throw TracedException(std::logic_error("Invalid sub operation"));
+                                        }},
                       sub.from);
              },
              [](auto&&) -> std::vector<std::byte>
-             { throw ecpps::TracedException(std::logic_error("Invalid sub operation")); }},
+             {
+                  throw ecpps::TracedException(std::logic_error("Invalid sub operation"));
+             }},
          sub.to);
 }
 
@@ -273,28 +355,44 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitMul(const Mul
              {
                   return std::visit(
                       OverloadedVisitor{[&mul, this](const RegisterOperand&)
-                                        { return this->EmitSpecificMul<OperandCombination::RegisterToRegister>(mul); },
+                                        {
+                                             return this->EmitSpecificMul<OperandCombination::RegisterToRegister>(mul);
+                                        },
                                         [&mul, this](const IntegerOperand&)
-                                        { return this->EmitSpecificMul<OperandCombination::ImmediateToRegister>(mul); },
+                                        {
+                                             return this->EmitSpecificMul<OperandCombination::ImmediateToRegister>(mul);
+                                        },
                                         [&mul, this](const MemoryLocationOperand&)
-                                        { return this->EmitSpecificMul<OperandCombination::MemoryToRegister>(mul); },
+                                        {
+                                             return this->EmitSpecificMul<OperandCombination::MemoryToRegister>(mul);
+                                        },
                                         [](auto&&) -> std::vector<std::byte>
-                                        { throw TracedException(std::logic_error("Invalid mul operation")); }},
+                                        {
+                                             throw TracedException(std::logic_error("Invalid mul operation"));
+                                        }},
                       mul.from);
              },
              [&mul, this](const MemoryLocationOperand&)
              {
                   return std::visit(
                       OverloadedVisitor{[&mul, this](const RegisterOperand&)
-                                        { return this->EmitSpecificMul<OperandCombination::RegisterToMemory>(mul); },
+                                        {
+                                             return this->EmitSpecificMul<OperandCombination::RegisterToMemory>(mul);
+                                        },
                                         [&mul, this](const IntegerOperand&)
-                                        { return this->EmitSpecificMul<OperandCombination::ImmediateToMemory>(mul); },
+                                        {
+                                             return this->EmitSpecificMul<OperandCombination::ImmediateToMemory>(mul);
+                                        },
                                         [](auto&&) -> std::vector<std::byte>
-                                        { throw TracedException(std::logic_error("Invalid mul operation")); }},
+                                        {
+                                             throw TracedException(std::logic_error("Invalid mul operation"));
+                                        }},
                       mul.from);
              },
              [](auto&&) -> std::vector<std::byte>
-             { throw TracedException(std::logic_error("Invalid mul operation")); }},
+             {
+                  throw TracedException(std::logic_error("Invalid mul operation"));
+             }},
          mul.to);
 }
 
@@ -306,37 +404,55 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitDiv(const Div
              {
                   return std::visit(
                       OverloadedVisitor{[&div, this](const RegisterOperand&)
-                                        { return this->EmitSpecificDiv<OperandCombination::RegisterToRegister>(div); },
+                                        {
+                                             return this->EmitSpecificDiv<OperandCombination::RegisterToRegister>(div);
+                                        },
                                         [&div, this](const IntegerOperand&)
-                                        { return this->EmitSpecificDiv<OperandCombination::ImmediateToRegister>(div); },
+                                        {
+                                             return this->EmitSpecificDiv<OperandCombination::ImmediateToRegister>(div);
+                                        },
                                         [](auto&&) -> std::vector<std::byte>
-                                        { throw ecpps::TracedException(std::logic_error("Invalid mul operation")); }},
+                                        {
+                                             throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
+                                        }},
                       div.from);
              },
              [&div, this](const MemoryLocationOperand&)
              {
                   return std::visit(
                       OverloadedVisitor{[&div, this](const RegisterOperand&)
-                                        { return this->EmitSpecificDiv<OperandCombination::RegisterToMemory>(div); },
+                                        {
+                                             return this->EmitSpecificDiv<OperandCombination::RegisterToMemory>(div);
+                                        },
                                         [&div, this](const IntegerOperand&)
-                                        { return this->EmitSpecificDiv<OperandCombination::ImmediateToMemory>(div); },
+                                        {
+                                             return this->EmitSpecificDiv<OperandCombination::ImmediateToMemory>(div);
+                                        },
                                         [](auto&&) -> std::vector<std::byte>
-                                        { throw ecpps::TracedException(std::logic_error("Invalid mul operation")); }},
+                                        {
+                                             throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
+                                        }},
                       div.from);
              },
              [](auto&&) -> std::vector<std::byte>
-             { throw ecpps::TracedException(std::logic_error("Invalid mul operation")); }},
+             {
+                  throw ecpps::TracedException(std::logic_error("Invalid mul operation"));
+             }},
          div.to);
 }
 
 std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitLea(const TakeAddressInstruction& lea)
 {
-     return std::visit(
-         OverloadedVisitor{[&lea, this](const RegisterOperand&)
-                           { return this->EmitSpecificLea<OperandCombination::MemoryToRegister>(lea); },
-                           [](auto&&) -> std::vector<std::byte>
-                           { throw ecpps::TracedException(std::logic_error("Invalid address-of operation")); }},
-         lea.to);
+     return std::visit(OverloadedVisitor{[&lea, this](const RegisterOperand&)
+                                         {
+                                              return this->EmitSpecificLea<OperandCombination::MemoryToRegister>(lea);
+                                         },
+                                         [](auto&&) -> std::vector<std::byte>
+                                         {
+                                              throw ecpps::TracedException(
+                                                  std::logic_error("Invalid address-of operation"));
+                                         }},
+                       lea.to);
 }
 
 std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitCall(const CallInstruction& call)
@@ -349,7 +465,10 @@ std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitCall(const Ca
      return {std::byte{0x90}, std::byte{0x90}, std::byte{0x90}, std::byte{0x90}, std::byte{0x90}};
 }
 
-std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitReturn(void) { return x86_64::GenerateRet(); }
+std::vector<std::byte> ecpps::codegen::emitters::X8664Emitter::EmitReturn(void)
+{
+     return x86_64::GenerateRet();
+}
 
 std::size_t ecpps::codegen::emitters::X8664Emitter::RegisterToIndex(const RegisterOperand& register_)
 {
@@ -725,8 +844,8 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
                                : throw TracedException(std::logic_error(
                                      std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
                case qwordSize:
-                    return fromSize == byteSize ? x86_64::GenerateMovZeroExtendMem8ToReg64(
-                                                      destinationRegister, sourceRegisterOffset, sourceRegister)
+                    return fromSize == byteSize   ? x86_64::GenerateMovZeroExtendMem8ToReg64(
+                                                        destinationRegister, sourceRegisterOffset, sourceRegister)
                            : fromSize == wordSize ? x86_64::GenerateMovZeroExtendMem16ToReg64(
                                                         destinationRegister, sourceRegisterOffset, sourceRegister)
                            : fromSize == dwordSize
@@ -1328,7 +1447,9 @@ struct ecpps::codegen::emitters::EmitSpecificDivImpl<ecpps::codegen::emitters::O
      static std::vector<std::byte> operator()([[maybe_unused]] X8664Emitter* self, const DivInstruction& div)
      {
           constexpr auto Absolute = [](std::signed_integral auto number) constexpr noexcept
-          { return number >= 0 ? number : -number; };
+          {
+               return number >= 0 ? number : -number;
+          };
           const auto& source = std::get<IntegerOperand>(div.from);
           const auto& destination = std::get<RegisterOperand>(div.to);
           const auto divisor = source.Value();
@@ -1415,7 +1536,10 @@ struct ecpps::codegen::emitters::EmitSpecificDivImpl<ecpps::codegen::emitters::O
                    x86_64::GenerateSignedMulImmToReg64(x86_64::Rax, static_cast<std::uint64_t>(magic.magic)));
                code.append_range(x86_64::GenerateSignedShrImmToReg64(x86_64::Rax, 32));
 
-               if (magic.shift) { code.append_range(x86_64::GenerateSignedSarImmToReg32(x86_64::Rax, magic.shift)); }
+               if (magic.shift)
+               {
+                    code.append_range(x86_64::GenerateSignedSarImmToReg32(x86_64::Rax, magic.shift));
+               }
                code.append_range(x86_64::GenerateSubRegToReg32(x86_64::Rax, x86_64::Rcx));
                code.append_range(x86_64::GenerateMovRegToReg32(destReg, x86_64::Rax));
 

--- a/compiler/ecpps/src/CodeGeneration/Emitters/x86_64.cpp
+++ b/compiler/ecpps/src/CodeGeneration/Emitters/x86_64.cpp
@@ -866,8 +866,8 @@ struct ecpps::codegen::emitters::EmitSpecificConversionImpl<
                                 : throw TracedException(std::logic_error(
                                        std::format("Cannot move-extend {} bits to {} bits", fromSize, toSize)));
                case qwordSize:
-                    return fromSize == byteSize   ? x86_64::GenerateMovZeroExtendMem8ToReg64(
-                                                         destinationRegister, sourceRegisterOffset, sourceRegister)
+                    return fromSize == byteSize ? x86_64::GenerateMovZeroExtendMem8ToReg64(
+                                                       destinationRegister, sourceRegisterOffset, sourceRegister)
                            : fromSize == wordSize ? x86_64::GenerateMovZeroExtendMem16ToReg64(
                                                          destinationRegister, sourceRegisterOffset, sourceRegister)
                            : fromSize == dwordSize

--- a/compiler/ecpps/src/CodeGeneration/Emitters/x86_64/Opcodes.cpp
+++ b/compiler/ecpps/src/CodeGeneration/Emitters/x86_64/Opcodes.cpp
@@ -12,13 +12,19 @@ inline namespace detail
      constexpr auto MakePusher(auto&& vector)
           requires std::ranges::output_range<decltype(vector), std::byte>
      {
-          return [&vector](std::byte b) { vector.push_back(b); };
+          return [&vector](std::byte b)
+          {
+               vector.push_back(b);
+          };
      }
      template <typename T>
      concept IsPushByteFunctor = requires(T t, std::byte b) {
           { t(b) } -> std::same_as<void>;
      };
-     static void Emit(IsPushByteFunctor auto&& push, std::integral auto b) { push(static_cast<std::byte>(b)); }
+     static void Emit(IsPushByteFunctor auto&& push, std::integral auto b)
+     {
+          push(static_cast<std::byte>(b));
+     }
      static void Rex(IsPushByteFunctor auto&& push, bool w, bool r, bool x, bool b)
      {
           std::uint8_t rex = 0x40u;

--- a/compiler/ecpps/src/CodeGeneration/Emitters/x86_64/Opcodes.cpp
+++ b/compiler/ecpps/src/CodeGeneration/Emitters/x86_64/Opcodes.cpp
@@ -205,7 +205,7 @@ std::vector<std::byte> ecpps::codegen::x86_64::GenerateMovImmToMem64(std::size_t
      if (imm > std::numeric_limits<std::uint32_t>::max())
      {
           binary.append_range(GenerateMovImmToMem32(
-              reg, offset, static_cast<std::uint32_t>(imm & std::numeric_limits<std::uint32_t>::max())));
+               reg, offset, static_cast<std::uint32_t>(imm & std::numeric_limits<std::uint32_t>::max())));
           binary.append_range(GenerateMovImmToMem32(reg, offset + 4, static_cast<std::uint32_t>(imm >> 32)));
           return binary;
      }
@@ -1267,7 +1267,7 @@ std::vector<std::byte> ecpps::codegen::x86_64::GenerateUnsignedMulRegToReg8([[ma
 }
 
 std::vector<std::byte> ecpps::codegen::x86_64::GenerateUnsignedMulRegToMem64(
-    std::size_t destination, std::size_t destinationOffset, [[maybe_unused]] std::size_t sourceRegister)
+     std::size_t destination, std::size_t destinationOffset, [[maybe_unused]] std::size_t sourceRegister)
 {
      std::vector<std::byte> binary{};
      Rex(MakePusher(binary), true, false, false, destination >= 8);
@@ -1278,7 +1278,7 @@ std::vector<std::byte> ecpps::codegen::x86_64::GenerateUnsignedMulRegToMem64(
 }
 
 std::vector<std::byte> ecpps::codegen::x86_64::GenerateUnsignedMulRegToMem32(
-    std::size_t destination, std::size_t destinationOffset, [[maybe_unused]] std::size_t sourceRegister)
+     std::size_t destination, std::size_t destinationOffset, [[maybe_unused]] std::size_t sourceRegister)
 {
      std::vector<std::byte> binary{};
      Rex(MakePusher(binary), false, false, false, destination >= 8);
@@ -1289,7 +1289,7 @@ std::vector<std::byte> ecpps::codegen::x86_64::GenerateUnsignedMulRegToMem32(
 }
 
 std::vector<std::byte> ecpps::codegen::x86_64::GenerateUnsignedMulRegToMem16(
-    std::size_t destination, std::size_t destinationOffset, [[maybe_unused]] std::size_t sourceRegister)
+     std::size_t destination, std::size_t destinationOffset, [[maybe_unused]] std::size_t sourceRegister)
 {
      std::vector<std::byte> binary{};
      Emit(MakePusher(binary), 0x66);
@@ -1484,8 +1484,8 @@ std::vector<std::byte> ecpps::codegen::x86_64::GenerateSignedMulRegToMem16(std::
 }
 
 std::vector<std::byte> ecpps::codegen::x86_64::GenerateSignedMulRegToMem8(
-    [[maybe_unused]] std::size_t destination, [[maybe_unused]] std::size_t destinationOffset,
-    [[maybe_unused]] std::size_t sourceRegister)
+     [[maybe_unused]] std::size_t destination, [[maybe_unused]] std::size_t destinationOffset,
+     [[maybe_unused]] std::size_t sourceRegister)
 {
      return {};
 }

--- a/compiler/ecpps/src/CodeGeneration/Emitters/x86_64/Opcodes.h
+++ b/compiler/ecpps/src/CodeGeneration/Emitters/x86_64/Opcodes.h
@@ -25,8 +25,14 @@ namespace ecpps::codegen::x86_64 // NOLINT(readability-identifier-naming)
 
      constexpr std::size_t Rip = 16;
 
-     constexpr std::vector<std::byte> GenerateRet(void) { return {std::byte{0xC3}}; }
-     constexpr std::vector<std::byte> GenerateNop(void) { return {std::byte{0x90}}; }
+     constexpr std::vector<std::byte> GenerateRet(void)
+     {
+          return {std::byte{0xC3}};
+     }
+     constexpr std::vector<std::byte> GenerateNop(void)
+     {
+          return {std::byte{0x90}};
+     }
      std::vector<std::byte> GenerateUD2(void);
      std::vector<std::byte> GenerateCwd(void);
      std::vector<std::byte> GenerateCqo(void);

--- a/compiler/ecpps/src/CodeGeneration/Nodes.cpp
+++ b/compiler/ecpps/src/CodeGeneration/Nodes.cpp
@@ -27,41 +27,32 @@ ecpps::codegen::IntegerRangeOperand::IntegerRangeOperand(std::vector<unsigned ch
 std::string ecpps::codegen::ToString(const Instruction& instruction)
 {
      return std::visit(
-         OverloadedVisitor{[](const MovInstruction& instruction)
-                           {
-                                std::string built =
-                                    instruction.isConversion
-                                        ? std::format(
-                                              "mov.{}-{}",
-                                              std::visit(OverloadedVisitor{[](std::monostate) -> std::size_t
-                                                                           {
-                                                                                return 0;
-                                                                           },
-                                                                           [](const auto& operand) -> std::size_t
-                                                                           {
-                                                                                return operand.Size();
-                                                                           }},
-                                                         instruction.source),
-                                              std::visit(OverloadedVisitor{[](std::monostate) -> std::size_t
-                                                                           {
-                                                                                return 0;
-                                                                           },
-                                                                           [](const auto& operand) -> std::size_t
-                                                                           {
-                                                                                return operand.Size();
-                                                                           }},
-                                                         instruction.destination))
-                                        : std::format("mov.{}", instruction.width);
-                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
-                                                                            {
-                                                                                 return "?";
-                                                                            },
-                                                                            [](const auto& operand) -> std::string
-                                                                            {
-                                                                                 return operand.ToString();
-                                                                            }},
-                                                          instruction.destination);
-                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+          OverloadedVisitor{[](const MovInstruction& instruction)
+                            {
+                                 std::string built =
+                                      instruction.isConversion
+                                           ? std::format(
+                                                  "mov.{}-{}",
+                                                  std::visit(OverloadedVisitor{[](std::monostate) -> std::size_t
+                                                                               {
+                                                                                    return 0;
+                                                                               },
+                                                                               [](const auto& operand) -> std::size_t
+                                                                               {
+                                                                                    return operand.Size();
+                                                                               }},
+                                                             instruction.source),
+                                                  std::visit(OverloadedVisitor{[](std::monostate) -> std::size_t
+                                                                               {
+                                                                                    return 0;
+                                                                               },
+                                                                               [](const auto& operand) -> std::size_t
+                                                                               {
+                                                                                    return operand.Size();
+                                                                               }},
+                                                             instruction.destination))
+                                           : std::format("mov.{}", instruction.width);
+                                 built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
                                                                              {
                                                                                   return "?";
                                                                              },
@@ -69,37 +60,22 @@ std::string ecpps::codegen::ToString(const Instruction& instruction)
                                                                              {
                                                                                   return operand.ToString();
                                                                              }},
-                                                           instruction.source);
-                                return built;
-                           },
-                           [](const TakeAddressInstruction& instruction)
-                           {
-                                std::string built = "address-of";
-                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
-                                                                            {
-                                                                                 return "?";
-                                                                            },
-                                                                            [](const auto& operand) -> std::string
-                                                                            {
-                                                                                 return operand.ToString();
-                                                                            }},
-                                                          instruction.to);
-                                built += ", " + instruction.from.ToString();
-                                return built;
-                           },
-                           [](const AddInstruction& instruction)
-                           {
-                                std::string built = std::format("add.{}", instruction.width);
-                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
-                                                                            {
-                                                                                 return "?";
-                                                                            },
-                                                                            [](const auto& operand) -> std::string
-                                                                            {
-                                                                                 return operand.ToString();
-                                                                            }},
-                                                          instruction.to);
-                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                           instruction.destination);
+                                 built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                              {
+                                                                                   return "?";
+                                                                              },
+                                                                              [](const auto& operand) -> std::string
+                                                                              {
+                                                                                   return operand.ToString();
+                                                                              }},
+                                                            instruction.source);
+                                 return built;
+                            },
+                            [](const TakeAddressInstruction& instruction)
+                            {
+                                 std::string built = "address-of";
+                                 built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
                                                                              {
                                                                                   return "?";
                                                                              },
@@ -107,22 +83,14 @@ std::string ecpps::codegen::ToString(const Instruction& instruction)
                                                                              {
                                                                                   return operand.ToString();
                                                                              }},
-                                                           instruction.from);
-                                return built;
-                           },
-                           [](const SubInstruction& instruction)
-                           {
-                                std::string built = std::format("sub.{}", instruction.width);
-                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
-                                                                            {
-                                                                                 return "?";
-                                                                            },
-                                                                            [](const auto& operand) -> std::string
-                                                                            {
-                                                                                 return operand.ToString();
-                                                                            }},
-                                                          instruction.to);
-                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                           instruction.to);
+                                 built += ", " + instruction.from.ToString();
+                                 return built;
+                            },
+                            [](const AddInstruction& instruction)
+                            {
+                                 std::string built = std::format("add.{}", instruction.width);
+                                 built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
                                                                              {
                                                                                   return "?";
                                                                              },
@@ -130,23 +98,22 @@ std::string ecpps::codegen::ToString(const Instruction& instruction)
                                                                              {
                                                                                   return operand.ToString();
                                                                              }},
-                                                           instruction.from);
-                                return built;
-                           },
-                           [](const MulInstruction& instruction)
-                           {
-                                std::string built = instruction.isSigned ? std::format("imul.{}", instruction.width)
-                                                                         : std::format("mul.{}", instruction.width);
-                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
-                                                                            {
-                                                                                 return "?";
-                                                                            },
-                                                                            [](const auto& operand) -> std::string
-                                                                            {
-                                                                                 return operand.ToString();
-                                                                            }},
-                                                          instruction.to);
-                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                           instruction.to);
+                                 built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                              {
+                                                                                   return "?";
+                                                                              },
+                                                                              [](const auto& operand) -> std::string
+                                                                              {
+                                                                                   return operand.ToString();
+                                                                              }},
+                                                            instruction.from);
+                                 return built;
+                            },
+                            [](const SubInstruction& instruction)
+                            {
+                                 std::string built = std::format("sub.{}", instruction.width);
+                                 built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
                                                                              {
                                                                                   return "?";
                                                                              },
@@ -154,23 +121,23 @@ std::string ecpps::codegen::ToString(const Instruction& instruction)
                                                                              {
                                                                                   return operand.ToString();
                                                                              }},
-                                                           instruction.from);
-                                return built;
-                           },
-                           [](const DivInstruction& instruction)
-                           {
-                                std::string built = instruction.isSigned ? std::format("idiv.{}", instruction.width)
-                                                                         : std::format("div.{}", instruction.width);
-                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
-                                                                            {
-                                                                                 return "?";
-                                                                            },
-                                                                            [](const auto& operand) -> std::string
-                                                                            {
-                                                                                 return operand.ToString();
-                                                                            }},
-                                                          instruction.to);
-                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                           instruction.to);
+                                 built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                              {
+                                                                                   return "?";
+                                                                              },
+                                                                              [](const auto& operand) -> std::string
+                                                                              {
+                                                                                   return operand.ToString();
+                                                                              }},
+                                                            instruction.from);
+                                 return built;
+                            },
+                            [](const MulInstruction& instruction)
+                            {
+                                 std::string built = instruction.isSigned ? std::format("imul.{}", instruction.width)
+                                                                          : std::format("mul.{}", instruction.width);
+                                 built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
                                                                              {
                                                                                   return "?";
                                                                              },
@@ -178,18 +145,51 @@ std::string ecpps::codegen::ToString(const Instruction& instruction)
                                                                              {
                                                                                   return operand.ToString();
                                                                              }},
-                                                           instruction.from);
-                                return built;
-                           },
-                           [](const CallInstruction& instruction)
-                           {
-                                return "call " + instruction.functionName;
-                           },
-                           [](const ReturnInstruction&) -> std::string
-                           {
-                                return "ret";
-                           }},
-         instruction);
+                                                           instruction.to);
+                                 built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                              {
+                                                                                   return "?";
+                                                                              },
+                                                                              [](const auto& operand) -> std::string
+                                                                              {
+                                                                                   return operand.ToString();
+                                                                              }},
+                                                            instruction.from);
+                                 return built;
+                            },
+                            [](const DivInstruction& instruction)
+                            {
+                                 std::string built = instruction.isSigned ? std::format("idiv.{}", instruction.width)
+                                                                          : std::format("div.{}", instruction.width);
+                                 built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                             {
+                                                                                  return "?";
+                                                                             },
+                                                                             [](const auto& operand) -> std::string
+                                                                             {
+                                                                                  return operand.ToString();
+                                                                             }},
+                                                           instruction.to);
+                                 built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                              {
+                                                                                   return "?";
+                                                                              },
+                                                                              [](const auto& operand) -> std::string
+                                                                              {
+                                                                                   return operand.ToString();
+                                                                              }},
+                                                            instruction.from);
+                                 return built;
+                            },
+                            [](const CallInstruction& instruction)
+                            {
+                                 return "call " + instruction.functionName;
+                            },
+                            [](const ReturnInstruction&) -> std::string
+                            {
+                                 return "ret";
+                            }},
+          instruction);
 }
 
 std::string ecpps::codegen::Routine::GenerateName(void)

--- a/compiler/ecpps/src/CodeGeneration/Nodes.cpp
+++ b/compiler/ecpps/src/CodeGeneration/Nodes.cpp
@@ -4,9 +4,15 @@
 #include <variant>
 #include "../Parsing/Tokeniser.h"
 
-std::string ecpps::codegen::RegisterOperand::ToString(void) const { return this->_index->friendlyName; }
+std::string ecpps::codegen::RegisterOperand::ToString(void) const
+{
+     return this->_index->friendlyName;
+}
 
-std::string ecpps::codegen::IntegerOperand::ToString(void) const { return std::format("0x{:x}", this->_value); }
+std::string ecpps::codegen::IntegerOperand::ToString(void) const
+{
+     return std::format("0x{:x}", this->_value);
+}
 
 std::string ecpps::codegen::MemoryLocationOperand::ToString(void) const
 {
@@ -21,97 +27,168 @@ ecpps::codegen::IntegerRangeOperand::IntegerRangeOperand(std::vector<unsigned ch
 std::string ecpps::codegen::ToString(const Instruction& instruction)
 {
      return std::visit(
-         OverloadedVisitor{
-             [](const MovInstruction& instruction)
-             {
-                  std::string built =
-                      instruction.isConversion
-                          ? std::format("mov.{}-{}",
-                                        std::visit(OverloadedVisitor{[](std::monostate) -> std::size_t { return 0; },
-                                                                     [](const auto& operand) -> std::size_t
-                                                                     { return operand.Size(); }},
-                                                   instruction.source),
-                                        std::visit(OverloadedVisitor{[](std::monostate) -> std::size_t { return 0; },
-                                                                     [](const auto& operand) -> std::size_t
-                                                                     { return operand.Size(); }},
-                                                   instruction.destination))
-                          : std::format("mov.{}", instruction.width);
-                  built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                              [](const auto& operand) -> std::string
-                                                              { return operand.ToString(); }},
-                                            instruction.destination);
-                  built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                               [](const auto& operand) -> std::string
-                                                               { return operand.ToString(); }},
-                                             instruction.source);
-                  return built;
-             },
-             [](const TakeAddressInstruction& instruction)
-             {
-                  std::string built = "address-of";
-                  built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                              [](const auto& operand) -> std::string
-                                                              { return operand.ToString(); }},
-                                            instruction.to);
-                  built += ", " + instruction.from.ToString();
-                  return built;
-             },
-             [](const AddInstruction& instruction)
-             {
-                  std::string built = std::format("add.{}", instruction.width);
-                  built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                              [](const auto& operand) -> std::string
-                                                              { return operand.ToString(); }},
-                                            instruction.to);
-                  built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                               [](const auto& operand) -> std::string
-                                                               { return operand.ToString(); }},
-                                             instruction.from);
-                  return built;
-             },
-             [](const SubInstruction& instruction)
-             {
-                  std::string built = std::format("sub.{}", instruction.width);
-                  built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                              [](const auto& operand) -> std::string
-                                                              { return operand.ToString(); }},
-                                            instruction.to);
-                  built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                               [](const auto& operand) -> std::string
-                                                               { return operand.ToString(); }},
-                                             instruction.from);
-                  return built;
-             },
-             [](const MulInstruction& instruction)
-             {
-                  std::string built = instruction.isSigned ? std::format("imul.{}", instruction.width)
-                                                           : std::format("mul.{}", instruction.width);
-                  built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                              [](const auto& operand) -> std::string
-                                                              { return operand.ToString(); }},
-                                            instruction.to);
-                  built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                               [](const auto& operand) -> std::string
-                                                               { return operand.ToString(); }},
-                                             instruction.from);
-                  return built;
-             },
-             [](const DivInstruction& instruction)
-             {
-                  std::string built = instruction.isSigned ? std::format("idiv.{}", instruction.width)
-                                                           : std::format("div.{}", instruction.width);
-                  built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                              [](const auto& operand) -> std::string
-                                                              { return operand.ToString(); }},
-                                            instruction.to);
-                  built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string { return "?"; },
-                                                               [](const auto& operand) -> std::string
-                                                               { return operand.ToString(); }},
-                                             instruction.from);
-                  return built;
-             },
-             [](const CallInstruction& instruction) { return "call " + instruction.functionName; },
-             [](const ReturnInstruction&) -> std::string { return "ret"; }},
+         OverloadedVisitor{[](const MovInstruction& instruction)
+                           {
+                                std::string built =
+                                    instruction.isConversion
+                                        ? std::format(
+                                              "mov.{}-{}",
+                                              std::visit(OverloadedVisitor{[](std::monostate) -> std::size_t
+                                                                           {
+                                                                                return 0;
+                                                                           },
+                                                                           [](const auto& operand) -> std::size_t
+                                                                           {
+                                                                                return operand.Size();
+                                                                           }},
+                                                         instruction.source),
+                                              std::visit(OverloadedVisitor{[](std::monostate) -> std::size_t
+                                                                           {
+                                                                                return 0;
+                                                                           },
+                                                                           [](const auto& operand) -> std::size_t
+                                                                           {
+                                                                                return operand.Size();
+                                                                           }},
+                                                         instruction.destination))
+                                        : std::format("mov.{}", instruction.width);
+                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                            {
+                                                                                 return "?";
+                                                                            },
+                                                                            [](const auto& operand) -> std::string
+                                                                            {
+                                                                                 return operand.ToString();
+                                                                            }},
+                                                          instruction.destination);
+                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                             {
+                                                                                  return "?";
+                                                                             },
+                                                                             [](const auto& operand) -> std::string
+                                                                             {
+                                                                                  return operand.ToString();
+                                                                             }},
+                                                           instruction.source);
+                                return built;
+                           },
+                           [](const TakeAddressInstruction& instruction)
+                           {
+                                std::string built = "address-of";
+                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                            {
+                                                                                 return "?";
+                                                                            },
+                                                                            [](const auto& operand) -> std::string
+                                                                            {
+                                                                                 return operand.ToString();
+                                                                            }},
+                                                          instruction.to);
+                                built += ", " + instruction.from.ToString();
+                                return built;
+                           },
+                           [](const AddInstruction& instruction)
+                           {
+                                std::string built = std::format("add.{}", instruction.width);
+                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                            {
+                                                                                 return "?";
+                                                                            },
+                                                                            [](const auto& operand) -> std::string
+                                                                            {
+                                                                                 return operand.ToString();
+                                                                            }},
+                                                          instruction.to);
+                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                             {
+                                                                                  return "?";
+                                                                             },
+                                                                             [](const auto& operand) -> std::string
+                                                                             {
+                                                                                  return operand.ToString();
+                                                                             }},
+                                                           instruction.from);
+                                return built;
+                           },
+                           [](const SubInstruction& instruction)
+                           {
+                                std::string built = std::format("sub.{}", instruction.width);
+                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                            {
+                                                                                 return "?";
+                                                                            },
+                                                                            [](const auto& operand) -> std::string
+                                                                            {
+                                                                                 return operand.ToString();
+                                                                            }},
+                                                          instruction.to);
+                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                             {
+                                                                                  return "?";
+                                                                             },
+                                                                             [](const auto& operand) -> std::string
+                                                                             {
+                                                                                  return operand.ToString();
+                                                                             }},
+                                                           instruction.from);
+                                return built;
+                           },
+                           [](const MulInstruction& instruction)
+                           {
+                                std::string built = instruction.isSigned ? std::format("imul.{}", instruction.width)
+                                                                         : std::format("mul.{}", instruction.width);
+                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                            {
+                                                                                 return "?";
+                                                                            },
+                                                                            [](const auto& operand) -> std::string
+                                                                            {
+                                                                                 return operand.ToString();
+                                                                            }},
+                                                          instruction.to);
+                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                             {
+                                                                                  return "?";
+                                                                             },
+                                                                             [](const auto& operand) -> std::string
+                                                                             {
+                                                                                  return operand.ToString();
+                                                                             }},
+                                                           instruction.from);
+                                return built;
+                           },
+                           [](const DivInstruction& instruction)
+                           {
+                                std::string built = instruction.isSigned ? std::format("idiv.{}", instruction.width)
+                                                                         : std::format("div.{}", instruction.width);
+                                built += " " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                            {
+                                                                                 return "?";
+                                                                            },
+                                                                            [](const auto& operand) -> std::string
+                                                                            {
+                                                                                 return operand.ToString();
+                                                                            }},
+                                                          instruction.to);
+                                built += ", " + std::visit(OverloadedVisitor{[](std::monostate) -> std::string
+                                                                             {
+                                                                                  return "?";
+                                                                             },
+                                                                             [](const auto& operand) -> std::string
+                                                                             {
+                                                                                  return operand.ToString();
+                                                                             }},
+                                                           instruction.from);
+                                return built;
+                           },
+                           [](const CallInstruction& instruction)
+                           {
+                                return "call " + instruction.functionName;
+                           },
+                           [](const ReturnInstruction&) -> std::string
+                           {
+                                return "ret";
+                           }},
          instruction);
 }
 

--- a/compiler/ecpps/src/CodeGeneration/Nodes.h
+++ b/compiler/ecpps/src/CodeGeneration/Nodes.h
@@ -334,9 +334,9 @@ namespace ecpps::codegen
      };
 
      using Instruction =
-         std::variant<MovInstruction, ReturnInstruction, AddInstruction, MulInstruction, DivInstruction,
-                      CallInstruction, TakeAddressInstruction,
-                      SubInstruction /*, PushInstruction, PopInstruction , std::unique_ptr<CustomInstruction>*/>;
+          std::variant<MovInstruction, ReturnInstruction, AddInstruction, MulInstruction, DivInstruction,
+                       CallInstruction, TakeAddressInstruction,
+                       SubInstruction /*, PushInstruction, PopInstruction , std::unique_ptr<CustomInstruction>*/>;
      [[nodiscard]] std::string ToString(const Instruction& instruction);
 
      struct Routine

--- a/compiler/ecpps/src/CodeGeneration/Nodes.h
+++ b/compiler/ecpps/src/CodeGeneration/Nodes.h
@@ -14,13 +14,18 @@ namespace ecpps::codegen
           /* static_assert(requires(const TOperand& operand) {
                 { operand.ToString() } -> std::same_as<std::string>;
            });*/
-          [[nodiscard]] std::size_t Size(void) const noexcept { return this->_size; }
+          [[nodiscard]] std::size_t Size(void) const noexcept
+          {
+               return this->_size;
+          }
 
      protected:
           std::size_t _size;
 
      private:
-          explicit OperandBase(const std::size_t width) : _size(width) {}
+          explicit OperandBase(const std::size_t width) : _size(width)
+          {
+          }
 
           friend TOperand;
      };
@@ -34,7 +39,10 @@ namespace ecpps::codegen
 
           [[nodiscard]] std::string ToString(void) const;
 
-          [[nodiscard]] const std::shared_ptr<abi::VirtualRegister>& Index(void) const noexcept { return this->_index; }
+          [[nodiscard]] const std::shared_ptr<abi::VirtualRegister>& Index(void) const noexcept
+          {
+               return this->_index;
+          }
 
      private:
           std::shared_ptr<abi::VirtualRegister> _index;
@@ -47,7 +55,10 @@ namespace ecpps::codegen
           }
           [[nodiscard]] std::string ToString(void) const;
 
-          [[nodiscard]] std::size_t Value(void) const noexcept { return this->_value; }
+          [[nodiscard]] std::size_t Value(void) const noexcept
+          {
+               return this->_value;
+          }
 
      private:
           std::size_t _value;
@@ -62,8 +73,14 @@ namespace ecpps::codegen
           }
           [[nodiscard]] std::string ToString(void) const;
 
-          [[nodiscard]] const RegisterOperand& Register(void) const noexcept { return this->_register; }
-          [[nodiscard]] std::size_t Displacement(void) const noexcept { return this->_displacement; }
+          [[nodiscard]] const RegisterOperand& Register(void) const noexcept
+          {
+               return this->_register;
+          }
+          [[nodiscard]] std::size_t Displacement(void) const noexcept
+          {
+               return this->_displacement;
+          }
 
      private:
           RegisterOperand _register;
@@ -73,9 +90,15 @@ namespace ecpps::codegen
      struct IntegerRangeOperand : OperandBase<IntegerRangeOperand>
      {
           explicit IntegerRangeOperand(std::vector<unsigned char> values);
-          [[nodiscard]] std::string ToString(void) const { return std::format("{}", this->_values); }
+          [[nodiscard]] std::string ToString(void) const
+          {
+               return std::format("{}", this->_values);
+          }
 
-          [[nodiscard]] const std::vector<unsigned char>& Values(void) const noexcept { return this->_values; }
+          [[nodiscard]] const std::vector<unsigned char>& Values(void) const noexcept
+          {
+               return this->_values;
+          }
 
      private:
           std::vector<unsigned char> _values;
@@ -187,14 +210,18 @@ namespace ecpps::codegen
      {
           Operand source;
 
-          explicit PushInstruction(Operand source) : source(std::move(source)) {}
+          explicit PushInstruction(Operand source) : source(std::move(source))
+          {
+          }
      };
 
      struct PopInstruction
      {
           Operand destination;
 
-          explicit PopInstruction(Operand destination) : destination(std::move(destination)) {}
+          explicit PopInstruction(Operand destination) : destination(std::move(destination))
+          {
+          }
      };
 
      struct ReturnInstruction
@@ -205,7 +232,9 @@ namespace ecpps::codegen
      {
           std::string functionName;
 
-          explicit CallInstruction(std::string name) : functionName(std::move(name)) {}
+          explicit CallInstruction(std::string name) : functionName(std::move(name))
+          {
+          }
      };
 
      struct TakeAddressInstruction

--- a/compiler/ecpps/src/CodeGeneration/PseudoAssembly.cpp
+++ b/compiler/ecpps/src/CodeGeneration/PseudoAssembly.cpp
@@ -36,15 +36,15 @@ static void CopyRangeOperandIntoMemory(const ecpps::codegen::IntegerRangeOperand
                                        std::vector<Instruction>& code)
 {
      const auto AppendInteger =
-         [&code]<std::size_t NBytes>(const std::shared_ptr<ecpps::abi::VirtualRegister>& relativeTo,
-                                     std::size_t location, const std::size_t integer)
+          [&code]<std::size_t NBytes>(const std::shared_ptr<ecpps::abi::VirtualRegister>& relativeTo,
+                                      std::size_t location, const std::size_t integer)
      {
           constexpr auto width = NBytes * ecpps::typeSystem::CharWidth;
 
           code.emplace_back(ecpps::codegen::MovInstruction{
-              ecpps::codegen::IntegerOperand{integer, width},
-              ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{relativeTo}, location, width},
-              width});
+               ecpps::codegen::IntegerOperand{integer, width},
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{relativeTo}, location, width},
+               width});
      };
 
      auto& abi = ecpps::abi::ABI::Current();
@@ -56,8 +56,8 @@ static void CopyRangeOperandIntoMemory(const ecpps::codegen::IntegerRangeOperand
           while (!IsAligned(offset, 2) && std::distance(rangeIterator, range.Values().end()) >= 1)
           {
                const auto value =
-                   abi.ConvertEndian<1, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                         // modernize-avoid-c-arrays)
+                    abi.ConvertEndian<1, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                          // modernize-avoid-c-arrays)
                AppendInteger.template operator()<1>(reg, offset, value);
                ++rangeIterator;
                offset++;
@@ -65,8 +65,8 @@ static void CopyRangeOperandIntoMemory(const ecpps::codegen::IntegerRangeOperand
           while (!IsAligned(offset, 4) && std::distance(rangeIterator, range.Values().end()) >= 2)
           {
                const auto value =
-                   abi.ConvertEndian<2, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                         // modernize-avoid-c-arrays)
+                    abi.ConvertEndian<2, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                          // modernize-avoid-c-arrays)
                AppendInteger.template operator()<2>(reg, offset, value);
                rangeIterator += 2;
                offset += 2;
@@ -74,8 +74,8 @@ static void CopyRangeOperandIntoMemory(const ecpps::codegen::IntegerRangeOperand
           while (!IsAligned(offset, 8) && std::distance(rangeIterator, range.Values().end()) >= 4)
           {
                const auto value =
-                   abi.ConvertEndian<4, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                         // modernize-avoid-c-arrays)
+                    abi.ConvertEndian<4, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                          // modernize-avoid-c-arrays)
                AppendInteger.template operator()<4>(reg, offset, value);
                rangeIterator += 4;
                offset += 4;
@@ -84,8 +84,8 @@ static void CopyRangeOperandIntoMemory(const ecpps::codegen::IntegerRangeOperand
           while (std::distance(rangeIterator, range.Values().end()) >= 8)
           {
                const auto value =
-                   abi.ConvertEndian<8, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                         // modernize-avoid-c-arrays)
+                    abi.ConvertEndian<8, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                          // modernize-avoid-c-arrays)
                AppendInteger.template operator()<8>(reg, offset, value);
                rangeIterator += 8;
                offset += 8;
@@ -94,8 +94,8 @@ static void CopyRangeOperandIntoMemory(const ecpps::codegen::IntegerRangeOperand
           while (std::distance(rangeIterator, range.Values().end()) >= 4)
           {
                const auto value =
-                   abi.ConvertEndian<4, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                         // modernize-avoid-c-arrays)
+                    abi.ConvertEndian<4, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                          // modernize-avoid-c-arrays)
                AppendInteger.template operator()<4>(reg, offset, value);
                rangeIterator += 4;
                offset += 4;
@@ -104,8 +104,8 @@ static void CopyRangeOperandIntoMemory(const ecpps::codegen::IntegerRangeOperand
           while (std::distance(rangeIterator, range.Values().end()) >= 2)
           {
                const auto value =
-                   abi.ConvertEndian<2, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                         // modernize-avoid-c-arrays)
+                    abi.ConvertEndian<2, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                          // modernize-avoid-c-arrays)
                AppendInteger.template operator()<2>(reg, offset, value);
                rangeIterator += 2;
                offset += 2;
@@ -114,8 +114,8 @@ static void CopyRangeOperandIntoMemory(const ecpps::codegen::IntegerRangeOperand
           while (std::distance(rangeIterator, range.Values().end()) >= 1)
           {
                const auto value =
-                   abi.ConvertEndian<1, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                         // modernize-avoid-c-arrays)
+                    abi.ConvertEndian<1, unsigned char[]>(rangeIterator); // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                          // modernize-avoid-c-arrays)
                AppendInteger.template operator()<1>(reg, offset, value);
                ++rangeIterator;
                offset++;
@@ -141,82 +141,82 @@ static std::vector<unsigned char> SerialiseByteArray(const std::vector<std::uint
           case 1:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 1>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 2:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 2>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 3:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 3>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 4:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 4>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 5:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 5>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 6:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 6>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 7:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 7>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 8:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 8>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 9:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 9>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                          // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 10:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 10>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                           // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 11:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 11>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                           // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 12:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 12>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                           // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 13:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 13>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                           // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 14:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 14>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                           // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 15:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 15>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                           // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 16:
                bytes.append_range(abi.ConvertEndian<unsigned char[], 16>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                           // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           default: throw TracedException("Invalid size");
           }
@@ -240,82 +240,82 @@ static std::vector<char8_t> SerialiseByteArrayChar(const std::vector<std::uint32
           case 1:
                bytes.append_range(abi.ConvertEndian<char8_t[], 1>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 2:
                bytes.append_range(abi.ConvertEndian<char8_t[], 2>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 3:
                bytes.append_range(abi.ConvertEndian<char8_t[], 3>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 4:
                bytes.append_range(abi.ConvertEndian<char8_t[], 4>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 5:
                bytes.append_range(abi.ConvertEndian<char8_t[], 5>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 6:
                bytes.append_range(abi.ConvertEndian<char8_t[], 6>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 7:
                bytes.append_range(abi.ConvertEndian<char8_t[], 7>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 8:
                bytes.append_range(abi.ConvertEndian<char8_t[], 8>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 9:
                bytes.append_range(abi.ConvertEndian<char8_t[], 9>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                    // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 10:
                bytes.append_range(abi.ConvertEndian<char8_t[], 10>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                     // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 11:
                bytes.append_range(abi.ConvertEndian<char8_t[], 11>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                     // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 12:
                bytes.append_range(abi.ConvertEndian<char8_t[], 12>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                     // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 13:
                bytes.append_range(abi.ConvertEndian<char8_t[], 13>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                     // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 14:
                bytes.append_range(abi.ConvertEndian<char8_t[], 14>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                     // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 15:
                bytes.append_range(abi.ConvertEndian<char8_t[], 15>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                     // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           case 16:
                bytes.append_range(abi.ConvertEndian<char8_t[], 16>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                     // modernize-avoid-c-arrays)
-                   value));
+                    value));
                break;
           default: throw TracedException("Invalid size");
           }
@@ -358,18 +358,19 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           }
 
           auto destinationStorage =
-              std::holds_alternative<ecpps::codegen::RegisterOperand>(left)
-                  ? ecpps::abi::ABI::Current().AllocateRegister(std::get<ecpps::codegen::RegisterOperand>(left).Index(),
-                                                                ecpps::abi::RegisterAllocation::Priority)
-                  : ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
+               std::holds_alternative<ecpps::codegen::RegisterOperand>(left)
+                    ? ecpps::abi::ABI::Current().AllocateRegister(
+                           std::get<ecpps::codegen::RegisterOperand>(left).Index(),
+                           ecpps::abi::RegisterAllocation::Priority)
+                    : ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
 
           std::vector<Instruction> codeBuffer{};
           const auto right = ParseExpression(context, codeBuffer, addition->Right());
           if (std::holds_alternative<ecpps::codegen::RegisterOperand>(right) &&
               *std::get<ecpps::codegen::RegisterOperand>(right).Index()->physical ==
-                  *destinationStorage.Ptr()->physical)
+                   *destinationStorage.Ptr()->physical)
                destinationStorage =
-                   ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
+                    ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
 
           if (std::holds_alternative<ecpps::codegen::ErrorOperand>(left) ||
               std::holds_alternative<ecpps::codegen::ErrorOperand>(right))
@@ -378,12 +379,12 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           if (!std::holds_alternative<ecpps::codegen::RegisterOperand>(left) ||
               *std::get<ecpps::codegen::RegisterOperand>(left).Index()->physical != *destinationStorage->physical)
                code.emplace_back(ecpps::codegen::MovInstruction{
-                   left, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}, destinationStorage->width});
+                    left, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}, destinationStorage->width});
 
           code.append_range(codeBuffer);
 
           code.emplace_back(ecpps::codegen::AddInstruction{
-              right, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}, destinationStorage->width});
+               right, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}, destinationStorage->width});
 
           return ecpps::codegen::RegisterOperand{destinationStorage.Ptr()};
      }
@@ -405,7 +406,7 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           code.append_range(codeBuffer);
 
           code.emplace_back(ecpps::codegen::AddInstruction{
-              right, destinationStorage, addition->Right()->Type()->Size() * ecpps::typeSystem::CharWidth});
+               right, destinationStorage, addition->Right()->Type()->Size() * ecpps::typeSystem::CharWidth});
 
           return destinationStorage; // NOLINT(clang-diagnostic-nrvo)
      }
@@ -427,7 +428,7 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           code.append_range(codeBuffer);
 
           code.emplace_back(ecpps::codegen::SubInstruction{
-              right, destinationStorage, subtraction->Right()->Type()->Size() * ecpps::typeSystem::CharWidth});
+               right, destinationStorage, subtraction->Right()->Type()->Size() * ecpps::typeSystem::CharWidth});
 
           return destinationStorage; // NOLINT(clang-diagnostic-nrvo)
      }
@@ -452,10 +453,11 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           }
 
           auto destinationStorage =
-              std::holds_alternative<ecpps::codegen::RegisterOperand>(left)
-                  ? ecpps::abi::ABI::Current().AllocateRegister(std::get<ecpps::codegen::RegisterOperand>(left).Index(),
-                                                                ecpps::abi::RegisterAllocation::Priority)
-                  : ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
+               std::holds_alternative<ecpps::codegen::RegisterOperand>(left)
+                    ? ecpps::abi::ABI::Current().AllocateRegister(
+                           std::get<ecpps::codegen::RegisterOperand>(left).Index(),
+                           ecpps::abi::RegisterAllocation::Priority)
+                    : ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
 
           const auto right = ParseExpression(context, code, subtraction->Right());
 
@@ -465,9 +467,9 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
 
           if (!std::holds_alternative<ecpps::codegen::RegisterOperand>(left))
                code.emplace_back(ecpps::codegen::MovInstruction{
-                   left, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}, destinationStorage->width});
+                    left, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}, destinationStorage->width});
           code.emplace_back(ecpps::codegen::SubInstruction{
-              right, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}, destinationStorage->width});
+               right, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}, destinationStorage->width});
 
           return ecpps::codegen::RegisterOperand{destinationStorage.Ptr()};
      }
@@ -494,11 +496,11 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
 
           const auto left = ParseExpression(context, code, multiplication->Left());
 
-          auto storage =
-              std::holds_alternative<ecpps::codegen::RegisterOperand>(left)
-                  ? ecpps::abi::ABI::Current().AllocateRegister(std::get<ecpps::codegen::RegisterOperand>(left).Index(),
-                                                                ecpps::abi::RegisterAllocation::Priority)
-                  : ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
+          auto storage = std::holds_alternative<ecpps::codegen::RegisterOperand>(left)
+                              ? ecpps::abi::ABI::Current().AllocateRegister(
+                                     std::get<ecpps::codegen::RegisterOperand>(left).Index(),
+                                     ecpps::abi::RegisterAllocation::Priority)
+                              : ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
 
           const auto right = ParseExpression(context, code, multiplication->Right());
 
@@ -535,11 +537,11 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
 
           const auto left = ParseExpression(context, code, div->Left());
 
-          auto storage =
-              std::holds_alternative<ecpps::codegen::RegisterOperand>(left)
-                  ? ecpps::abi::ABI::Current().AllocateRegister(std::get<ecpps::codegen::RegisterOperand>(left).Index(),
-                                                                ecpps::abi::RegisterAllocation::Priority)
-                  : ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
+          auto storage = std::holds_alternative<ecpps::codegen::RegisterOperand>(left)
+                              ? ecpps::abi::ABI::Current().AllocateRegister(
+                                     std::get<ecpps::codegen::RegisterOperand>(left).Index(),
+                                     ecpps::abi::RegisterAllocation::Priority)
+                              : ecpps::abi::ABI::Current().AllocateRegister(ecpps::typeSystem::CharWidth * sizeInBytes);
 
           const auto right = ParseExpression(context, code, div->Right());
 
@@ -561,15 +563,15 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
 
           auto& currentAbi = ecpps::abi::ABI::Current();
           const std::string functionName = ecpps::abi::ABI::MangleName(
-              function.linkage, function.Name().value_or("__unknown"), function.callingConvention, function.returnType,
-              function.parameters |
-                  std::views::transform(
-                      [](const ecpps::ir::FunctionScope::Parameter& parameter)
-                      {
-                           return parameter.type;
-                      }) |
-                  std::ranges::to<std::vector>(),
-              function.namespacePath);
+               function.linkage, function.Name().value_or("__unknown"), function.callingConvention, function.returnType,
+               function.parameters |
+                    std::views::transform(
+                         [](const ecpps::ir::FunctionScope::Parameter& parameter)
+                         {
+                              return parameter.type;
+                         }) |
+                    std::ranges::to<std::vector>(),
+               function.namespacePath);
           auto& callingConvention = currentAbi.CallingConventionFromName(function.callingConvention);
 
           runtime_assert(function.parameters.size() == call->Arguments().size(),
@@ -580,10 +582,10 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           const auto returnTypeSize = callingConvention.GetRequirementsForType(function.returnType);
           const auto parameterSizes = function.parameters |
                                       std::views::transform(
-                                          [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                          {
-                                               return callingConvention.GetRequirementsForType(parameter.type);
-                                          }) |
+                                           [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
+                                           {
+                                                return callingConvention.GetRequirementsForType(parameter.type);
+                                           }) |
                                       std::ranges::to<std::vector>();
 
           const auto argumentStorage = callingConvention.LocateParameters(returnTypeSize, parameterSizes);
@@ -602,26 +604,26 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
                if (std::holds_alternative<ecpps::abi::AllocatedRegister>(storage.value))
                {
                     destination =
-                        ecpps::codegen::RegisterOperand{std::get<ecpps::abi::AllocatedRegister>(storage.value).Ptr()};
+                         ecpps::codegen::RegisterOperand{std::get<ecpps::abi::AllocatedRegister>(storage.value).Ptr()};
                }
                else if (std::holds_alternative<ecpps::abi::MemoryLocation>(storage.value))
                {
                     const auto& memLoc = std::get<ecpps::abi::MemoryLocation>(storage.value);
                     destination = ecpps::codegen::MemoryLocationOperand{
-                        ecpps::codegen::RegisterOperand{memLoc.reg}, memLoc.offset, parameter.type->Size() * CHAR_BIT};
+                         ecpps::codegen::RegisterOperand{memLoc.reg}, memLoc.offset, parameter.type->Size() * CHAR_BIT};
                }
                else
                     throw TracedException("Invalid parameter storage type in function call");
 
                code.emplace_back(
-                   ecpps::codegen::MovInstruction{operand, destination, parameter.type->Size() * CHAR_BIT});
+                    ecpps::codegen::MovInstruction{operand, destination, parameter.type->Size() * CHAR_BIT});
           }
 
           if (function.isDllImportExport)
                ecpps::codegen::g_functionImports[functionName] = function.dllImportName.empty() ? functionName
                                                                  : function.dllImportName.empty()
-                                                                     ? functionName
-                                                                     : function.dllImportName;
+                                                                      ? functionName
+                                                                      : function.dllImportName;
           code.emplace_back(ecpps::codegen::CallInstruction{functionName});
           callAbi->Finish(code);
 
@@ -629,7 +631,7 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           if (std::holds_alternative<std::monostate>(returnStorage.value))
                return ecpps::codegen::Operand{std::monostate{}};
           return ecpps::codegen::Operand{
-              ecpps::codegen::RegisterOperand{std::get<ecpps::abi::AllocatedRegister>(returnStorage.value).Ptr()}};
+               ecpps::codegen::RegisterOperand{std::get<ecpps::abi::AllocatedRegister>(returnStorage.value).Ptr()}};
      }
      if (auto* const load = dynamic_cast<ecpps::ir::LoadNode*>(value.get()); load != nullptr)
      {
@@ -643,7 +645,7 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           const auto width = storageRequest.size * ecpps::typeSystem::CharWidth;
 
           return ecpps::codegen::Operand{ecpps::codegen::MemoryLocationOperand{
-              ecpps::codegen::RegisterOperand{memoryLocation.reg}, memoryLocation.offset, width}};
+               ecpps::codegen::RegisterOperand{memoryLocation.reg}, memoryLocation.offset, width}};
      }
      if (auto* const addressOf = dynamic_cast<ecpps::ir::AddressOfNode*>(value.get()); addressOf != nullptr)
      {
@@ -663,9 +665,9 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           const auto resultReg = abi.AllocateRegister(abi.PointerSize() * ecpps::typeSystem::CharWidth);
 
           code.emplace_back(ecpps::codegen::TakeAddressInstruction{
-              ecpps::codegen::MemoryLocationOperand{mem.Register(), mem.Displacement(),
-                                                    abi.PointerSize() * ecpps::typeSystem::CharWidth},
-              ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{resultReg.Ptr()}}});
+               ecpps::codegen::MemoryLocationOperand{mem.Register(), mem.Displacement(),
+                                                     abi.PointerSize() * ecpps::typeSystem::CharWidth},
+               ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{resultReg.Ptr()}}});
 
           return ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{resultReg.Ptr()}};
      }
@@ -683,20 +685,20 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
                const auto& mem = std::get<ecpps::codegen::MemoryLocationOperand>(operandToPerformIndirectionOn);
 
                code.emplace_back(ecpps::codegen::MovInstruction{
-                   ecpps::codegen::MemoryLocationOperand{mem.Register(), mem.Displacement(),
-                                                         abi.PointerSize() * ecpps::typeSystem::CharWidth},
-                   ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{tmpReg.Ptr()}},
-                   abi.PointerSize() * ecpps::typeSystem::CharWidth});
+                    ecpps::codegen::MemoryLocationOperand{mem.Register(), mem.Displacement(),
+                                                          abi.PointerSize() * ecpps::typeSystem::CharWidth},
+                    ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{tmpReg.Ptr()}},
+                    abi.PointerSize() * ecpps::typeSystem::CharWidth});
                return ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{tmpReg.Ptr()}, 0,
                                                             pointerType->BaseType()->Size() *
-                                                                ecpps::typeSystem::CharWidth};
+                                                                 ecpps::typeSystem::CharWidth};
           }
 
           if (std::holds_alternative<ecpps::codegen::RegisterOperand>(operandToPerformIndirectionOn))
           {
                return ecpps::codegen::MemoryLocationOperand{
-                   std::get<ecpps::codegen::RegisterOperand>(operandToPerformIndirectionOn), 0,
-                   pointerType->BaseType()->Size() * ecpps::typeSystem::CharWidth};
+                    std::get<ecpps::codegen::RegisterOperand>(operandToPerformIndirectionOn), 0,
+                    pointerType->BaseType()->Size() * ecpps::typeSystem::CharWidth};
           }
 
           throw TracedException("Invalid operand for the address-of instruction");
@@ -724,7 +726,7 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           {
                ecpps::codegen::MovInstruction movInstruction{inner, ecpps::codegen::RegisterOperand{storage.Ptr()},
                                                              convert->Operand()->Type()->Size() *
-                                                                 ecpps::typeSystem::CharWidth};
+                                                                  ecpps::typeSystem::CharWidth};
                movInstruction.isConversion = true;
                code.emplace_back(std::move(movInstruction));
           }
@@ -732,7 +734,7 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           {
                ecpps::codegen::MovInstruction movInstruction{inner, ecpps::codegen::RegisterOperand{storage.Ptr()},
                                                              convert->Operand()->Type()->Size() *
-                                                                 ecpps::typeSystem::CharWidth};
+                                                                  ecpps::typeSystem::CharWidth};
                movInstruction.isConversion = true;
                code.emplace_back(std::move(movInstruction));
           }
@@ -746,22 +748,23 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           const auto left = ParseExpression(context, code, postIncrement->Operand());
 
           auto destinationStorage = ecpps::abi::ABI::Current().AllocateRegister(
-              postIncrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth);
+               postIncrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth);
 
           std::vector<Instruction> codeBuffer{};
-          const auto right = ecpps::codegen::IntegerOperand{
-              postIncrement->IncrementValue(), postIncrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth};
+          const auto right =
+               ecpps::codegen::IntegerOperand{postIncrement->IncrementValue(),
+                                              postIncrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth};
 
           if (std::holds_alternative<ecpps::codegen::ErrorOperand>(left)) return ecpps::codegen::ErrorOperand{};
 
           code.append_range(codeBuffer);
 
           code.emplace_back(
-              ecpps::codegen::MovInstruction{left, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()},
-                                             postIncrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth});
+               ecpps::codegen::MovInstruction{left, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()},
+                                              postIncrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth});
 
           code.emplace_back(ecpps::codegen::AddInstruction{
-              right, left, postIncrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth});
+               right, left, postIncrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth});
 
           return ecpps::codegen::RegisterOperand{destinationStorage.Ptr()};
      }
@@ -772,22 +775,23 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           const auto left = ParseExpression(context, code, postDecrement->Operand());
 
           auto destinationStorage = ecpps::abi::ABI::Current().AllocateRegister(
-              postDecrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth);
+               postDecrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth);
 
           std::vector<Instruction> codeBuffer{};
-          const auto right = ecpps::codegen::IntegerOperand{
-              postDecrement->IncrementValue(), postDecrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth};
+          const auto right =
+               ecpps::codegen::IntegerOperand{postDecrement->IncrementValue(),
+                                              postDecrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth};
 
           if (std::holds_alternative<ecpps::codegen::ErrorOperand>(left)) return ecpps::codegen::ErrorOperand{};
 
           code.append_range(codeBuffer);
 
           code.emplace_back(
-              ecpps::codegen::MovInstruction{left, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()},
-                                             postDecrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth});
+               ecpps::codegen::MovInstruction{left, ecpps::codegen::RegisterOperand{destinationStorage.Ptr()},
+                                              postDecrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth});
 
           code.emplace_back(ecpps::codegen::SubInstruction{
-              right, left, postDecrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth});
+               right, left, postDecrement->Operand()->Type()->Size() * ecpps::typeSystem::CharWidth});
 
           return ecpps::codegen::RegisterOperand{destinationStorage.Ptr()};
      }
@@ -808,9 +812,9 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           const auto instructionIndex = code.size();
 
           code.emplace_back(ecpps::codegen::TakeAddressInstruction{
-              ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{abi.StringRegister()},
-                                                    context.GetStringOffset(stringIndex), movWidth},
-              ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}});
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{abi.StringRegister()},
+                                                     context.GetStringOffset(stringIndex), movWidth},
+               ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}});
           context.AddStringPatch(static_cast<std::uint32_t>(instructionIndex), ecpps::InstructionPatchType::LeaFrom,
                                  stringIndex);
 
@@ -840,8 +844,8 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
                          "Invalid operand for lea");
 
           code.emplace_back(
-              ecpps::codegen::TakeAddressInstruction{std::get<ecpps::codegen::MemoryLocationOperand>(loaded),
-                                                     ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}});
+               ecpps::codegen::TakeAddressInstruction{std::get<ecpps::codegen::MemoryLocationOperand>(loaded),
+                                                      ecpps::codegen::RegisterOperand{destinationStorage.Ptr()}});
 
           return ecpps::codegen::RegisterOperand{destinationStorage.Ptr()};
      }
@@ -880,12 +884,12 @@ static void CompileReturn(ecpps::codegen::AssemblyContext& context, std::vector<
           // TODO: Mapping function
           ecpps::abi::MicrosoftX64CallingConvention callingConvention{};
           const auto returnStorage =
-              callingConvention.ReturnValueStorage(callingConvention.GetRequirementsForType(node.Value()->Type()));
+               callingConvention.ReturnValueStorage(callingConvention.GetRequirementsForType(node.Value()->Type()));
           code.emplace_back(
-              ecpps::codegen::MovInstruction{ParseExpression(context, code, node.Value()),
-                                             ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{
-                                                 std::get<ecpps::abi::AllocatedRegister>(returnStorage.value).Ptr()}},
-                                             node.Value()->Type()->Size() * ecpps::typeSystem::CharWidth});
+               ecpps::codegen::MovInstruction{ParseExpression(context, code, node.Value()),
+                                              ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{
+                                                   std::get<ecpps::abi::AllocatedRegister>(returnStorage.value).Ptr()}},
+                                              node.Value()->Type()->Size() * ecpps::typeSystem::CharWidth});
      }
 
      code.emplace_back(ecpps::codegen::ReturnInstruction{});
@@ -1012,20 +1016,20 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
           const auto returnTypeSize = callingConvention.GetRequirementsForType(function.returnType);
           const auto parameterSizes = function.parameters |
                                       std::views::transform(
-                                          [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                          {
-                                               return callingConvention.GetRequirementsForType(parameter.type);
-                                          }) |
+                                           [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
+                                           {
+                                                return callingConvention.GetRequirementsForType(parameter.type);
+                                           }) |
                                       std::ranges::to<std::vector>();
 
           const std::size_t callStackSpace =
-              callingConvention.CalculateArgumentStackSpace(returnTypeSize, parameterSizes);
+               callingConvention.CalculateArgumentStackSpace(returnTypeSize, parameterSizes);
           maxArgumentStackSpace = std::max(maxArgumentStackSpace, callStackSpace);
      }
      stackManager->ReserveCallArgumentSpace(maxArgumentStackSpace);
 
      std::unordered_map<std::string, std::pair<ecpps::abi::StorageRef, ecpps::abi::StorageRequirement>>& symbolTable =
-         context.symbolTables.emplace();
+          context.symbolTables.emplace();
 
      symbolTable.reserve(node.Locals().size());
      for (const auto& decl : node.Locals())
@@ -1038,29 +1042,29 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
           ecpps::abi::StorageRequirement request{type->Size(), type->Alignment(),
                                                  IsIntegral(type) ? ecpps::abi::RequiredStorageKind::Integer
                                                  : IsFloatingPoint(type)
-                                                     ? ecpps::abi::RequiredStorageKind::FloatingPoint
+                                                      ? ecpps::abi::RequiredStorageKind::FloatingPoint
                                                  : IsPointer(type) ? ecpps::abi::RequiredStorageKind::Pointer
                                                                    : ecpps::abi::RequiredStorageKind::Aggregate};
 
           auto storage = stackManager->ReserveStorage(request);
           symbolTable.emplace(
-              variableDecl.Name().value_or("__unknown_local_variable"),
-              std::pair<ecpps::abi::StorageRef, ecpps::abi::StorageRequirement>{std::move(storage), request});
+               variableDecl.Name().value_or("__unknown_local_variable"),
+               std::pair<ecpps::abi::StorageRef, ecpps::abi::StorageRequirement>{std::move(storage), request});
      }
 
      context.stackFrameAdjustment = stackManager->GetParameterAdjustment();
 
      context.functionParameters = parentCallingConvention.LocateParameters(
-         ecpps::abi::StorageRequirement{node.ReturnType()->Size(), node.ReturnType()->Alignment(),
-                                        ecpps::abi::RequiredStorageKind::Integer},
-         node.ParameterList() |
-             std::views::transform(
-                 [](const ecpps::ir::FunctionScope::Parameter& parameter)
-                 {
-                      return ecpps::abi::StorageRequirement{parameter.type->Size(), parameter.type->Alignment(),
-                                                            ecpps::abi::RequiredStorageKind::Integer};
-                 }) |
-             std::ranges::to<std::vector>());
+          ecpps::abi::StorageRequirement{node.ReturnType()->Size(), node.ReturnType()->Alignment(),
+                                         ecpps::abi::RequiredStorageKind::Integer},
+          node.ParameterList() |
+               std::views::transform(
+                    [](const ecpps::ir::FunctionScope::Parameter& parameter)
+                    {
+                         return ecpps::abi::StorageRequirement{parameter.type->Size(), parameter.type->Alignment(),
+                                                               ecpps::abi::RequiredStorageKind::Integer};
+                    }) |
+               std::ranges::to<std::vector>());
 
      for (const auto& line : node.Body())
      {
@@ -1071,26 +1075,26 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
                const auto& function = *call->Function();
 
                const std::string functionName =
-                   ecpps::abi::ABI::MangleName(function.linkage, function.Name().value_or("__unknown"),
-                                               function.callingConvention, function.returnType,
-                                               function.parameters |
-                                                   std::views::transform(
-                                                       [](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                                       {
-                                                            return parameter.type;
-                                                       }) |
-                                                   std::ranges::to<std::vector>(),
-                                               function.namespacePath);
+                    ecpps::abi::ABI::MangleName(function.linkage, function.Name().value_or("__unknown"),
+                                                function.callingConvention, function.returnType,
+                                                function.parameters |
+                                                     std::views::transform(
+                                                          [](const ecpps::ir::FunctionScope::Parameter& parameter)
+                                                          {
+                                                               return parameter.type;
+                                                          }) |
+                                                     std::ranges::to<std::vector>(),
+                                                function.namespacePath);
                const auto& callingConvention = currentAbi.CallingConventionFromName(function.callingConvention);
                const auto returnTypeSize = callingConvention.GetRequirementsForType(function.returnType);
                const auto parameterSizes =
-                   function.parameters |
-                   std::views::transform(
-                       [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
-                       {
-                            return callingConvention.GetRequirementsForType(parameter.type);
-                       }) |
-                   std::ranges::to<std::vector>();
+                    function.parameters |
+                    std::views::transform(
+                         [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
+                         {
+                              return callingConvention.GetRequirementsForType(parameter.type);
+                         }) |
+                    std::ranges::to<std::vector>();
 
                const auto argumentStorage = callingConvention.LocateParameters(returnTypeSize, parameterSizes);
                auto argumentIterator = call->Arguments().begin();
@@ -1108,25 +1112,25 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
                     if (std::holds_alternative<ecpps::abi::AllocatedRegister>(storage.value))
                     {
                          destination = ecpps::codegen::RegisterOperand{
-                             std::get<ecpps::abi::AllocatedRegister>(storage.value).Ptr()};
+                              std::get<ecpps::abi::AllocatedRegister>(storage.value).Ptr()};
                     }
                     else if (std::holds_alternative<ecpps::abi::MemoryLocation>(storage.value))
                     {
                          const auto& memLoc = std::get<ecpps::abi::MemoryLocation>(storage.value);
                          destination =
-                             ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{memLoc.reg},
-                                                                   memLoc.offset, parameter.type->Size() * CHAR_BIT};
+                              ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{memLoc.reg},
+                                                                    memLoc.offset, parameter.type->Size() * CHAR_BIT};
                     }
                     else
                          throw TracedException("Invalid parameter storage type in function call");
 
                     instructions.emplace_back(
-                        ecpps::codegen::MovInstruction{operand, destination, parameter.type->Size() * CHAR_BIT});
+                         ecpps::codegen::MovInstruction{operand, destination, parameter.type->Size() * CHAR_BIT});
                }
 
                if (function.isDllImportExport)
                     ecpps::codegen::g_functionImports[functionName] =
-                        function.dllImportName.empty() ? functionName : function.dllImportName;
+                         function.dllImportName.empty() ? functionName : function.dllImportName;
                instructions.emplace_back(ecpps::codegen::CallInstruction{functionName});
           }
           else if (const auto* const store = dynamic_cast<const ecpps::ir::StoreNode*>(line.get()); store != nullptr)
@@ -1139,8 +1143,8 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
                const auto initValue = ParseExpression(context, instructions, store->Value());
 
                const ecpps::codegen::Operand dest{
-                   ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{memoryLocation.reg},
-                                                         memoryLocation.offset, storageRequest.size * CHAR_BIT}};
+                    ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{memoryLocation.reg},
+                                                          memoryLocation.offset, storageRequest.size * CHAR_BIT}};
 
                if (std::holds_alternative<ecpps::codegen::IntegerRangeOperand>(initValue))
                {
@@ -1157,17 +1161,17 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
                          const auto tempReg = currentAbi.AllocateRegister(storageRequest.size * CHAR_BIT);
 
                          instructions.emplace_back(ecpps::codegen::MovInstruction{
-                             initValue, ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{tempReg.Ptr()}},
-                             storageRequest.size * CHAR_BIT});
+                              initValue, ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{tempReg.Ptr()}},
+                              storageRequest.size * CHAR_BIT});
 
                          instructions.emplace_back(ecpps::codegen::MovInstruction{
-                             ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{tempReg.Ptr()}}, dest,
-                             storageRequest.size * CHAR_BIT});
+                              ecpps::codegen::Operand{ecpps::codegen::RegisterOperand{tempReg.Ptr()}}, dest,
+                              storageRequest.size * CHAR_BIT});
                     }
                     else
                     {
                          instructions.emplace_back(
-                             ecpps::codegen::MovInstruction{initValue, dest, storageRequest.size * CHAR_BIT});
+                              ecpps::codegen::MovInstruction{initValue, dest, storageRequest.size * CHAR_BIT});
                     }
                }
           }
@@ -1189,7 +1193,7 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
                instructions.append_range(codeBuffer);
 
                instructions.emplace_back(ecpps::codegen::AddInstruction{
-                   right, destinationStorage, addition->Right()->Type()->Size() * ecpps::typeSystem::CharWidth});
+                    right, destinationStorage, addition->Right()->Type()->Size() * ecpps::typeSystem::CharWidth});
           }
      }
 
@@ -1197,16 +1201,16 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
      context.symbolTables.pop();
 
      return Routine::Branchless(
-         std::move(instructions),
-         ecpps::abi::ABI::MangleName(node.Linkage(), node.Name(), node.CallingConvention(), node.ReturnType(),
-                                     node.ParameterList() |
-                                         std::views::transform(
-                                             [](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                             {
-                                                  return parameter.type;
-                                             }) |
-                                         std::ranges::to<std::vector>(),
-                                     node.NamespacePath()));
+          std::move(instructions),
+          ecpps::abi::ABI::MangleName(node.Linkage(), node.Name(), node.CallingConvention(), node.ReturnType(),
+                                      node.ParameterList() |
+                                           std::views::transform(
+                                                [](const ecpps::ir::FunctionScope::Parameter& parameter)
+                                                {
+                                                     return parameter.type;
+                                                }) |
+                                           std::ranges::to<std::vector>(),
+                                      node.NamespacePath()));
 }
 
 void ecpps::codegen::Compile(CompilerConfig& config, SourceFile& source,

--- a/compiler/ecpps/src/CodeGeneration/PseudoAssembly.cpp
+++ b/compiler/ecpps/src/CodeGeneration/PseudoAssembly.cpp
@@ -563,8 +563,11 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           const std::string functionName = ecpps::abi::ABI::MangleName(
               function.linkage, function.Name().value_or("__unknown"), function.callingConvention, function.returnType,
               function.parameters |
-                  std::views::transform([](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                        { return parameter.type; }) |
+                  std::views::transform(
+                      [](const ecpps::ir::FunctionScope::Parameter& parameter)
+                      {
+                           return parameter.type;
+                      }) |
                   std::ranges::to<std::vector>(),
               function.namespacePath);
           auto& callingConvention = currentAbi.CallingConventionFromName(function.callingConvention);
@@ -575,11 +578,13 @@ static ecpps::codegen::Operand ParseExpression(ecpps::codegen::AssemblyContext& 
           const auto callAbi = callingConvention.PrepareForCall(code);
 
           const auto returnTypeSize = callingConvention.GetRequirementsForType(function.returnType);
-          const auto parameterSizes =
-              function.parameters |
-              std::views::transform([&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                    { return callingConvention.GetRequirementsForType(parameter.type); }) |
-              std::ranges::to<std::vector>();
+          const auto parameterSizes = function.parameters |
+                                      std::views::transform(
+                                          [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
+                                          {
+                                               return callingConvention.GetRequirementsForType(parameter.type);
+                                          }) |
+                                      std::ranges::to<std::vector>();
 
           const auto argumentStorage = callingConvention.LocateParameters(returnTypeSize, parameterSizes);
           auto argumentIterator = call->Arguments().begin();
@@ -994,7 +999,10 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
      auto stackManager = parentCallingConvention.BeginStack(instructions);
 
      std::vector<const ecpps::ir::FunctionCallNode*> allFunctionCalls;
-     for (const auto& line : node.Body()) { ScanNodeForFunctionCalls(line.get(), allFunctionCalls); }
+     for (const auto& line : node.Body())
+     {
+          ScanNodeForFunctionCalls(line.get(), allFunctionCalls);
+     }
 
      std::size_t maxArgumentStackSpace = 0;
      for (const auto* call : allFunctionCalls)
@@ -1002,11 +1010,13 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
           const auto& function = *call->Function();
           const auto& callingConvention = currentAbi.CallingConventionFromName(function.callingConvention);
           const auto returnTypeSize = callingConvention.GetRequirementsForType(function.returnType);
-          const auto parameterSizes =
-              function.parameters |
-              std::views::transform([&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                    { return callingConvention.GetRequirementsForType(parameter.type); }) |
-              std::ranges::to<std::vector>();
+          const auto parameterSizes = function.parameters |
+                                      std::views::transform(
+                                          [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
+                                          {
+                                               return callingConvention.GetRequirementsForType(parameter.type);
+                                          }) |
+                                      std::ranges::to<std::vector>();
 
           const std::size_t callStackSpace =
               callingConvention.CalculateArgumentStackSpace(returnTypeSize, parameterSizes);
@@ -1060,20 +1070,26 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
           {
                const auto& function = *call->Function();
 
-               const std::string functionName = ecpps::abi::ABI::MangleName(
-                   function.linkage, function.Name().value_or("__unknown"), function.callingConvention,
-                   function.returnType,
-                   function.parameters |
-                       std::views::transform([](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                             { return parameter.type; }) |
-                       std::ranges::to<std::vector>(),
-                   function.namespacePath);
+               const std::string functionName =
+                   ecpps::abi::ABI::MangleName(function.linkage, function.Name().value_or("__unknown"),
+                                               function.callingConvention, function.returnType,
+                                               function.parameters |
+                                                   std::views::transform(
+                                                       [](const ecpps::ir::FunctionScope::Parameter& parameter)
+                                                       {
+                                                            return parameter.type;
+                                                       }) |
+                                                   std::ranges::to<std::vector>(),
+                                               function.namespacePath);
                const auto& callingConvention = currentAbi.CallingConventionFromName(function.callingConvention);
                const auto returnTypeSize = callingConvention.GetRequirementsForType(function.returnType);
                const auto parameterSizes =
                    function.parameters |
-                   std::views::transform([&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                         { return callingConvention.GetRequirementsForType(parameter.type); }) |
+                   std::views::transform(
+                       [&callingConvention](const ecpps::ir::FunctionScope::Parameter& parameter)
+                       {
+                            return callingConvention.GetRequirementsForType(parameter.type);
+                       }) |
                    std::ranges::to<std::vector>();
 
                const auto argumentStorage = callingConvention.LocateParameters(returnTypeSize, parameterSizes);
@@ -1184,8 +1200,11 @@ static Routine CompileRoutine(ecpps::codegen::AssemblyContext& context, const ec
          std::move(instructions),
          ecpps::abi::ABI::MangleName(node.Linkage(), node.Name(), node.CallingConvention(), node.ReturnType(),
                                      node.ParameterList() |
-                                         std::views::transform([](const ecpps::ir::FunctionScope::Parameter& parameter)
-                                                               { return parameter.type; }) |
+                                         std::views::transform(
+                                             [](const ecpps::ir::FunctionScope::Parameter& parameter)
+                                             {
+                                                  return parameter.type;
+                                             }) |
                                          std::ranges::to<std::vector>(),
                                      node.NamespacePath()));
 }

--- a/compiler/ecpps/src/CodeGeneration/PseudoAssembly.h
+++ b/compiler/ecpps/src/CodeGeneration/PseudoAssembly.h
@@ -18,7 +18,10 @@ namespace ecpps::codegen
           std::size_t begin{};
           std::size_t end{};
 
-          [[nodiscard]] constexpr std::size_t Size(void) const noexcept { return this->end - this->begin; }
+          [[nodiscard]] constexpr std::size_t Size(void) const noexcept
+          {
+               return this->end - this->begin;
+          }
           [[nodiscard]] constexpr bool operator==(const ByteView& other) const noexcept
           {
                return this->Size() == other.Size() && this->begin == other.begin;
@@ -46,7 +49,9 @@ namespace ecpps::codegen
                std::uint32_t offset{};
           };
 
-          explicit AssemblyContext(CompilerConfig& config) : _config(std::ref(config)) {}
+          explicit AssemblyContext(CompilerConfig& config) : _config(std::ref(config))
+          {
+          }
           AssemblyContext(const AssemblyContext&) = delete;
           AssemblyContext(AssemblyContext&&) = delete;
           AssemblyContext& operator=(const AssemblyContext&) = delete;
@@ -111,7 +116,10 @@ namespace ecpps::codegen
                const auto& entry = _stringTable[index.indexInTable];
                return entry.offset + index.offset;
           }
-          [[nodiscard]] const auto& GetStringSection(void) const noexcept { return this->_arena; }
+          [[nodiscard]] const auto& GetStringSection(void) const noexcept
+          {
+               return this->_arena;
+          }
 
           void AddStringPatch(std::uint32_t instructionOffset, InstructionPatchType patchType, StringIndex index)
           {
@@ -123,7 +131,10 @@ namespace ecpps::codegen
           std::vector<ecpps::abi::StorageRef> functionParameters{};
           std::size_t stackFrameAdjustment = 0;
 
-          [[nodiscard]] auto& Patches(void) noexcept { return this->_patches; }
+          [[nodiscard]] auto& Patches(void) noexcept
+          {
+               return this->_patches;
+          }
 
      private:
           static std::uint32_t ReserveNextStringEntry(void) noexcept;

--- a/compiler/ecpps/src/CodeGeneration/PseudoAssembly.h
+++ b/compiler/ecpps/src/CodeGeneration/PseudoAssembly.h
@@ -89,8 +89,8 @@ namespace ecpps::codegen
                               //      return {.indexInTable = index, .offset = static_cast<std::uint32_t>(position)};
                               // }
                               if (const auto position =
-                                      std::basic_string_view<Byte>{this->_arena.data() + view.begin, view.Size()}.find(
-                                          probe);
+                                       std::basic_string_view<Byte>{this->_arena.data() + view.begin, view.Size()}.find(
+                                            probe);
                                   position != std::basic_string_view<Byte>::npos)
                               {
                                    return {.indexInTable = index, .offset = static_cast<std::uint32_t>(position)};
@@ -127,7 +127,7 @@ namespace ecpps::codegen
           }
 
           std::stack<std::unordered_map<std::string, std::pair<ecpps::abi::StorageRef, ecpps::abi::StorageRequirement>>>
-              symbolTables;
+               symbolTables;
           std::vector<ecpps::abi::StorageRef> functionParameters{};
           std::size_t stackFrameAdjustment = 0;
 

--- a/compiler/ecpps/src/Debugger/Debuggers/Win64.cpp
+++ b/compiler/ecpps/src/Debugger/Debuggers/Win64.cpp
@@ -36,7 +36,10 @@ static std::string ResolveSymbol(HANDLE process, std::uintptr_t addr)
      std::string moduleName;
 
      DWORD64 modBase = SymGetModuleBase64(process, addr);
-     if (modBase != 0 && SymGetModuleInfo64(process, modBase, &modInfo) != 0) { moduleName = modInfo.ModuleName; }
+     if (modBase != 0 && SymGetModuleInfo64(process, modBase, &modInfo) != 0)
+     {
+          moduleName = modInfo.ModuleName;
+     }
 
      if (SymFromAddr(process, addr, nullptr, symbol) != 0)
      {
@@ -44,7 +47,10 @@ static std::string ResolveSymbol(HANDLE process, std::uintptr_t addr)
                              addr - symbol->Address);
      }
 
-     if (!moduleName.empty()) { return std::format("{}!0x{:016X}", moduleName, addr); }
+     if (!moduleName.empty())
+     {
+          return std::format("{}!0x{:016X}", moduleName, addr);
+     }
 
      return std::format("0x{:016X}", addr);
 }
@@ -83,7 +89,10 @@ static void Disassemble(HANDLE process, std::uintptr_t address, std::size_t size
 
      std::println("At {}:", ResolveSymbol(process, address));
      std::print("  ");
-     for (std::size_t i = 0; i < bytesRead; i++) { std::print("{:02X} ", std::to_integer<unsigned char>(bytes[i])); }
+     for (std::size_t i = 0; i < bytesRead; i++)
+     {
+          std::print("{:02X} ", std::to_integer<unsigned char>(bytes[i]));
+     }
      std::println("; <no disasm>");
 }
 

--- a/compiler/ecpps/src/Debugger/Debuggers/Win64.cpp
+++ b/compiler/ecpps/src/Debugger/Debuggers/Win64.cpp
@@ -23,7 +23,7 @@ static std::uint64_t ResolveRegister([[maybe_unused]] const CONTEXT& ctx, [[mayb
      return 0;
 }
 
-static std::string ResolveSymbol(HANDLE process, std::uintptr_t addr)
+static std::string ResolveSymbol(HANDLE process, std::uintptr_t address)
 {
      std::string buffer{};
      buffer.resize(sizeof(SYMBOL_INFO) + MAX_SYM_NAME);
@@ -35,24 +35,24 @@ static std::string ResolveSymbol(HANDLE process, std::uintptr_t addr)
      modInfo.SizeOfStruct = sizeof(modInfo);
      std::string moduleName;
 
-     DWORD64 modBase = SymGetModuleBase64(process, addr);
-     if (modBase != 0 && SymGetModuleInfo64(process, modBase, &modInfo) != 0)
+     DWORD64 modBase = ::SymGetModuleBase64(process, address);
+     if (modBase != 0 && ::SymGetModuleInfo64(process, modBase, &modInfo) != 0)
      {
           moduleName = modInfo.ModuleName;
      }
 
-     if (SymFromAddr(process, addr, nullptr, symbol) != 0)
+     if (::SymFromAddr(process, address, nullptr, symbol) != 0)
      {
           return std::format("{}!{}+0x{:X}", moduleName.empty() ? "?" : moduleName, symbol->Name,
-                             addr - symbol->Address);
+                             address - symbol->Address);
      }
 
      if (!moduleName.empty())
      {
-          return std::format("{}!0x{:016X}", moduleName, addr);
+          return std::format("{}!0x{:016X}", moduleName, address);
      }
 
-     return std::format("0x{:016X}", addr);
+     return std::format("0x{:016X}", address);
 }
 
 static void PrintStackTrace(HANDLE process, HANDLE thread, const CONTEXT& ctx)
@@ -67,10 +67,10 @@ static void PrintStackTrace(HANDLE process, HANDLE thread, const CONTEXT& ctx)
 
      for (std::size_t frameIndex = 0; frameIndex < 64; frameIndex++)
      {
-          if (StackWalk64(
+          if (::StackWalk64(
                    IMAGE_FILE_MACHINE_AMD64, process, thread, &frame,
                    reinterpret_cast<PVOID>(const_cast<CONTEXT*>(&ctx)), // NOLINT(cppcoreguidelines-pro-type-const-cast)
-                   nullptr, SymFunctionTableAccess64, SymGetModuleBase64, nullptr) == 0)
+                   nullptr, ::SymFunctionTableAccess64, ::SymGetModuleBase64, nullptr) == 0)
                break;
 
           if (frame.AddrPC.Offset == 0) break;
@@ -81,7 +81,7 @@ static void Disassemble(HANDLE process, std::uintptr_t address, std::size_t size
 {
      std::array<std::byte, 32> bytes{};
      SIZE_T bytesRead{};
-     if (ReadProcessMemory(process, reinterpret_cast<LPCVOID>(address), bytes.data(), size, &bytesRead) == 0)
+     if (::ReadProcessMemory(process, reinterpret_cast<LPCVOID>(address), bytes.data(), size, &bytesRead) == 0)
      {
           std::println("Failed to read instructions at 0x{:016X} (error {})", address, GetLastError());
           return;
@@ -100,7 +100,7 @@ static PromptResult PromptLoop(HANDLE process, HANDLE thread)
 {
      CONTEXT ctx{};
      ctx.ContextFlags = CONTEXT_FULL;
-     if (GetThreadContext(thread, &ctx) != 0)
+     if (::GetThreadContext(thread, &ctx) != 0)
      {
           std::println("Failed to get thread context (error {})", GetLastError());
      }
@@ -130,8 +130,8 @@ static PromptResult PromptLoop(HANDLE process, HANDLE thread)
      }
      if (command == "di")
      {
-          std::uintptr_t addr = ctx.Rip;
-          Disassemble(process, addr);
+          std::uintptr_t address = ctx.Rip;
+          Disassemble(process, address);
           return PromptResult::None;
      }
      if (command == "stack")
@@ -162,8 +162,8 @@ static PromptResult PromptLoop(HANDLE process, HANDLE thread)
 
           SIZE_T bytesRead = 0;
           std::vector<std::byte> buffer(count * 8);
-          if (ReadProcessMemory(process, reinterpret_cast<LPCVOID>(address), buffer.data(), buffer.size(),
-                                &bytesRead) == FALSE)
+          if (::ReadProcessMemory(process, reinterpret_cast<LPCVOID>(address), buffer.data(), buffer.size(),
+                                  &bytesRead) == FALSE)
           {
                std::println("Failed to read memory at 0x{:016x} (error {})", address, GetLastError());
                return PromptResult::None;
@@ -234,16 +234,16 @@ int ecpps::debugging::Win64Debugger::Debug([[maybe_unused]] CompilerConfig& conf
      PROCESS_INFORMATION pi{};
      DWORD creationFlags = DEBUG_ONLY_THIS_PROCESS;
 
-     if (CreateProcessW(nullptr, commandLine, nullptr, nullptr, FALSE, creationFlags, nullptr, nullptr, &si, &pi) ==
+     if (::CreateProcessW(nullptr, commandLine, nullptr, nullptr, FALSE, creationFlags, nullptr, nullptr, &si, &pi) ==
          FALSE)
      {
           return static_cast<int>(GetLastError());
      }
 
-     SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
+     ::SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
 
      // std::string symbolPath = "srv*C:\\Symbols*https://msdl.microsoft.com/download/symbols";
-     if (SymInitialize(pi.hProcess, nullptr, TRUE) == 0)
+     if (::SymInitialize(pi.hProcess, nullptr, TRUE) == 0)
      {
           std::println("SymInitialize failed ({:x})", GetLastError());
      }
@@ -254,9 +254,9 @@ int ecpps::debugging::Win64Debugger::Debug([[maybe_unused]] CompilerConfig& conf
 
      while (running)
      {
-          if (!WaitForDebugEvent(&dbgEvent, INFINITE))
+          if (!::WaitForDebugEvent(&dbgEvent, INFINITE))
           {
-               TerminateProcess(pi.hProcess, 1);
+               ::TerminateProcess(pi.hProcess, 1);
                exitCode = 1;
                break;
           }
@@ -287,9 +287,9 @@ int ecpps::debugging::Win64Debugger::Debug([[maybe_unused]] CompilerConfig& conf
           {
                auto base = reinterpret_cast<DWORD64>(dbgEvent.u.CreateProcessInfo.lpBaseOfImage);
                HANDLE file = dbgEvent.u.CreateProcessInfo.hFile;
-               SymLoadModuleEx(pi.hProcess, file, nullptr, nullptr, base, 0, nullptr, 0);
+               ::SymLoadModuleEx(pi.hProcess, file, nullptr, nullptr, base, 0, nullptr, 0);
                std::println("[+] Loaded main module at 0x{:016X}", base);
-               if (file) CloseHandle(file);
+               if (file) ::CloseHandle(file);
                break;
           }
 
@@ -302,7 +302,7 @@ int ecpps::debugging::Win64Debugger::Debug([[maybe_unused]] CompilerConfig& conf
           {
                auto base = reinterpret_cast<DWORD64>(dbgEvent.u.LoadDll.lpBaseOfDll);
                HANDLE file = dbgEvent.u.LoadDll.hFile;
-               SymLoadModuleEx(pi.hProcess, file, nullptr, nullptr, base, 0, nullptr, 0);
+               ::SymLoadModuleEx(pi.hProcess, file, nullptr, nullptr, base, 0, nullptr, 0);
 
                std::string path;
                if (dbgEvent.u.LoadDll.lpImageName)
@@ -311,16 +311,16 @@ int ecpps::debugging::Win64Debugger::Debug([[maybe_unused]] CompilerConfig& conf
                     nameBuffer.resize(MAX_PATH);
                     SIZE_T bytesRead = 0;
                     LPCVOID namePtr = nullptr;
-                    if (ReadProcessMemory(pi.hProcess, dbgEvent.u.LoadDll.lpImageName, &namePtr, sizeof(namePtr),
-                                          &bytesRead) &&
+                    if (::ReadProcessMemory(pi.hProcess, dbgEvent.u.LoadDll.lpImageName, &namePtr, sizeof(namePtr),
+                                            &bytesRead) &&
                         namePtr)
                     {
-                         ReadProcessMemory(pi.hProcess, namePtr, nameBuffer.data(), nameBuffer.size(), &bytesRead);
+                         ::ReadProcessMemory(pi.hProcess, namePtr, nameBuffer.data(), nameBuffer.size(), &bytesRead);
                          path = nameBuffer;
                     }
                }
                std::println("# DLL loaded at 0x{:016x} ({})", base, path.empty() ? "unknown" : path);
-               if (dbgEvent.u.LoadDll.hFile) CloseHandle(dbgEvent.u.LoadDll.hFile);
+               if (dbgEvent.u.LoadDll.hFile) ::CloseHandle(dbgEvent.u.LoadDll.hFile);
           }
           break;
           case UNLOAD_DLL_DEBUG_EVENT:
@@ -333,8 +333,8 @@ int ecpps::debugging::Win64Debugger::Debug([[maybe_unused]] CompilerConfig& conf
                SIZE_T read{};
                std::string string;
                string.resize(dbgEvent.u.DebugString.nDebugStringLength);
-               ReadProcessMemory(pi.hProcess, dbgEvent.u.DebugString.lpDebugStringData, string.data(), string.size(),
-                                 &read);
+               ::ReadProcessMemory(pi.hProcess, dbgEvent.u.DebugString.lpDebugStringData, string.data(), string.size(),
+                                   &read);
                std::print("{}", string);
           }
           break;
@@ -344,16 +344,16 @@ int ecpps::debugging::Win64Debugger::Debug([[maybe_unused]] CompilerConfig& conf
           default: break;
           }
 
-          ContinueDebugEvent(dbgEvent.dwProcessId, dbgEvent.dwThreadId, continueStatus);
+          ::ContinueDebugEvent(dbgEvent.dwProcessId, dbgEvent.dwThreadId, continueStatus);
      }
 
-     if (WaitForSingleObject(pi.hProcess, 0) != WAIT_OBJECT_0) WaitForSingleObject(pi.hProcess, INFINITE);
+     if (::WaitForSingleObject(pi.hProcess, 0) != WAIT_OBJECT_0) ::WaitForSingleObject(pi.hProcess, INFINITE);
 
      DWORD processExitCode = 0;
-     if (GetExitCodeProcess(pi.hProcess, &processExitCode) != 0) processExitCode = exitCode;
+     if (::GetExitCodeProcess(pi.hProcess, &processExitCode) != 0) processExitCode = exitCode;
 
-     CloseHandle(pi.hThread);
-     CloseHandle(pi.hProcess);
+     ::CloseHandle(pi.hThread);
+     ::CloseHandle(pi.hProcess);
 
      std::println("Process exited with code {} (0x{:x})", processExitCode, processExitCode);
 

--- a/compiler/ecpps/src/Debugger/Debuggers/Win64.cpp
+++ b/compiler/ecpps/src/Debugger/Debuggers/Win64.cpp
@@ -68,9 +68,9 @@ static void PrintStackTrace(HANDLE process, HANDLE thread, const CONTEXT& ctx)
      for (std::size_t frameIndex = 0; frameIndex < 64; frameIndex++)
      {
           if (StackWalk64(
-                  IMAGE_FILE_MACHINE_AMD64, process, thread, &frame,
-                  reinterpret_cast<PVOID>(const_cast<CONTEXT*>(&ctx)), // NOLINT(cppcoreguidelines-pro-type-const-cast)
-                  nullptr, SymFunctionTableAccess64, SymGetModuleBase64, nullptr) == 0)
+                   IMAGE_FILE_MACHINE_AMD64, process, thread, &frame,
+                   reinterpret_cast<PVOID>(const_cast<CONTEXT*>(&ctx)), // NOLINT(cppcoreguidelines-pro-type-const-cast)
+                   nullptr, SymFunctionTableAccess64, SymGetModuleBase64, nullptr) == 0)
                break;
 
           if (frame.AddrPC.Offset == 0) break;

--- a/compiler/ecpps/src/Execution/Constexpr.h
+++ b/compiler/ecpps/src/Execution/Constexpr.h
@@ -15,51 +15,51 @@ namespace ecpps::ir
                                                              BumpAllocator& allocator)
      {
           return std::visit(
-              OverloadedVisitor{
-                  [type](std::monostate) -> std::unique_ptr<T>
-                  {
-                       return std::make_unique<T>(type, nullptr, true);
-                  },
-                  [type, &allocator, &result](const std::uint64_t value) -> std::unique_ptr<T>
-                  {
-                       return std::make_unique<PRValue>(
-                           type,
-                           std::unique_ptr<IntegralNode, IRDeleter>(new (allocator) IntegralNode(value, result.source)),
-                           true);
-                  },
-                  [type, &allocator, &result](const ConstantAggregateArray& array) -> std::unique_ptr<T>
-                  {
-                       const auto* arrayType = type->CastTo<typeSystem::ArrayType>();
-                       runtime_assert(arrayType != nullptr, "Invalid type provided for the constant evaluator");
-                       const auto* elementType = arrayType->ElementType();
-                       const auto* intElementType = elementType->CastTo<typeSystem::IntegralType>();
-                       runtime_assert(arrayType->ElementCount() == array.members.size(),
-                                      "Mismatch between the array type and element count");
-                       runtime_assert(intElementType != nullptr,
-                                      "Invalid underlying type provided for the constant evaluator");
+               OverloadedVisitor{
+                    [type](std::monostate) -> std::unique_ptr<T>
+                    {
+                         return std::make_unique<T>(type, nullptr, true);
+                    },
+                    [type, &allocator, &result](const std::uint64_t value) -> std::unique_ptr<T>
+                    {
+                         return std::make_unique<PRValue>(type,
+                                                          std::unique_ptr<IntegralNode, IRDeleter>(
+                                                               new (allocator) IntegralNode(value, result.source)),
+                                                          true);
+                    },
+                    [type, &allocator, &result](const ConstantAggregateArray& array) -> std::unique_ptr<T>
+                    {
+                         const auto* arrayType = type->CastTo<typeSystem::ArrayType>();
+                         runtime_assert(arrayType != nullptr, "Invalid type provided for the constant evaluator");
+                         const auto* elementType = arrayType->ElementType();
+                         const auto* intElementType = elementType->CastTo<typeSystem::IntegralType>();
+                         runtime_assert(arrayType->ElementCount() == array.members.size(),
+                                        "Mismatch between the array type and element count");
+                         runtime_assert(intElementType != nullptr,
+                                        "Invalid underlying type provided for the constant evaluator");
 
-                       const auto allHoldInts =
-                           array.members |
-                           std::views::transform(
-                               [](const ConstantEvaluatedVariant& element)
-                               {
-                                    using std::string_view_literals::operator""sv;
-                                    if (!std::holds_alternative<std::uint64_t>(element))
-                                         throw ecpps::TracedException("Invalid int array sequence");
-                                    return static_cast<std::uint32_t>(std::get<std::uint64_t>(element));
-                               }) |
-                           std::ranges::to<std::vector>();
+                         const auto allHoldInts =
+                              array.members |
+                              std::views::transform(
+                                   [](const ConstantEvaluatedVariant& element)
+                                   {
+                                        using std::string_view_literals::operator""sv;
+                                        if (!std::holds_alternative<std::uint64_t>(element))
+                                             throw ecpps::TracedException("Invalid int array sequence");
+                                        return static_cast<std::uint32_t>(std::get<std::uint64_t>(element));
+                                   }) |
+                              std::ranges::to<std::vector>();
 
-                       return std::make_unique<PRValue>(
-                           type,
-                           std::unique_ptr<IntegerArrayNode, IRDeleter>(
-                               new (allocator) IntegerArrayNode(allHoldInts, intElementType, result.source)),
-                           true);
-                  },
-                  [](const auto&) -> std::unique_ptr<T>
-                  {
-                       throw[]{};
-                  }},
-              result.variant);
+                         return std::make_unique<PRValue>(
+                              type,
+                              std::unique_ptr<IntegerArrayNode, IRDeleter>(
+                                   new (allocator) IntegerArrayNode(allHoldInts, intElementType, result.source)),
+                              true);
+                    },
+                    [](const auto&) -> std::unique_ptr<T>
+                    {
+                         throw[]{};
+                    }},
+               result.variant);
      }
 } // namespace ecpps::ir

--- a/compiler/ecpps/src/Execution/Constexpr.h
+++ b/compiler/ecpps/src/Execution/Constexpr.h
@@ -16,7 +16,10 @@ namespace ecpps::ir
      {
           return std::visit(
               OverloadedVisitor{
-                  [type](std::monostate) -> std::unique_ptr<T> { return std::make_unique<T>(type, nullptr, true); },
+                  [type](std::monostate) -> std::unique_ptr<T>
+                  {
+                       return std::make_unique<T>(type, nullptr, true);
+                  },
                   [type, &allocator, &result](const std::uint64_t value) -> std::unique_ptr<T>
                   {
                        return std::make_unique<PRValue>(
@@ -53,7 +56,10 @@ namespace ecpps::ir
                                new (allocator) IntegerArrayNode(allHoldInts, intElementType, result.source)),
                            true);
                   },
-                  [](const auto&) -> std::unique_ptr<T> { throw[]{}; }},
+                  [](const auto&) -> std::unique_ptr<T>
+                  {
+                       throw[]{};
+                  }},
               result.variant);
      }
 } // namespace ecpps::ir

--- a/compiler/ecpps/src/Execution/Context.h
+++ b/compiler/ecpps/src/Execution/Context.h
@@ -142,7 +142,7 @@ namespace ecpps::ir
      inline InvalidRequest::InvalidRequest(const InvalidRequest& other)
      {
           this->suggestedRequest =
-              other.suggestedRequest ? std::make_unique<TypeRequest>(*other.suggestedRequest) : nullptr;
+               other.suggestedRequest ? std::make_unique<TypeRequest>(*other.suggestedRequest) : nullptr;
      }
      inline InvalidRequest::InvalidRequest(std::unique_ptr<TypeRequest> suggestedRequest,
                                            std::vector<diagnostics::DiagnosticsMessage> diagnostics)
@@ -154,7 +154,7 @@ namespace ecpps::ir
           if (this != &other)
           {
                this->suggestedRequest =
-                   other.suggestedRequest ? std::make_unique<TypeRequest>(*other.suggestedRequest) : nullptr;
+                    other.suggestedRequest ? std::make_unique<TypeRequest>(*other.suggestedRequest) : nullptr;
           }
           return *this;
      }
@@ -180,38 +180,38 @@ namespace ecpps::ir
                seed = HashCombine(seed, value.data.index());
 
                std::visit(
-                   [&](const auto& data)
-                   {
-                        using T = std::decay_t<decltype(data)>;
+                    [&](const auto& data)
+                    {
+                         using T = std::decay_t<decltype(data)>;
 
-                        if constexpr (std::is_same_v<T, StandardSignedIntegerRequest>)
-                        {
-                             seed = HashCombine(seed, data.size);
-                             seed = HashCombine(seed, data.signedness);
-                             seed = HashCombine(seed, data.isCharWithoutSign);
-                        }
-                        else if constexpr (std::is_same_v<T, BoundedArrayRequest>)
-                        {
-                             seed = HashCombine(seed, data.elementType);
-                             seed = HashCombine(seed, data.size);
-                        }
-                        else if constexpr (std::is_same_v<T, PlatformIntegerRequest>)
-                        {
-                             seed = HashCombine(seed, data.kind);
-                        }
-                        else if constexpr (std::is_same_v<T, PointerRequest>)
-                        {
-                             seed = HashCombine(seed, data.elementType);
-                        }
-                        else if constexpr (std::is_same_v<T, VoidRequest>)
-                        {
-                        }
-                        else if constexpr (std::is_same_v<T, InvalidRequest>)
-                             seed = HashCombine(seed, &data);
-                        else
-                             std::terminate();
-                   },
-                   value.data);
+                         if constexpr (std::is_same_v<T, StandardSignedIntegerRequest>)
+                         {
+                              seed = HashCombine(seed, data.size);
+                              seed = HashCombine(seed, data.signedness);
+                              seed = HashCombine(seed, data.isCharWithoutSign);
+                         }
+                         else if constexpr (std::is_same_v<T, BoundedArrayRequest>)
+                         {
+                              seed = HashCombine(seed, data.elementType);
+                              seed = HashCombine(seed, data.size);
+                         }
+                         else if constexpr (std::is_same_v<T, PlatformIntegerRequest>)
+                         {
+                              seed = HashCombine(seed, data.kind);
+                         }
+                         else if constexpr (std::is_same_v<T, PointerRequest>)
+                         {
+                              seed = HashCombine(seed, data.elementType);
+                         }
+                         else if constexpr (std::is_same_v<T, VoidRequest>)
+                         {
+                         }
+                         else if constexpr (std::is_same_v<T, InvalidRequest>)
+                              seed = HashCombine(seed, &data);
+                         else
+                              std::terminate();
+                    },
+                    value.data);
 
                return seed;
           }
@@ -252,7 +252,7 @@ namespace ecpps::ir
 
                auto created = CreateType(request);
                return this->_typeDatabase.emplace(request, Node{.typePointer = std::move(created), .hitCount = 1})
-                   .first->second.typePointer.get();
+                    .first->second.typePointer.get();
           }
 
           [[nodiscard]] std::size_t Count(void) const noexcept
@@ -263,10 +263,10 @@ namespace ecpps::ir
           {
                return this->_typeDatabase | std::views::values |
                       std::views::transform(
-                          [](const Node& node)
-                          {
-                               return NonownedNode{.typePointer = node.typePointer.get(), .hitCount = node.hitCount};
-                          }) |
+                           [](const Node& node)
+                           {
+                                return NonownedNode{.typePointer = node.typePointer.get(), .hitCount = node.hitCount};
+                           }) |
                       std::ranges::to<std::vector>();
           }
 
@@ -306,34 +306,34 @@ namespace ecpps::ir
                          {
                          case typeSystem::TypeKind::Char:
                               return data.signedness == typeSystem::Signedness::Signed
-                                         ? std::make_unique<typeSystem::CharacterType>(
-                                               ecpps::typeSystem::CharacterSign::SignedChar,
-                                               std::format("{}signed char", cv), request.qualifiers)
-                                         : std::make_unique<typeSystem::CharacterType>(
-                                               ecpps::typeSystem::CharacterSign::UnsignedChar,
-                                               std::format("{}unsigned char", cv), request.qualifiers);
+                                          ? std::make_unique<typeSystem::CharacterType>(
+                                                 ecpps::typeSystem::CharacterSign::SignedChar,
+                                                 std::format("{}signed char", cv), request.qualifiers)
+                                          : std::make_unique<typeSystem::CharacterType>(
+                                                 ecpps::typeSystem::CharacterSign::UnsignedChar,
+                                                 std::format("{}unsigned char", cv), request.qualifiers);
                          case typeSystem::TypeKind::Short:
                          case typeSystem::TypeKind::Int:
                          case typeSystem::TypeKind::Long:
                          case typeSystem::TypeKind::LongLong:
                               return std::make_unique<typeSystem::IntegralType>(
-                                  data.signedness, data.size,
-                                  std::format("{}{}{}", cv,
-                                              data.signedness == typeSystem::Signedness::Signed ? "" : "unsigned ",
-                                              (
-                                                  [size = data.size] -> std::string
-                                                  {
-                                                       switch (size)
-                                                       {
-                                                       case typeSystem::TypeKind::Char: return "char";
-                                                       case typeSystem::TypeKind::Short: return "short";
-                                                       case typeSystem::TypeKind::Int: return "int";
-                                                       case typeSystem::TypeKind::Long: return "long";
-                                                       case typeSystem::TypeKind::LongLong: return "long long";
-                                                       }
-                                                       return "?";
-                                                  })()),
-                                  request.qualifiers);
+                                   data.signedness, data.size,
+                                   std::format("{}{}{}", cv,
+                                               data.signedness == typeSystem::Signedness::Signed ? "" : "unsigned ",
+                                               (
+                                                    [size = data.size] -> std::string
+                                                    {
+                                                         switch (size)
+                                                         {
+                                                         case typeSystem::TypeKind::Char: return "char";
+                                                         case typeSystem::TypeKind::Short: return "short";
+                                                         case typeSystem::TypeKind::Int: return "int";
+                                                         case typeSystem::TypeKind::Long: return "long";
+                                                         case typeSystem::TypeKind::LongLong: return "long long";
+                                                         }
+                                                         return "?";
+                                                    })()),
+                                   request.qualifiers);
                          }
                     }
                     if (std::holds_alternative<PlatformIntegerRequest>(request.data))
@@ -367,22 +367,22 @@ namespace ecpps::ir
                          }
 
                          return std::make_unique<typeSystem::IntegralType>(
-                             signedness, size,
-                             std::format("{}{}{}", cv, signedness == typeSystem::Signedness::Signed ? "" : "unsigned ",
-                                         (
-                                             [size] -> std::string
-                                             {
-                                                  switch (size)
-                                                  {
-                                                  case typeSystem::TypeKind::Char: return "char";
-                                                  case typeSystem::TypeKind::Short: return "short";
-                                                  case typeSystem::TypeKind::Int: return "int";
-                                                  case typeSystem::TypeKind::Long: return "long";
-                                                  case typeSystem::TypeKind::LongLong: return "long long";
-                                                  }
-                                                  return "?";
-                                             })()),
-                             request.qualifiers);
+                              signedness, size,
+                              std::format("{}{}{}", cv, signedness == typeSystem::Signedness::Signed ? "" : "unsigned ",
+                                          (
+                                               [size] -> std::string
+                                               {
+                                                    switch (size)
+                                                    {
+                                                    case typeSystem::TypeKind::Char: return "char";
+                                                    case typeSystem::TypeKind::Short: return "short";
+                                                    case typeSystem::TypeKind::Int: return "int";
+                                                    case typeSystem::TypeKind::Long: return "long";
+                                                    case typeSystem::TypeKind::LongLong: return "long long";
+                                                    }
+                                                    return "?";
+                                               })()),
+                              request.qualifiers);
                     }
                }
                else if (request.kind == TypeKind::Error)
@@ -405,8 +405,8 @@ namespace ecpps::ir
                     {
                          const auto& pointerData = std::get<PointerRequest>(request.data);
                          return std::make_unique<typeSystem::PointerType>(
-                             pointerData.elementType, std::format("{}* {}", pointerData.elementType->Name(), cv),
-                             request.qualifiers);
+                              pointerData.elementType, std::format("{}* {}", pointerData.elementType->Name(), cv),
+                              request.qualifiers);
                     }
                }
 
@@ -425,7 +425,7 @@ namespace ecpps::ir
           Scope* parentScope = nullptr;
           std::unordered_set<typeSystem::NonowningTypePointer, typeSystem::TypePointerHash,
                              typeSystem::TypePointerEqual>
-              types{};
+               types{};
           std::vector<std::shared_ptr<FunctionScope>> functions{};
           std::unordered_map<std::string, typeSystem::NonowningTypePointer> typeAliases{};
      };
@@ -655,59 +655,59 @@ namespace ecpps::ir
           }
 
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::Name> Name(
-              std::string value) && noexcept
+               std::string value) && noexcept
           {
                this->_scope->SetName(std::forward<std::remove_reference_t<decltype(value)>>(value));
                return std::move(*this);
           }
 
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::ReturnType> ReturnType(
-              typeSystem::NonowningTypePointer value) && noexcept
+               typeSystem::NonowningTypePointer value) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::returnType>(std::move(value));
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::Parameters> Parameters(
-              std::vector<FunctionScope::Parameter> value) && noexcept
+               std::vector<FunctionScope::Parameter> value) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::parameters>(std::move(value));
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::CallingConvention> CallingConvention(
-              abi::CallingConventionName value) && noexcept
+               abi::CallingConventionName value) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::callingConvention>(value);
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::Linkage> Linkage(
-              abi::Linkage value) && noexcept
+               abi::Linkage value) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::linkage>(value);
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::IsStatic> IsStatic(
-              bool value = true) && noexcept
+               bool value = true) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::isStatic>(value);
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::IsInline> IsInline(
-              bool value = true) && noexcept
+               bool value = true) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::isInline>(value);
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::IsFriend> IsFriend(
-              bool value = true) && noexcept
+               bool value = true) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::isFriend>(value);
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::IsExtern> IsExtern(
-              bool value = true) && noexcept
+               bool value = true) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::isExtern>(value);
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::ConstexprSpecifier> ConstexprSpecifier(
-              ConstexprType value) && noexcept
+               ConstexprType value) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::constexprSpecifier>(value);
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::IsDllImportExport> IsDllImportExport(
-              bool value = true) && noexcept
+               bool value = true) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::isDllImportExport>(value);
           }
@@ -720,7 +720,7 @@ namespace ecpps::ir
                return std::move(*this).template PropertySetter<&FunctionScope::source>(std::move(value));
           }
           [[nodiscard]] FunctionScopeBuilder<TState | FunctionScopeBuilderState::NamespacePath> NamespacePath(
-              std::vector<std::string> value) && noexcept
+               std::vector<std::string> value) && noexcept
           {
                return std::move(*this).template PropertySetter<&FunctionScope::namespacePath>(std::move(value));
           }

--- a/compiler/ecpps/src/Execution/Context.h
+++ b/compiler/ecpps/src/Execution/Context.h
@@ -203,7 +203,9 @@ namespace ecpps::ir
                         {
                              seed = HashCombine(seed, data.elementType);
                         }
-                        else if constexpr (std::is_same_v<T, VoidRequest>) {}
+                        else if constexpr (std::is_same_v<T, VoidRequest>)
+                        {
+                        }
                         else if constexpr (std::is_same_v<T, InvalidRequest>)
                              seed = HashCombine(seed, &data);
                         else
@@ -253,13 +255,18 @@ namespace ecpps::ir
                    .first->second.typePointer.get();
           }
 
-          [[nodiscard]] std::size_t Count(void) const noexcept { return this->_typeDatabase.size(); }
+          [[nodiscard]] std::size_t Count(void) const noexcept
+          {
+               return this->_typeDatabase.size();
+          }
           [[nodiscard]] std::vector<NonownedNode> List(void) const noexcept
           {
                return this->_typeDatabase | std::views::values |
                       std::views::transform(
                           [](const Node& node)
-                          { return NonownedNode{.typePointer = node.typePointer.get(), .hitCount = node.hitCount}; }) |
+                          {
+                               return NonownedNode{.typePointer = node.typePointer.get(), .hitCount = node.hitCount};
+                          }) |
                       std::ranges::to<std::vector>();
           }
 
@@ -428,12 +435,23 @@ namespace ecpps::ir
      {
           virtual ~ContextBase(void);
 
-          [[nodiscard]] const Scope& GetScope(void) const noexcept { return *this->_vScope; }
-          [[nodiscard]] Scope& GetScope(void) noexcept { return *this->_vScope; }
-          template <typename U> [[nodiscard]] U& GetScope(void) noexcept { return *static_cast<U*>(this->_vScope); }
+          [[nodiscard]] const Scope& GetScope(void) const noexcept
+          {
+               return *this->_vScope;
+          }
+          [[nodiscard]] Scope& GetScope(void) noexcept
+          {
+               return *this->_vScope;
+          }
+          template <typename U> [[nodiscard]] U& GetScope(void) noexcept
+          {
+               return *static_cast<U*>(this->_vScope);
+          }
 
      protected:
-          explicit ContextBase(Scope* vScope) : _vScope(vScope) {}
+          explicit ContextBase(Scope* vScope) : _vScope(vScope)
+          {
+          }
 
      private:
           Scope* _vScope;
@@ -464,7 +482,9 @@ namespace ecpps::ir
      };
      struct NamespaceContext final : ContextBase
      {
-          explicit NamespaceContext(Scope* vScope) : ContextBase(vScope) {}
+          explicit NamespaceContext(Scope* vScope) : ContextBase(vScope)
+          {
+          }
      };
 
      enum struct ConstexprType : std::uint_fast8_t
@@ -484,7 +504,9 @@ namespace ecpps::ir
      struct TemplateNonTypeParameter final : TemplateParameter
      {
           typeSystem::NonowningTypePointer type;
-          explicit TemplateNonTypeParameter(typeSystem::NonowningTypePointer type) : type(type) {}
+          explicit TemplateNonTypeParameter(typeSystem::NonowningTypePointer type) : type(type)
+          {
+          }
      };
      struct Variable final : ir::Entity
      {
@@ -542,7 +564,10 @@ namespace ecpps::ir
                     {
                          return std::get<Variable>(this->local).Name().value_or("<anonymous>");
                     }
-                    if (std::holds_alternative<ThisTag>(this->local)) { return "*this"; }
+                    if (std::holds_alternative<ThisTag>(this->local))
+                    {
+                         return "*this";
+                    }
                     return "__unknown_local";
                }
           };
@@ -550,7 +575,9 @@ namespace ecpps::ir
           std::vector<std::unique_ptr<TemplateParameter>> templateParameters{};
           std::vector<std::string> namespacePath{};
 
-          explicit FunctionScope(void) : ir::Entity(ir::EntityKind::Function, std::nullopt) {}
+          explicit FunctionScope(void) : ir::Entity(ir::EntityKind::Function, std::nullopt)
+          {
+          }
 
           using ir::Entity::SetName;
 
@@ -710,13 +737,18 @@ namespace ecpps::ir
                this->_scope->*T = std::forward<std::remove_reference_t<decltype(value)>>(value);
                return std::move(*this);
           }
-          explicit FunctionScopeBuilder(FunctionScope* scope) : _scope(scope) {}
+          explicit FunctionScopeBuilder(FunctionScope* scope) : _scope(scope)
+          {
+          }
           FunctionScope* _scope;
 
           template <FunctionScopeBuilderState> friend struct FunctionScopeBuilder;
           friend inline FunctionScopeBuilder<> MakeFunctionScope(void);
      };
-     inline FunctionScopeBuilder<> MakeFunctionScope(void) { return FunctionScopeBuilder{new FunctionScope{}}; }
+     inline FunctionScopeBuilder<> MakeFunctionScope(void)
+     {
+          return FunctionScopeBuilder{new FunctionScope{}};
+     }
 
      struct ClassScope final : Scope
      {
@@ -731,7 +763,9 @@ namespace ecpps::ir
           bool isInline = false;
           std::vector<std::unique_ptr<NamespaceScope>> subNamespaces{};
           std::vector<std::unique_ptr<ClassScope>> classes{};
-          explicit NamespaceScope(void) : ir::Entity(ir::EntityKind::Namespace, std::nullopt) {}
+          explicit NamespaceScope(void) : ir::Entity(ir::EntityKind::Namespace, std::nullopt)
+          {
+          }
           explicit NamespaceScope(std::string name, bool isInline = false)
               : ir::Entity(ir::EntityKind::Namespace, std::move(name)), isInline(isInline)
           {

--- a/compiler/ecpps/src/Execution/ControlFlow.h
+++ b/compiler/ecpps/src/Execution/ControlFlow.h
@@ -14,8 +14,14 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] bool HasValue(void) const noexcept { return this->_value != nullptr; }
-          [[nodiscard]] const Expression& Value(void) const noexcept { return this->_value; }
+          [[nodiscard]] bool HasValue(void) const noexcept
+          {
+               return this->_value != nullptr;
+          }
+          [[nodiscard]] const Expression& Value(void) const noexcept
+          {
+               return this->_value;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {

--- a/compiler/ecpps/src/Execution/Entities.h
+++ b/compiler/ecpps/src/Execution/Entities.h
@@ -38,7 +38,7 @@ namespace ecpps::ir
                return this->_entries[kind].size();
           }
           [[nodiscard]] const std::unordered_map<EntityKind, std::vector<std::optional<std::string>>>& Entries(
-              void) const noexcept
+               void) const noexcept
           {
                return this->_entries;
           }

--- a/compiler/ecpps/src/Execution/Entities.h
+++ b/compiler/ecpps/src/Execution/Entities.h
@@ -58,7 +58,10 @@ namespace ecpps::ir
           [[nodiscard]] std::size_t Count(void) const noexcept
           {
                return std::accumulate(this->_entries.begin(), this->_entries.end(), 0ULL,
-                                      [](std::size_t sum, const auto& pair) { return sum + pair.second.size(); });
+                                      [](std::size_t sum, const auto& pair)
+                                      {
+                                           return sum + pair.second.size();
+                                      });
           }
 
      private:
@@ -91,8 +94,14 @@ namespace ecpps::ir
           Entity& operator=(const Entity&) = delete;
           Entity& operator=(Entity&&) = default;
 
-          [[nodiscard]] EntityKind Kind(void) const noexcept { return this->_kind; }
-          [[nodiscard]] const std::optional<std::string>& Name(void) const noexcept { return this->_name; }
+          [[nodiscard]] EntityKind Kind(void) const noexcept
+          {
+               return this->_kind;
+          }
+          [[nodiscard]] const std::optional<std::string>& Name(void) const noexcept
+          {
+               return this->_name;
+          }
           [[nodiscard]] virtual std::string ToString(void) const = 0;
 
      protected:

--- a/compiler/ecpps/src/Execution/Expressions.h
+++ b/compiler/ecpps/src/Execution/Expressions.h
@@ -16,19 +16,49 @@ namespace ecpps
 
           virtual ~ExpressionBase(void) = default;
 
-          [[nodiscard]] constexpr static bool IsExpression(void) noexcept { return true; }
+          [[nodiscard]] constexpr static bool IsExpression(void) noexcept
+          {
+               return true;
+          }
 
-          [[nodiscard]] virtual bool IsLValue(void) const noexcept { return false; }
-          [[nodiscard]] virtual bool IsXValue(void) const noexcept { return false; }
-          [[nodiscard]] virtual bool IsPRValue(void) const noexcept { return false; }
+          [[nodiscard]] virtual bool IsLValue(void) const noexcept
+          {
+               return false;
+          }
+          [[nodiscard]] virtual bool IsXValue(void) const noexcept
+          {
+               return false;
+          }
+          [[nodiscard]] virtual bool IsPRValue(void) const noexcept
+          {
+               return false;
+          }
 
-          [[nodiscard]] bool IsGLValue(void) const noexcept { return this->IsLValue() || this->IsXValue(); }
-          [[nodiscard]] bool IsRValue(void) const noexcept { return this->IsXValue() || this->IsPRValue(); }
+          [[nodiscard]] bool IsGLValue(void) const noexcept
+          {
+               return this->IsLValue() || this->IsXValue();
+          }
+          [[nodiscard]] bool IsRValue(void) const noexcept
+          {
+               return this->IsXValue() || this->IsPRValue();
+          }
 
-          [[nodiscard]] bool IsConstantExpression(void) const noexcept { return this->_isConstantExpression; }
-          [[nodiscard]] const ir::NodePointer& Value(void) const& noexcept { return this->_value; }
-          [[nodiscard]] ir::NodePointer&& Value(void) && noexcept { return std::move(this->_value); }
-          [[nodiscard]] typeSystem::NonowningTypePointer Type(void) const noexcept { return this->_type; }
+          [[nodiscard]] bool IsConstantExpression(void) const noexcept
+          {
+               return this->_isConstantExpression;
+          }
+          [[nodiscard]] const ir::NodePointer& Value(void) const& noexcept
+          {
+               return this->_value;
+          }
+          [[nodiscard]] ir::NodePointer&& Value(void) && noexcept
+          {
+               return std::move(this->_value);
+          }
+          [[nodiscard]] typeSystem::NonowningTypePointer Type(void) const noexcept
+          {
+               return this->_type;
+          }
 
      private:
           typeSystem::NonowningTypePointer _type;
@@ -42,7 +72,10 @@ namespace ecpps
      public:
           using ExpressionBase::ExpressionBase;
 
-          [[nodiscard]] bool IsLValue(void) const noexcept override { return true; }
+          [[nodiscard]] bool IsLValue(void) const noexcept override
+          {
+               return true;
+          }
      };
 
      class XValue final : public ExpressionBase
@@ -50,13 +83,19 @@ namespace ecpps
      public:
           using ExpressionBase::ExpressionBase;
 
-          [[nodiscard]] bool IsXValue(void) const noexcept override { return true; }
+          [[nodiscard]] bool IsXValue(void) const noexcept override
+          {
+               return true;
+          }
      };
      class PRValue final : public ExpressionBase
      {
      public:
           using ExpressionBase::ExpressionBase;
 
-          [[nodiscard]] bool IsPRValue(void) const noexcept override { return true; }
+          [[nodiscard]] bool IsPRValue(void) const noexcept override
+          {
+               return true;
+          }
      };
 } // namespace ecpps

--- a/compiler/ecpps/src/Execution/IR.cpp
+++ b/compiler/ecpps/src/Execution/IR.cpp
@@ -47,7 +47,10 @@ namespace
                if (!param.name.empty()) signature += " " + param.name;
           }
           signature += ")";
-          if (func->returnType) { signature += " -> " + func->returnType->Name(); }
+          if (func->returnType)
+          {
+               signature += " -> " + func->returnType->Name();
+          }
           return signature;
      }
 
@@ -136,7 +139,11 @@ namespace
                }
           }
 
-          std::ranges::sort(similar, [](const auto& a, const auto& b) { return a.second < b.second; });
+          std::ranges::sort(similar,
+                            [](const auto& a, const auto& b)
+                            {
+                                 return a.second < b.second;
+                            });
 
           return similar;
      }
@@ -178,7 +185,11 @@ namespace
                }
           }
 
-          std::ranges::sort(similar, [](const auto& a, const auto& b) { return a.second < b.second; });
+          std::ranges::sort(similar,
+                            [](const auto& a, const auto& b)
+                            {
+                                 return a.second < b.second;
+                            });
 
           return similar;
      }
@@ -527,12 +538,15 @@ void ecpps::ir::IR::ParseFunctionDefinition(const ast::FunctionDefinitionNode& n
              .Build();
      functionScope->parameters = parameters;
      functionScope->linkage = linkage;
-     auto functionContext = std::make_shared<FunctionContext>(
-         functionScope.get(), node.Signature().callingConvention, returnType, name,
-         parameters |
-             std::views::transform([](const FunctionScope::Parameter& parameter) -> decltype(auto)
-                                   { return parameter.type; }) |
-             std::ranges::to<std::vector>());
+     auto functionContext =
+         std::make_shared<FunctionContext>(functionScope.get(), node.Signature().callingConvention, returnType, name,
+                                           parameters |
+                                               std::views::transform(
+                                                   [](const FunctionScope::Parameter& parameter) -> decltype(auto)
+                                                   {
+                                                        return parameter.type;
+                                                   }) |
+                                               std::ranges::to<std::vector>());
 
      ir.GetContext() = this->GetContext();
      auto* vFunctionScope = functionScope.get();
@@ -929,7 +943,10 @@ std::vector<std::string> ecpps::ir::IR::NamespacePathFromContext(void) const
 void ecpps::ir::IR::ParseNamespace(const ast::NamespaceNode& node)
 {
      std::string namespaceName;
-     if (node.Name() != nullptr) { namespaceName = node.Name()->ToString(0); }
+     if (node.Name() != nullptr)
+     {
+          namespaceName = node.Name()->ToString(0);
+     }
 
      auto& parentScope = this->GetContext().contextSequence.back()->GetScope();
      auto* parentNamespace = dynamic_cast<NamespaceScope*>(&parentScope);
@@ -1556,7 +1573,10 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
      std::vector<std::string> qualifiers;
      bool isFromGlobalNamespace = false;
 
-     if (auto* id = dynamic_cast<ast::IdentifierNode*>(node.Function().get())) { identifierFunction = id; }
+     if (auto* id = dynamic_cast<ast::IdentifierNode*>(node.Function().get()))
+     {
+          identifierFunction = id;
+     }
      else if (auto* qid = dynamic_cast<ast::QualifiedIdNode*>(node.Function().get()))
      {
           const auto& parts = qid->Path();
@@ -1622,7 +1642,9 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
 
                     auto it = std::ranges::find_if(namespaceScope->subNamespaces,
                                                    [&qualifier](const std::unique_ptr<ecpps::ir::NamespaceScope>& ns)
-                                                   { return ns->Name() == qualifier; });
+                                                   {
+                                                        return ns->Name() == qualifier;
+                                                   });
                     if (it == namespaceScope->subNamespaces.end())
                     {
                          matchesQualifiers = false;
@@ -1635,8 +1657,11 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
           }
 
           std::vector<Expression> arguments = node.Arguments() |
-                                              std::views::transform([this](const ast::NodePointer& argument)
-                                                                    { return this->ParseExpression(argument); }) |
+                                              std::views::transform(
+                                                  [this](const ast::NodePointer& argument)
+                                                  {
+                                                       return this->ParseExpression(argument);
+                                                  }) |
                                               std::ranges::to<std::vector>();
 
           for (const auto& candidate : scope->functions)
@@ -1674,10 +1699,13 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
 
      std::string errorMessage = "Unresolved function " + name;
 
-     std::vector<Expression> argumentsForAnalysis =
-         node.Arguments() |
-         std::views::transform([this](const ast::NodePointer& argument) { return this->ParseExpression(argument); }) |
-         std::ranges::to<std::vector>();
+     std::vector<Expression> argumentsForAnalysis = node.Arguments() |
+                                                    std::views::transform(
+                                                        [this](const ast::NodePointer& argument)
+                                                        {
+                                                             return this->ParseExpression(argument);
+                                                        }) |
+                                                    std::ranges::to<std::vector>();
 
      auto exactMatches = CollectExactMatches(name, this->GetContext().contextSequence);
      if (!exactMatches.empty())
@@ -2100,7 +2128,10 @@ Expression ecpps::ir::IR::ParseListInitialisation(const ast::NodePointer& expres
           if (parsedInit == nullptr) return nullptr;
           initialisers.push_back(std::move(parsedInit));
      }
-     if (initialisers.empty()) { return ParseValueInitialisation(desiredType); }
+     if (initialisers.empty())
+     {
+          return ParseValueInitialisation(desiredType);
+     }
      if (initialisers.size() == 1 && !IsReference(desiredType))
      {
           auto initialiserExpression = std::move(initialisers.front());
@@ -2215,7 +2246,10 @@ bool ecpps::ir::IR::IsNarrowingConversion([[maybe_unused]] const Expression& exp
                }
           }
 
-          const auto has = [&](std::string_view t) { return std::ranges::contains(tokens, t); };
+          const auto has = [&](std::string_view t)
+          {
+               return std::ranges::contains(tokens, t);
+          };
 
           const auto longCount = std::ranges::count(tokens, "long");
 
@@ -2242,7 +2276,10 @@ bool ecpps::ir::IR::IsNarrowingConversion([[maybe_unused]] const Expression& exp
                return fallbackRequest;
           }
 
-          if (isChar && !isSigned && !isUnsigned) { signedRequest.isCharWithoutSign = true; }
+          if (isChar && !isSigned && !isUnsigned)
+          {
+               signedRequest.isCharWithoutSign = true;
+          }
           else
           {
                signedRequest.signedness =

--- a/compiler/ecpps/src/Execution/IR.cpp
+++ b/compiler/ecpps/src/Execution/IR.cpp
@@ -94,7 +94,7 @@ namespace
      }
 
      std::vector<std::shared_ptr<ecpps::ir::FunctionScope>> CollectExactMatches(
-         const std::string& name, std::deque<ecpps::ir::ContextPointer>& contextSequence)
+          const std::string& name, std::deque<ecpps::ir::ContextPointer>& contextSequence)
      {
           std::vector<std::shared_ptr<ecpps::ir::FunctionScope>> exactMatches;
           for (const auto& context : contextSequence)
@@ -105,7 +105,7 @@ namespace
      }
 
      std::vector<std::pair<std::string, std::size_t>> CollectSimilarNames(
-         const std::string& name, std::size_t argumentCount, std::deque<ecpps::ir::ContextPointer>& contextSequence)
+          const std::string& name, std::size_t argumentCount, std::deque<ecpps::ir::ContextPointer>& contextSequence)
      {
           std::vector<std::pair<std::string, std::size_t>> similar;
           std::set<std::string> seen;
@@ -129,7 +129,7 @@ namespace
 
                     const std::size_t paramCount = func->parameters.size();
                     const std::size_t argPenalty =
-                        (paramCount > argumentCount) ? (paramCount - argumentCount) : (argumentCount - paramCount);
+                         (paramCount > argumentCount) ? (paramCount - argumentCount) : (argumentCount - paramCount);
 
                     const std::size_t score = nameDistance + (argPenalty * 2);
 
@@ -149,7 +149,7 @@ namespace
      }
 
      std::vector<std::pair<std::string, std::size_t>> CollectSimilarIdentifierNames(
-         const std::string& name, std::deque<ecpps::ir::ContextPointer>& contextSequence)
+          const std::string& name, std::deque<ecpps::ir::ContextPointer>& contextSequence)
      {
           std::vector<std::pair<std::string, std::size_t>> similar;
           std::set<std::string> seen;
@@ -209,9 +209,9 @@ namespace
           {
                using std::string_view_literals::operator""sv;
                info.parameterFailures.emplace_back(
-                   static_cast<std::size_t>(-1),
-                   std::format("Expected {} argument{}, got {}", function->parameters.size(),
-                               function->parameters.size() == 1 ? ""sv : "s"sv, arguments.size()));
+                    static_cast<std::size_t>(-1),
+                    std::format("Expected {} argument{}, got {}", function->parameters.size(),
+                                function->parameters.size() == 1 ? ""sv : "s"sv, arguments.size()));
                return info;
           }
 
@@ -223,7 +223,7 @@ namespace
                if (argument == nullptr)
                {
                     info.parameterFailures.emplace_back(
-                        paramIndex, std::format("Parameter {}: Invalid argument expression", paramIndex));
+                         paramIndex, std::format("Parameter {}: Invalid argument expression", paramIndex));
                     paramIndex++;
                     continue;
                }
@@ -270,9 +270,9 @@ std::vector<IRNodePointer> ecpps::ir::IR::Parse(Diagnostics& diagnostics, BumpAl
      ir.GetContext().globalScope->types.insert(signedCharType);
      TypeRequest unsignedCharRequest{.kind = TypeKind::Fundamental,
                                      .data =
-                                         StandardSignedIntegerRequest{.size = typeSystem::TypeKind::Char,
-                                                                      .signedness = typeSystem::Signedness::Unsigned,
-                                                                      .isCharWithoutSign = false}};
+                                          StandardSignedIntegerRequest{.size = typeSystem::TypeKind::Char,
+                                                                       .signedness = typeSystem::Signedness::Unsigned,
+                                                                       .isCharWithoutSign = false}};
      const auto* unsignedCharType = GetTypeContext().Get(unsignedCharRequest);
      ir.GetContext().globalScope->types.insert(unsignedCharType);
      TypeRequest shortRequest{.kind = TypeKind::Fundamental,
@@ -301,9 +301,9 @@ std::vector<IRNodePointer> ecpps::ir::IR::Parse(Diagnostics& diagnostics, BumpAl
      ir.GetContext().globalScope->types.insert(longLongType);
      TypeRequest unsignedShortRequest{.kind = TypeKind::Fundamental,
                                       .data =
-                                          StandardSignedIntegerRequest{.size = typeSystem::TypeKind::Short,
-                                                                       .signedness = typeSystem::Signedness::Unsigned,
-                                                                       .isCharWithoutSign = false}};
+                                           StandardSignedIntegerRequest{.size = typeSystem::TypeKind::Short,
+                                                                        .signedness = typeSystem::Signedness::Unsigned,
+                                                                        .isCharWithoutSign = false}};
      const auto* unsignedShortType = GetTypeContext().Get(unsignedShortRequest);
      ir.GetContext().globalScope->types.insert(unsignedShortType);
      TypeRequest unsignedIntRequest{.kind = TypeKind::Fundamental,
@@ -314,16 +314,16 @@ std::vector<IRNodePointer> ecpps::ir::IR::Parse(Diagnostics& diagnostics, BumpAl
      ir.GetContext().globalScope->types.insert(unsignedIntType);
      TypeRequest unsignedLongRequest{.kind = TypeKind::Fundamental,
                                      .data =
-                                         StandardSignedIntegerRequest{.size = typeSystem::TypeKind::Long,
-                                                                      .signedness = typeSystem::Signedness::Unsigned,
-                                                                      .isCharWithoutSign = false}};
+                                          StandardSignedIntegerRequest{.size = typeSystem::TypeKind::Long,
+                                                                       .signedness = typeSystem::Signedness::Unsigned,
+                                                                       .isCharWithoutSign = false}};
      const auto* unsignedLongType = GetTypeContext().Get(unsignedLongRequest);
      ir.GetContext().globalScope->types.insert(unsignedLongType);
      TypeRequest unsignedLongLongRequest{
-         .kind = TypeKind::Fundamental,
-         .data = StandardSignedIntegerRequest{.size = typeSystem::TypeKind::LongLong,
-                                              .signedness = typeSystem::Signedness::Unsigned,
-                                              .isCharWithoutSign = false}};
+          .kind = TypeKind::Fundamental,
+          .data = StandardSignedIntegerRequest{.size = typeSystem::TypeKind::LongLong,
+                                               .signedness = typeSystem::Signedness::Unsigned,
+                                               .isCharWithoutSign = false}};
      const auto* unsignedLongLongType = GetTypeContext().Get(unsignedLongLongRequest);
      ir.GetContext().globalScope->types.insert(unsignedLongLongType);
      ir.GetContext().contextSequence.push_back(std::make_unique<NamespaceContext>(ir.GetContext().globalScope.get()));
@@ -372,8 +372,8 @@ void ecpps::ir::IR::ParseNode(const ast::NodePointer& node)
           if (targetType == nullptr)
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "Invalid target type in using declaration", aliasNode->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "Invalid target type in using declaration", aliasNode->Source()));
                return;
           }
 
@@ -406,13 +406,13 @@ void ecpps::ir::IR::ParseFunctionDeclaration(const ast::FunctionDeclarationNode&
      if (node.Signature().externOptional.has_value())
      {
           const std::string& languageLinkage =
-              node.Signature().externOptional.value(); // NOLINT(bugprone-unchecked-optional-access)
+               node.Signature().externOptional.value(); // NOLINT(bugprone-unchecked-optional-access)
           if (languageLinkage == "C") linkage = abi::Linkage::CLinkage;
           else
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
-                       "Invalid language linkage specification", node.Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
+                         "Invalid language linkage specification", node.Source()));
           }
      }
      else if (node.Signature().isInline ||
@@ -443,24 +443,24 @@ void ecpps::ir::IR::ParseFunctionDeclaration(const ast::FunctionDeclarationNode&
 
      const std::string name = node.Signature().name == nullptr ? "__unknown_func" : node.Signature().name->ToString(0);
      auto functionScope =
-         MakeFunctionScope()
-             .Name(name)
-             .ReturnType(returnType)
-             .CallingConvention(node.Signature().callingConvention)
-             .Linkage(linkage)
-             .IsDllImportExport(isDllImportExport)
-             .DllImportName(dllImportName)
-             .IsExtern(node.Signature().isExtern)
-             .IsFriend(node.Signature().isFriend)
-             .IsInline(node.Signature().isInline)
-             .IsStatic(false) // TODO: node.Signature().isStatic
-             .ConstexprSpecifier(node.Signature().constexprSpecifier == ast::ConstantExpressionSpecifier::Constexpr
-                                     ? ecpps::ir::ConstexprType::Constexpr
-                                     : ecpps::ir::ConstexprType::None)
-             .Parameters(parameters)
-             .Source(node.Source())
-             .NamespacePath(namespacePath)
-             .Build();
+          MakeFunctionScope()
+               .Name(name)
+               .ReturnType(returnType)
+               .CallingConvention(node.Signature().callingConvention)
+               .Linkage(linkage)
+               .IsDllImportExport(isDllImportExport)
+               .DllImportName(dllImportName)
+               .IsExtern(node.Signature().isExtern)
+               .IsFriend(node.Signature().isFriend)
+               .IsInline(node.Signature().isInline)
+               .IsStatic(false) // TODO: node.Signature().isStatic
+               .ConstexprSpecifier(node.Signature().constexprSpecifier == ast::ConstantExpressionSpecifier::Constexpr
+                                        ? ecpps::ir::ConstexprType::Constexpr
+                                        : ecpps::ir::ConstexprType::None)
+               .Parameters(parameters)
+               .Source(node.Source())
+               .NamespacePath(namespacePath)
+               .Build();
      functionScope->parameters = parameters;
      this->GetContext().contextSequence.back()->GetScope().functions.push_back(std::move(functionScope));
 }
@@ -480,13 +480,13 @@ void ecpps::ir::IR::ParseFunctionDefinition(const ast::FunctionDefinitionNode& n
      if (node.Signature().externOptional.has_value())
      {
           const std::string& languageLinkage =
-              node.Signature().externOptional.value(); // NOLINT(bugprone-unchecked-optional-access)
+               node.Signature().externOptional.value(); // NOLINT(bugprone-unchecked-optional-access)
           if (languageLinkage == "C") linkage = abi::Linkage::CLinkage;
           else
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
-                       "Invalid language linkage specification", node.Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
+                         "Invalid language linkage specification", node.Source()));
           }
      }
      else if (node.Signature().isInline ||
@@ -518,35 +518,35 @@ void ecpps::ir::IR::ParseFunctionDefinition(const ast::FunctionDefinitionNode& n
 
      const std::string name = node.Signature().name == nullptr ? "__unknown_func" : node.Signature().name->ToString(0);
      auto functionScope =
-         MakeFunctionScope()
-             .Name(name)
-             .ReturnType(returnType)
-             .CallingConvention(node.Signature().callingConvention)
-             .Linkage(linkage)
-             .IsDllImportExport(isDllImportExport)
-             .DllImportName(dllImportName)
-             .IsExtern(node.Signature().isExtern)
-             .IsFriend(node.Signature().isFriend)
-             .IsInline(node.Signature().isInline)
-             .IsStatic(false) // TODO: node.Signature().isStatic
-             .ConstexprSpecifier(node.Signature().constexprSpecifier == ast::ConstantExpressionSpecifier::Constexpr
-                                     ? ecpps::ir::ConstexprType::Constexpr
-                                     : ecpps::ir::ConstexprType::None)
-             .Parameters(parameters)
-             .Source(node.Source())
-             .NamespacePath(namespacePath)
-             .Build();
+          MakeFunctionScope()
+               .Name(name)
+               .ReturnType(returnType)
+               .CallingConvention(node.Signature().callingConvention)
+               .Linkage(linkage)
+               .IsDllImportExport(isDllImportExport)
+               .DllImportName(dllImportName)
+               .IsExtern(node.Signature().isExtern)
+               .IsFriend(node.Signature().isFriend)
+               .IsInline(node.Signature().isInline)
+               .IsStatic(false) // TODO: node.Signature().isStatic
+               .ConstexprSpecifier(node.Signature().constexprSpecifier == ast::ConstantExpressionSpecifier::Constexpr
+                                        ? ecpps::ir::ConstexprType::Constexpr
+                                        : ecpps::ir::ConstexprType::None)
+               .Parameters(parameters)
+               .Source(node.Source())
+               .NamespacePath(namespacePath)
+               .Build();
      functionScope->parameters = parameters;
      functionScope->linkage = linkage;
      auto functionContext =
-         std::make_shared<FunctionContext>(functionScope.get(), node.Signature().callingConvention, returnType, name,
-                                           parameters |
-                                               std::views::transform(
-                                                   [](const FunctionScope::Parameter& parameter) -> decltype(auto)
-                                                   {
-                                                        return parameter.type;
-                                                   }) |
-                                               std::ranges::to<std::vector>());
+          std::make_shared<FunctionContext>(functionScope.get(), node.Signature().callingConvention, returnType, name,
+                                            parameters |
+                                                 std::views::transform(
+                                                      [](const FunctionScope::Parameter& parameter) -> decltype(auto)
+                                                      {
+                                                           return parameter.type;
+                                                      }) |
+                                                 std::ranges::to<std::vector>());
 
      ir.GetContext() = this->GetContext();
      auto* vFunctionScope = functionScope.get();
@@ -555,7 +555,7 @@ void ecpps::ir::IR::ParseFunctionDefinition(const ast::FunctionDefinitionNode& n
      ir.GetContext().contextSequence.push_back(std::move(functionContext));
      std::uint64_t paramIndex{};
      std::shared_ptr<std::vector<FunctionScope::LocalEntity>> locals =
-         std::make_shared<std::vector<FunctionScope::LocalEntity>>();
+          std::make_shared<std::vector<FunctionScope::LocalEntity>>();
      locals->reserve(parameters.size());
      vFunctionScope->SetLocals(locals);
 
@@ -566,34 +566,34 @@ void ecpps::ir::IR::ParseFunctionDefinition(const ast::FunctionDefinitionNode& n
           locals->push_back(std::move(localEntity));
 
           auto paramNode = std::make_unique<PRValue>(
-              param.type,
-              std::unique_ptr<ParameterNode, IRDeleter>(new (*this->GetContext().nodeAllocator)
-                                                            ParameterNode(paramIndex++, node.Source())),
-              false);
+               param.type,
+               std::unique_ptr<ParameterNode, IRDeleter>(new (*this->GetContext().nodeAllocator)
+                                                              ParameterNode(paramIndex++, node.Source())),
+               false);
 
           ir._built.push_back(std::unique_ptr<ir::StoreNode, IRDeleter>{
-              new (*this->GetContext().nodeAllocator) ir::StoreNode(param.name, std::move(paramNode), node.Source())});
+               new (*this->GetContext().nodeAllocator) ir::StoreNode(param.name, std::move(paramNode), node.Source())});
      }
 
      for (const auto& line : node.Body()) ir.ParseNode(line);
 
      if (returnType != nullptr && typeSystem::g_void->CommonWith(returnType))
           ir._built.push_back(std::unique_ptr<ir::ReturnNode, IRDeleter>{new (*ir.GetContext().nodeAllocator)
-                                                                             ir::ReturnNode(nullptr, node.Source())});
+                                                                              ir::ReturnNode(nullptr, node.Source())});
 
      if (name == "main" && (ir._built.empty() || ir._built.back()->Kind() != NodeKind::Return))
           ir._built.push_back(
-              std::unique_ptr<ir::ReturnNode, IRDeleter>{new (*ir.GetContext().nodeAllocator) ir::ReturnNode(
-                  std::make_unique<PRValue>(typeSystem::g_int.get(),
-                                            std::unique_ptr<IntegralNode, IRDeleter>{new (
-                                                *ir.GetContext().nodeAllocator) ir::IntegralNode(0, node.Source())},
-                                            true),
-                  node.Source())});
+               std::unique_ptr<ir::ReturnNode, IRDeleter>{new (*ir.GetContext().nodeAllocator) ir::ReturnNode(
+                    std::make_unique<PRValue>(typeSystem::g_int.get(),
+                                              std::unique_ptr<IntegralNode, IRDeleter>{new (
+                                                   *ir.GetContext().nodeAllocator) ir::IntegralNode(0, node.Source())},
+                                              true),
+                    node.Source())});
 
      this->_built.push_back(std::unique_ptr<ecpps::ir::ProcedureNode, IRDeleter>{
-         new (*this->GetContext().nodeAllocator) ecpps::ir::ProcedureNode(
-             linkage, node.Signature().callingConvention, returnType, name, std::move(parameters), std::move(locals),
-             std::move(ir._built), node.Source(), NamespacePathFromContext())});
+          new (*this->GetContext().nodeAllocator) ecpps::ir::ProcedureNode(
+               linkage, node.Signature().callingConvention, returnType, name, std::move(parameters), std::move(locals),
+               std::move(ir._built), node.Source(), NamespacePathFromContext())});
 
      this->GetContext().contextSequence.pop_back();
 }
@@ -609,13 +609,13 @@ void ecpps::ir::IR::ParseReturn(const ast::ReturnNode& node)
           if (!typeSystem::g_void->CommonWith(function->returnType)) // NOLINT(clang-analyzer-core.NullDereference)
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "Cannot convert from void to type " + function->returnType->Name() + " (aka " +
-                           function->returnType->RawName() + ")",
-                       node.Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "Cannot convert from void to type " + function->returnType->Name() + " (aka " +
+                              function->returnType->RawName() + ")",
+                         node.Source()));
           }
           this->_built.push_back(std::unique_ptr<ir::ReturnNode, IRDeleter>{
-              new (*this->GetContext().nodeAllocator) ir::ReturnNode(nullptr, node.Source())});
+               new (*this->GetContext().nodeAllocator) ir::ReturnNode(nullptr, node.Source())});
      }
 
      auto returnExpression = ParseExpression(node.Value());
@@ -625,12 +625,12 @@ void ecpps::ir::IR::ParseReturn(const ast::ReturnNode& node)
      {
           auto& value = *optionalConstexpr;
           returnExpression =
-              ConstantEvaluationResultToExpression(value, returnExpression->Type(), *this->GetContext().nodeAllocator);
+               ConstantEvaluationResultToExpression(value, returnExpression->Type(), *this->GetContext().nodeAllocator);
      }
 
      auto converted = ConvertTo(std::move(returnExpression), function->returnType);
      this->_built.push_back(std::unique_ptr<ir::ReturnNode, IRDeleter>{
-         new (*this->GetContext().nodeAllocator) ir::ReturnNode(std::move(converted), node.Source())});
+          new (*this->GetContext().nodeAllocator) ir::ReturnNode(std::move(converted), node.Source())});
 }
 
 void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode& node)
@@ -641,8 +641,9 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
           if (declaredType == nullptr)
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       std::format("Unknown type {} in typedef declaration", node.Type()->ToString(0)), node.Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         std::format("Unknown type {} in typedef declaration", node.Type()->ToString(0)),
+                         node.Source()));
                return;
           }
 
@@ -654,8 +655,8 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
                if (idExpr == nullptr)
                {
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
-                            "Expected identifier in typedef declarator", decl.name->Source()));
+                         diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
+                              "Expected identifier in typedef declarator", decl.name->Source()));
                     continue;
                }
 
@@ -675,8 +676,8 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
      if (declaredType == nullptr)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  std::format("Unknown type {} in variable declaration", node.Type()->ToString(0)), node.Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    std::format("Unknown type {} in variable declaration", node.Type()->ToString(0)), node.Source()));
           return;
      }
 
@@ -687,8 +688,8 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
           if (idExpr == nullptr)
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
-                       "Expected identifier in variable declarator", decl.name->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
+                         "Expected identifier in variable declarator", decl.name->Source()));
                continue;
           }
 
@@ -701,12 +702,12 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
           {
                if (inferLastArrayFromInitialiser)
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        std::make_unique<diagnostics::TypeError>(
-                            std::format(
-                                "Declaration of '{}' introduces an array of unbounded arrays which is not allowed, "
-                                "only the top-level array might be unbounded",
-                                varName),
-                            arrayLevel == nullptr ? node.Source() : arrayLevel->Source()));
+                         std::make_unique<diagnostics::TypeError>(
+                              std::format(
+                                   "Declaration of '{}' introduces an array of unbounded arrays which is not allowed, "
+                                   "only the top-level array might be unbounded",
+                                   varName),
+                              arrayLevel == nullptr ? node.Source() : arrayLevel->Source()));
 
                if (arrayLevel == nullptr)
                {
@@ -718,21 +719,21 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
                if (arrayLevelExpression == nullptr) break; // assume the caller issued diagnostics
 
                auto constexprArraySize =
-                   arrayLevelExpression->Value()->TryConstantEvaluate(EvaluationContext{.currentDepth = 0});
+                    arrayLevelExpression->Value()->TryConstantEvaluate(EvaluationContext{.currentDepth = 0});
                if (!constexprArraySize.has_value())
                {
                     inferLastArrayFromInitialiser = true; // at least try to be useful...
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        std::make_unique<diagnostics::TypeError>(
-                            std::format("Arrays bounds must be defined by a constant expression", varName),
-                            arrayLevel == nullptr ? node.Source() : arrayLevel->Source()));
+                         std::make_unique<diagnostics::TypeError>(
+                              std::format("Arrays bounds must be defined by a constant expression", varName),
+                              arrayLevel == nullptr ? node.Source() : arrayLevel->Source()));
 
                     auto& nestedDiagnostics = constexprArraySize.error();
 
                     while (!nestedDiagnostics.empty())
                     {
                          this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                             std::move(nestedDiagnostics.top()));
+                              std::move(nestedDiagnostics.top()));
                          nestedDiagnostics.pop();
                     }
                     break;
@@ -742,9 +743,9 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
                {
                     inferLastArrayFromInitialiser = true; // at least try to be useful...
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        std::make_unique<diagnostics::TypeError>(
-                            std::format("Arrays bounds must be defined by an integer", varName),
-                            arrayLevel == nullptr ? node.Source() : arrayLevel->Source()));
+                         std::make_unique<diagnostics::TypeError>(
+                              std::format("Arrays bounds must be defined by an integer", varName),
+                              arrayLevel == nullptr ? node.Source() : arrayLevel->Source()));
                     break;
                }
                const auto length = std::get<std::uint64_t>(arraySize.variant);
@@ -779,8 +780,8 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
           if (duplicate)
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "Redefinition of variable '" + varName + "'", decl.name->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "Redefinition of variable '" + varName + "'", decl.name->Source()));
                continue;
           }
 
@@ -794,14 +795,14 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
                if (decl.initialiser == nullptr)
                {
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                            std::format("Unbounded array '{}' must have an initialiser", varName),
-                            decl.name->Source()));
+                         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                              std::format("Unbounded array '{}' must have an initialiser", varName),
+                              decl.name->Source()));
                }
                if (IsEligibleForStringLiteralInitialisation(variableType))
                {
                     if (auto* const stringInitialiser =
-                            dynamic_cast<ecpps::ast::StringLiteralNode*>(decl.initialiser.get());
+                             dynamic_cast<ecpps::ast::StringLiteralNode*>(decl.initialiser.get());
                         stringInitialiser != nullptr)
                     {
                          const auto& string = stringInitialiser->Value();
@@ -821,23 +822,23 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
                          for (const auto character : string) arrayValues.emplace_back(character);
                          arrayValues.emplace_back(0u);
                          std::unique_ptr<ecpps::ir::IntegerArrayNode, IRDeleter> arrayNode{
-                             new (*this->GetContext().nodeAllocator) ecpps::ir::IntegerArrayNode(
-                                 std::move(arrayValues), elementType, decl.initialiser->Source())};
+                              new (*this->GetContext().nodeAllocator) ecpps::ir::IntegerArrayNode(
+                                   std::move(arrayValues), elementType, decl.initialiser->Source())};
                          auto initialiserExpression =
-                             std::make_unique<ecpps::PRValue>(variableType, std::move(arrayNode), true);
+                              std::make_unique<ecpps::PRValue>(variableType, std::move(arrayNode), true);
 
                          this->_built.push_back(std::unique_ptr<ir::StoreNode, IRDeleter>{
-                             new (*this->GetContext().nodeAllocator)
-                                 ir::StoreNode(registeredVar.Name().value_or("__unknown_local_variable"),
-                                               std::move(initialiserExpression), decl.initialiser->Source())});
+                              new (*this->GetContext().nodeAllocator)
+                                   ir::StoreNode(registeredVar.Name().value_or("__unknown_local_variable"),
+                                                 std::move(initialiserExpression), decl.initialiser->Source())});
                     }
                }
                if (inferLastArrayFromInitialiser)
                {
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                            std::format("Array '{}' must be initialised with initialiser-lists", varName),
-                            decl.name->Source()));
+                         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                              std::format("Array '{}' must be initialised with initialiser-lists", varName),
+                              decl.name->Source()));
                }
 
                registeredVar.type = variableType;
@@ -848,8 +849,8 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
                if (initExpr == nullptr)
                {
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                            "Invalid initialiser for variable '" + varName + "'", decl.initialiser->Source()));
+                         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                              "Invalid initialiser for variable '" + varName + "'", decl.initialiser->Source()));
                     continue;
                }
                if (isArray)
@@ -860,25 +861,25 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
                     if (IsEligibleForStringLiteralInitialisation(arrayType->ElementType()))
                     {
                          if (auto* const stringInitialiser =
-                                 dynamic_cast<ecpps::ast::StringLiteralNode*>(decl.initialiser.get());
+                                  dynamic_cast<ecpps::ast::StringLiteralNode*>(decl.initialiser.get());
                              stringInitialiser != nullptr)
                          {
                               const auto& string = stringInitialiser->Value();
                               const auto arrayLength = string.length() + 1;
                               const auto* elementType =
-                                  arrayType->ElementType()->CastTo<ecpps::typeSystem::CharacterType>();
+                                   arrayType->ElementType()->CastTo<ecpps::typeSystem::CharacterType>();
                               runtime_assert(elementType != nullptr,
                                              "Expected a character type for string-literal initialisation");
 
                               if (arrayLength > arrayType->ElementCount())
                               {
                                    this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                                       diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                                           std::format("Cannot initialise an array with more elements than it can "
-                                                       "hold. Provided {} elements for an array of `{}` `{}`s",
-                                                       arrayLength, arrayType->ElementCount(),
-                                                       arrayType->ElementType()->RawName()),
-                                           decl.initialiser->Source()));
+                                        diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                                             std::format("Cannot initialise an array with more elements than it can "
+                                                         "hold. Provided {} elements for an array of `{}` `{}`s",
+                                                         arrayLength, arrayType->ElementCount(),
+                                                         arrayType->ElementType()->RawName()),
+                                             decl.initialiser->Source()));
                               }
 
                               std::vector<std::uint32_t> arrayValues{};
@@ -890,24 +891,24 @@ void ecpps::ir::IR::ParseVariableDeclaration(const ast::VariableDeclarationNode&
                                    arrayValues.resize(arrayType->ElementCount());
 
                               std::unique_ptr<ecpps::ir::IntegerArrayNode, IRDeleter> arrayNode{
-                                  new (*this->GetContext().nodeAllocator) ecpps::ir::IntegerArrayNode(
-                                      std::move(arrayValues), elementType, decl.initialiser->Source())};
+                                   new (*this->GetContext().nodeAllocator) ecpps::ir::IntegerArrayNode(
+                                        std::move(arrayValues), elementType, decl.initialiser->Source())};
                               auto initialiserExpression =
-                                  std::make_unique<ecpps::PRValue>(variableType, std::move(arrayNode), true);
+                                   std::make_unique<ecpps::PRValue>(variableType, std::move(arrayNode), true);
 
                               this->_built.push_back(std::unique_ptr<ir::StoreNode, IRDeleter>{
-                                  new (*this->GetContext().nodeAllocator)
-                                      ir::StoreNode(registeredVar.Name().value_or("__unknown_local_variable"),
-                                                    std::move(initialiserExpression), decl.initialiser->Source())});
+                                   new (*this->GetContext().nodeAllocator)
+                                        ir::StoreNode(registeredVar.Name().value_or("__unknown_local_variable"),
+                                                      std::move(initialiserExpression), decl.initialiser->Source())});
                          }
                          continue;
                     }
                }
 
                this->_built.push_back(std::unique_ptr<ir::StoreNode, IRDeleter>{
-                   new (*this->GetContext().nodeAllocator)
-                       ir::StoreNode(registeredVar.Name().value_or("__unknown_local_variable"), std::move(initExpr),
-                                     decl.initialiser->Source())});
+                    new (*this->GetContext().nodeAllocator)
+                         ir::StoreNode(registeredVar.Name().value_or("__unknown_local_variable"), std::move(initExpr),
+                                       decl.initialiser->Source())});
           }
           else
           {
@@ -1018,10 +1019,10 @@ Expression ecpps::ir::IR::ParseAdditiveExpression(Expression left, ast::Operator
                if (!isPlus)
                {
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                            std::format("Cannot subtract a pointer of type `{}` from an integer of type `{}`",
-                                        rightPointer->RawName(), leftIntegral->RawName()),
-                            source));
+                         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                              std::format("Cannot subtract a pointer of type `{}` from an integer of type `{}`",
+                                          rightPointer->RawName(), leftIntegral->RawName()),
+                              source));
                     return nullptr;
                }
 
@@ -1039,8 +1040,8 @@ Expression ecpps::ir::IR::ParseAdditiveExpression(Expression left, ast::Operator
 
                right = std::make_unique<PRValue>(rightIntegral,
                                                  std::unique_ptr<ConvertNode, IRDeleter>{
-                                                     new (*this->GetContext().nodeAllocator)
-                                                         ConvertNode(std::move(right), rightIntegral, innerSource)},
+                                                      new (*this->GetContext().nodeAllocator)
+                                                           ConvertNode(std::move(right), rightIntegral, innerSource)},
                                                  wasConstexpr);
           }
 
@@ -1048,17 +1049,17 @@ Expression ecpps::ir::IR::ParseAdditiveExpression(Expression left, ast::Operator
           {
                return std::make_unique<PRValue>(leftPointer,
                                                 std::unique_ptr<SubtractionNode, IRDeleter>{
-                                                    new (*this->GetContext().nodeAllocator)
-                                                        SubtractionNode(std::move(left), std::move(right), source)},
+                                                     new (*this->GetContext().nodeAllocator)
+                                                          SubtractionNode(std::move(left), std::move(right), source)},
                                                 false);
           }
 
           // ptr + int
           return std::make_unique<PRValue>(
-              leftPointer,
-              std::unique_ptr<AdditionNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                           AdditionNode(std::move(left), std::move(right), source)},
-              false);
+               leftPointer,
+               std::unique_ptr<AdditionNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                             AdditionNode(std::move(left), std::move(right), source)},
+               false);
      }
 
      if (leftPointer != nullptr && rightPointer != nullptr)
@@ -1066,17 +1067,17 @@ Expression ecpps::ir::IR::ParseAdditiveExpression(Expression left, ast::Operator
           if (operator_ != ast::Operator::Minus)
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build("Cannot add two pointers", source));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build("Cannot add two pointers", source));
                return nullptr;
           }
 
           if (leftPointer->BaseType() != rightPointer->BaseType())
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "Cannot subtract pointers to different types (" + left->Type()->Name() + " and " +
-                           right->Type()->Name() + ")",
-                       source));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "Cannot subtract pointers to different types (" + left->Type()->Name() + " and " +
+                              right->Type()->Name() + ")",
+                         source));
                return nullptr;
           }
 
@@ -1087,8 +1088,8 @@ Expression ecpps::ir::IR::ParseAdditiveExpression(Expression left, ast::Operator
 
           return std::make_unique<PRValue>(resultType,
                                            std::unique_ptr<SubtractionNode, IRDeleter>{
-                                               new (*this->GetContext().nodeAllocator)
-                                                   SubtractionNode(std::move(left), std::move(right), source)},
+                                                new (*this->GetContext().nodeAllocator)
+                                                     SubtractionNode(std::move(left), std::move(right), source)},
                                            false);
      }
 
@@ -1097,9 +1098,9 @@ Expression ecpps::ir::IR::ParseAdditiveExpression(Expression left, ast::Operator
           // TODO: Classes
 
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot perform this binary operation on " + left->Type()->Name() + " and " + right->Type()->Name(),
-                  left->Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot perform this binary operation on " + left->Type()->Name() + " and " + right->Type()->Name(),
+                    left->Value()->Source()));
 
           return nullptr;
      }
@@ -1112,10 +1113,10 @@ Expression ecpps::ir::IR::ParseAdditiveExpression(Expression left, ast::Operator
           const auto wasConstexpr = left->IsConstantExpression();
 
           left = std::make_unique<PRValue>(
-              leftIntegral,
-              std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                          ConvertNode(std::move(left), leftIntegral, innerSource)},
-              wasConstexpr);
+               leftIntegral,
+               std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                            ConvertNode(std::move(left), leftIntegral, innerSource)},
+               wasConstexpr);
      }
 
      if (right->Type() != rightIntegral) // got promoted
@@ -1124,41 +1125,42 @@ Expression ecpps::ir::IR::ParseAdditiveExpression(Expression left, ast::Operator
           const auto wasConstexpr = right->IsConstantExpression();
 
           right = std::make_unique<PRValue>(
-              rightIntegral,
-              std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                          ConvertNode(std::move(right), rightIntegral, innerSource)},
-              wasConstexpr);
+               rightIntegral,
+               std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                            ConvertNode(std::move(right), rightIntegral, innerSource)},
+               wasConstexpr);
      }
 
      const auto* resultType = leftIntegral->CommonWith(rightIntegral);
      if (resultType == nullptr)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot find a common integral type between " + left->Type()->Name() + " and " + left->Type()->Name(),
-                  left->Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot find a common integral type between " + left->Type()->Name() + " and " +
+                         left->Type()->Name(),
+                    left->Value()->Source()));
           return nullptr;
      }
 
      if (operator_ == ast::Operator::Plus)
           return std::make_unique<PRValue>(
-              resultType,
-              std::unique_ptr<AdditionNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                           AdditionNode(std::move(left), std::move(right), source)},
-              false);
+               resultType,
+               std::unique_ptr<AdditionNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                             AdditionNode(std::move(left), std::move(right), source)},
+               false);
 
      return std::make_unique<PRValue>(
-         resultType,
-         std::unique_ptr<SubtractionNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                         SubtractionNode(std::move(left), std::move(right), source)},
-         false);
+          resultType,
+          std::unique_ptr<SubtractionNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                           SubtractionNode(std::move(left), std::move(right), source)},
+          false);
 }
 
 Expression ecpps::ir::IR::ParseMultiplicativeExpression(Expression left, ast::Operator operator_, Expression right,
                                                         const Location& source) const
 {
      runtime_assert(operator_ == ast::Operator::Asterisk || operator_ == ast::Operator::Solidus ||
-                        operator_ == ast::Operator::Percent,
+                         operator_ == ast::Operator::Percent,
                     "Operator was not multiplicative in a multiplicative-expression");
 
      const auto* leftIntegral = left->Type()->CastTo<typeSystem::IntegralType>();
@@ -1169,9 +1171,9 @@ Expression ecpps::ir::IR::ParseMultiplicativeExpression(Expression left, ast::Op
           // TODO: Classes
 
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot perform this binary operation on " + left->Type()->Name() + " and " + right->Type()->Name(),
-                  left->Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot perform this binary operation on " + left->Type()->Name() + " and " + right->Type()->Name(),
+                    left->Value()->Source()));
 
           return nullptr;
      }
@@ -1184,10 +1186,10 @@ Expression ecpps::ir::IR::ParseMultiplicativeExpression(Expression left, ast::Op
           const auto wasConstexpr = left->IsConstantExpression();
 
           left = std::make_unique<PRValue>(
-              leftIntegral,
-              std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                          ConvertNode(std::move(left), leftIntegral, innerSource)},
-              wasConstexpr);
+               leftIntegral,
+               std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                            ConvertNode(std::move(left), leftIntegral, innerSource)},
+               wasConstexpr);
      }
 
      if (right->Type() != rightIntegral) // got promoted
@@ -1196,41 +1198,42 @@ Expression ecpps::ir::IR::ParseMultiplicativeExpression(Expression left, ast::Op
           const auto wasConstexpr = right->IsConstantExpression();
 
           right = std::make_unique<PRValue>(
-              rightIntegral,
-              std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                          ConvertNode(std::move(right), rightIntegral, innerSource)},
-              wasConstexpr);
+               rightIntegral,
+               std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                            ConvertNode(std::move(right), rightIntegral, innerSource)},
+               wasConstexpr);
      }
 
      const auto* resultType = leftIntegral->CommonWith(rightIntegral);
      if (resultType == nullptr)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot find a common integral type between " + left->Type()->Name() + " and " + left->Type()->Name(),
-                  left->Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot find a common integral type between " + left->Type()->Name() + " and " +
+                         left->Type()->Name(),
+                    left->Value()->Source()));
           return nullptr;
      }
 
      if (operator_ == ast::Operator::Asterisk)
           return std::make_unique<PRValue>(resultType,
                                            std::unique_ptr<MultiplicationNode, IRDeleter>{
-                                               new (*this->GetContext().nodeAllocator)
-                                                   MultiplicationNode(std::move(left), std::move(right), source)},
+                                                new (*this->GetContext().nodeAllocator)
+                                                     MultiplicationNode(std::move(left), std::move(right), source)},
                                            false);
 
      if (operator_ == ast::Operator::Solidus)
           return std::make_unique<PRValue>(
-              resultType,
-              std::unique_ptr<DivideNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                         DivideNode(std::move(left), std::move(right), source)},
-              false);
+               resultType,
+               std::unique_ptr<DivideNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                           DivideNode(std::move(left), std::move(right), source)},
+               false);
 
      return std::make_unique<PRValue>(
-         resultType,
-         std::unique_ptr<ModuloNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                    ModuloNode(std::move(left), std::move(right), source)},
-         false);
+          resultType,
+          std::unique_ptr<ModuloNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                      ModuloNode(std::move(left), std::move(right), source)},
+          false);
 }
 
 Expression ecpps::ir::IR::ParseShiftExpression([[maybe_unused]] Expression left,
@@ -1272,8 +1275,8 @@ Expression ecpps::ir::IR::ParseDereferenceExpression(Expression operand, const L
           // TODO: Classes
 
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot perform this unary operation on " + operand->Type()->Name(), operand->Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot perform this unary operation on " + operand->Type()->Name(), operand->Value()->Source()));
 
           return nullptr;
      }
@@ -1290,10 +1293,10 @@ Expression ecpps::ir::IR::ParseDereferenceExpression(Expression operand, const L
      // }
 
      return std::make_unique<LValue>(
-         pointerType->BaseType(),
-         std::unique_ptr<DereferenceNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                         DereferenceNode(std::move(operand), source)},
-         false);
+          pointerType->BaseType(),
+          std::unique_ptr<DereferenceNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                           DereferenceNode(std::move(operand), source)},
+          false);
 }
 
 Expression ecpps::ir::IR::ParseAddressOfExpression(Expression operand, const Location& source) const
@@ -1304,8 +1307,8 @@ Expression ecpps::ir::IR::ParseAddressOfExpression(Expression operand, const Loc
      {
 
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "An lvalue is required for a the address-of operator", operand->Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "An lvalue is required for a the address-of operator", operand->Value()->Source()));
 
           return nullptr;
      }
@@ -1319,10 +1322,11 @@ Expression ecpps::ir::IR::ParseAddressOfExpression(Expression operand, const Loc
      pointerRequest.data = PointerRequest{.elementType = operand->Type()};
      const auto* pointerType = GetTypeContext().Get(pointerRequest);
 
-     return std::make_unique<PRValue>(pointerType,
-                                      std::unique_ptr<AddressOfNode, IRDeleter>{new (
-                                          *this->GetContext().nodeAllocator) AddressOfNode(std::move(operand), source)},
-                                      false);
+     return std::make_unique<PRValue>(
+          pointerType,
+          std::unique_ptr<AddressOfNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                         AddressOfNode(std::move(operand), source)},
+          false);
 }
 
 Expression ecpps::ir::IR::ParseSubscriptExpression(Expression left, Expression right, const Location& source) const
@@ -1340,9 +1344,9 @@ Expression ecpps::ir::IR::ParseSubscriptExpression(Expression left, Expression r
          ((rightPointer == nullptr && !rightIsArray) || leftIntegral == nullptr))
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  std::format("Cannot subscript types `{}` and `{}`", left->Type()->Name(), right->Type()->Name()),
-                  source));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    std::format("Cannot subscript types `{}` and `{}`", left->Type()->Name(), right->Type()->Name()),
+                    source));
           return nullptr;
      }
 
@@ -1405,22 +1409,23 @@ Expression ecpps::ir::IR::ParsePreIncrementExpression(Expression operand, const 
           if (!operand->IsLValue())
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "A modifiable lvalue is required for a the builtin pre-increment operator",
-                       operand->Value()->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "A modifiable lvalue is required for a the builtin pre-increment operator",
+                         operand->Value()->Source()));
                return nullptr;
           }
 
           return std::make_unique<LValue>(
-              operandType,
-              std::unique_ptr<AdditionAssignNode, IRDeleter>{new (*this->GetContext().nodeAllocator) AdditionAssignNode(
-                  std::move(operand),
-                  std::make_unique<PRValue>(operandType,
-                                            std::unique_ptr<IntegralNode, IRDeleter>{
-                                                new (*this->GetContext().nodeAllocator) IntegralNode(1, source)},
-                                            true),
-                  source)},
-              false);
+               operandType,
+               std::unique_ptr<AdditionAssignNode, IRDeleter>{
+                    new (*this->GetContext().nodeAllocator) AdditionAssignNode(
+                         std::move(operand),
+                         std::make_unique<PRValue>(operandType,
+                                                   std::unique_ptr<IntegralNode, IRDeleter>{new (
+                                                        *this->GetContext().nodeAllocator) IntegralNode(1, source)},
+                                                   true),
+                         source)},
+               false);
      }
 
      throw TracedException("Not implemented");
@@ -1436,17 +1441,17 @@ Expression ecpps::ir::IR::ParsePostIncrementExpression(Expression operand, const
           if (!operand->IsLValue())
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "A modifiable lvalue is required for a the builtin post-increment operator",
-                       operand->Value()->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "A modifiable lvalue is required for a the builtin post-increment operator",
+                         operand->Value()->Source()));
                return nullptr;
           }
 
           return std::make_unique<PRValue>(
-              operandType,
-              std::unique_ptr<PostIncrementNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                                PostIncrementNode(std::move(operand), 1, source)},
-              false);
+               operandType,
+               std::unique_ptr<PostIncrementNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                                  PostIncrementNode(std::move(operand), 1, source)},
+               false);
      }
 
      throw TracedException("Not implemented");
@@ -1461,23 +1466,23 @@ Expression ecpps::ir::IR::ParsePreDecrementExpression(Expression operand, const 
           if (!operand->IsLValue())
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "A modifiable lvalue is required for a the builtin pre-decrement operator",
-                       operand->Value()->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "A modifiable lvalue is required for a the builtin pre-decrement operator",
+                         operand->Value()->Source()));
                return nullptr;
           }
 
           return std::make_unique<LValue>(
-              operandType,
-              std::unique_ptr<SubtractionAssignNode, IRDeleter>{
-                  new (*this->GetContext().nodeAllocator) SubtractionAssignNode(
-                      std::move(operand),
-                      std::make_unique<PRValue>(operandType,
-                                                std::unique_ptr<IntegralNode, IRDeleter>{
-                                                    new (*this->GetContext().nodeAllocator) IntegralNode(1, source)},
-                                                true),
-                      source)},
-              false);
+               operandType,
+               std::unique_ptr<SubtractionAssignNode, IRDeleter>{
+                    new (*this->GetContext().nodeAllocator) SubtractionAssignNode(
+                         std::move(operand),
+                         std::make_unique<PRValue>(operandType,
+                                                   std::unique_ptr<IntegralNode, IRDeleter>{new (
+                                                        *this->GetContext().nodeAllocator) IntegralNode(1, source)},
+                                                   true),
+                         source)},
+               false);
      }
 
      throw TracedException("Not implemented");
@@ -1493,17 +1498,17 @@ Expression ecpps::ir::IR::ParsePostDecrementExpression(Expression operand, const
           if (!operand->IsLValue())
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "A modifiable lvalue is required for a the builtin post-decrement operator",
-                       operand->Value()->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "A modifiable lvalue is required for a the builtin post-decrement operator",
+                         operand->Value()->Source()));
                return nullptr;
           }
 
           return std::make_unique<PRValue>(
-              operandType,
-              std::unique_ptr<PostDecrementNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                                PostDecrementNode(std::move(operand), 1, source)},
-              false);
+               operandType,
+               std::unique_ptr<PostDecrementNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                                  PostDecrementNode(std::move(operand), 1, source)},
+               false);
      }
 
      throw TracedException("Not implemented");
@@ -1523,12 +1528,12 @@ Expression ecpps::ir::IR::ParseUnaryExpression(const ast::UnaryOperatorNode& nod
      case ast::Operator::Ampersand: return this->ParseAddressOfExpression(std::move(operand), node.Source());
      case ast::Operator::Increment:
           return node.UnaryType() == ast::UnaryOperatorType::Prefix
-                     ? this->ParsePreIncrementExpression(std::move(operand), node.Source())
-                     : this->ParsePostIncrementExpression(std::move(operand), node.Source());
+                      ? this->ParsePreIncrementExpression(std::move(operand), node.Source())
+                      : this->ParsePostIncrementExpression(std::move(operand), node.Source());
      case ast::Operator::Decrement:
           return node.UnaryType() == ast::UnaryOperatorType::Prefix
-                     ? this->ParsePreDecrementExpression(std::move(operand), node.Source())
-                     : this->ParsePostDecrementExpression(std::move(operand), node.Source());
+                      ? this->ParsePreDecrementExpression(std::move(operand), node.Source())
+                      : this->ParsePostDecrementExpression(std::move(operand), node.Source());
      default: throw TracedException(std::logic_error("Invalid unary operator"));
      }
 }
@@ -1593,11 +1598,11 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
           if (isFromGlobalNamespace && parts.size() == 1)
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "Expected a function name in a call expression, found global scope specifier",
-                       node.Function()->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "Expected a function name in a call expression, found global scope specifier",
+                         node.Function()->Source()));
                identifierFunction =
-                   new ast::IdentifierNode("__unknown", node.Function()->Source()); // a leak yeah, but uh
+                    new ast::IdentifierNode("__unknown", node.Function()->Source()); // a leak yeah, but uh
           }
           else
                identifierFunction = dynamic_cast<ast::IdentifierNode*>(parts.back().get());
@@ -1606,9 +1611,10 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
      if (!identifierFunction)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  std::format("Expected a function name in a call expression, found: {}", node.Function()->ToString(0)),
-                  node.Function()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    std::format("Expected a function name in a call expression, found: {}",
+                                node.Function()->ToString(0)),
+                    node.Function()->Source()));
           return nullptr;
      }
 
@@ -1616,12 +1622,12 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
      std::priority_queue<std::pair<ecpps::ir::MatchingScore, std::shared_ptr<ecpps::ir::FunctionScope>>,
                          std::vector<std::pair<ecpps::ir::MatchingScore, std::shared_ptr<ecpps::ir::FunctionScope>>>,
                          CompareByPriority>
-         candidates{};
+          candidates{};
 
      bool didMatchName = false;
      for (const auto& context : (isFromGlobalNamespace ? std::deque{this->GetContext().contextSequence.front()}
                                                        : this->GetContext().contextSequence) |
-                                    std::views::reverse)
+                                     std::views::reverse)
      {
           if (didMatchName) break;
 
@@ -1658,10 +1664,10 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
 
           std::vector<Expression> arguments = node.Arguments() |
                                               std::views::transform(
-                                                  [this](const ast::NodePointer& argument)
-                                                  {
-                                                       return this->ParseExpression(argument);
-                                                  }) |
+                                                   [this](const ast::NodePointer& argument)
+                                                   {
+                                                        return this->ParseExpression(argument);
+                                                   }) |
                                               std::ranges::to<std::vector>();
 
           for (const auto& candidate : scope->functions)
@@ -1682,16 +1688,16 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
 
           std::vector<Expression> evaluatedArguments = std::views::zip(candidate->parameters, moveRange) |
                                                        std::views::transform(
-                                                           [this](auto&& pair)
-                                                           {
-                                                                auto&& [param, arg] = pair;
-                                                                return ConvertTo(std::move(arg), param.type);
-                                                           }) |
+                                                            [this](auto&& pair)
+                                                            {
+                                                                 auto&& [param, arg] = pair;
+                                                                 return ConvertTo(std::move(arg), param.type);
+                                                            }) |
                                                        std::ranges::to<std::vector>();
 
           auto call = std::unique_ptr<FunctionCallNode, IRDeleter>{
-              new (*this->GetContext().nodeAllocator)
-                  FunctionCallNode(candidate, std::move(evaluatedArguments), node.Source())};
+               new (*this->GetContext().nodeAllocator)
+                    FunctionCallNode(candidate, std::move(evaluatedArguments), node.Source())};
 
           // TODO: Check for references; lvalue reference => lvalue; rvalue reference => xvalue
           return std::make_unique<PRValue>(candidate->returnType, std::move(call), false);
@@ -1701,17 +1707,17 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
 
      std::vector<Expression> argumentsForAnalysis = node.Arguments() |
                                                     std::views::transform(
-                                                        [this](const ast::NodePointer& argument)
-                                                        {
-                                                             return this->ParseExpression(argument);
-                                                        }) |
+                                                         [this](const ast::NodePointer& argument)
+                                                         {
+                                                              return this->ParseExpression(argument);
+                                                         }) |
                                                     std::ranges::to<std::vector>();
 
      auto exactMatches = CollectExactMatches(name, this->GetContext().contextSequence);
      if (!exactMatches.empty())
      {
           auto mainError = ecpps::diagnostics::DiagnosticsBuilder<diagnostics::UnresolvedSymbolError>{}.Build(
-              name, errorMessage, identifierFunction->Source());
+               name, errorMessage, identifierFunction->Source());
 
           std::vector<const ast::Node*> argumentNodes;
           argumentNodes.reserve(node.Arguments().Size());
@@ -1719,15 +1725,15 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
           for (const auto& func : exactMatches)
           {
                auto candidateNote = std::make_unique<diagnostics::Information>(
-                   "candidate", "Candidate: " + FormatFunctionSignature(func), func->source);
+                    "candidate", "Candidate: " + FormatFunctionSignature(func), func->source);
 
                auto failureInfo = AnalyseCandidateFailure(func, argumentsForAnalysis);
                for (const auto& [paramIndex, failure] : failureInfo.parameterFailures)
                {
                     Location argSource =
-                        (std::cmp_not_equal(paramIndex, -1) && paramIndex > 0 && paramIndex <= argumentNodes.size())
-                            ? argumentNodes[paramIndex - 1]->Source()
-                            : identifierFunction->Source();
+                         (std::cmp_not_equal(paramIndex, -1) && paramIndex > 0 && paramIndex <= argumentNodes.size())
+                              ? argumentNodes[paramIndex - 1]->Source()
+                              : identifierFunction->Source();
 
                     auto failureNote = std::make_unique<diagnostics::Information>("note", failure, argSource);
 
@@ -1745,7 +1751,7 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
                               if ((ecpps::typeSystem::IsPointer(fromType) || ecpps::typeSystem::IsArray(fromType)) &&
                                   !ecpps::typeSystem::IsPointer(toType) && !ecpps::typeSystem::IsArray(toType))
                                    failureNote->SubDiagnostics().push_back(std::make_unique<diagnostics::Information>(
-                                       "note", "Did you mean to dereference the argument?", argSource));
+                                        "note", "Did you mean to dereference the argument?", argSource));
                          }
                     }
 
@@ -1760,19 +1766,19 @@ Expression ecpps::ir::IR::ParseCallExpression(const ast::CallOperatorNode& node)
      else
      {
           auto mainError =
-              std::make_unique<diagnostics::UnresolvedSymbolError>(name, errorMessage, identifierFunction->Source());
+               std::make_unique<diagnostics::UnresolvedSymbolError>(name, errorMessage, identifierFunction->Source());
 
           auto similarNames =
-              CollectSimilarNames(name, argumentsForAnalysis.size(), this->GetContext().contextSequence);
+               CollectSimilarNames(name, argumentsForAnalysis.size(), this->GetContext().contextSequence);
           if (!similarNames.empty())
           {
                auto didYouMeanNote =
-                   std::make_unique<diagnostics::Information>("note", "Did you mean:", identifierFunction->Source());
+                    std::make_unique<diagnostics::Information>("note", "Did you mean:", identifierFunction->Source());
 
                for (const auto& [similarName, distance] : similarNames)
                {
                     didYouMeanNote->SubDiagnostics().push_back(std::make_unique<diagnostics::Information>(
-                        "", std::format("    {} [distance={}]", similarName, distance), identifierFunction->Source()));
+                         "", std::format("    {} [distance={}]", similarName, distance), identifierFunction->Source()));
                }
 
                mainError->SubDiagnostics().push_back(std::move(didYouMeanNote));
@@ -1788,9 +1794,9 @@ Expression ecpps::ir::IR::ParseStringLiteral(const ast::StringLiteralNode& expre
 {
      const auto length = expression.Value().length();
      const auto* elementType =
-         GetTypeContext().Get(TypeRequest{.kind = TypeKind::Fundamental,
-                                          .qualifiers = typeSystem::Qualifiers::Const,
-                                          .data = StandardSignedIntegerRequest{.isCharWithoutSign = true}});
+          GetTypeContext().Get(TypeRequest{.kind = TypeKind::Fundamental,
+                                           .qualifiers = typeSystem::Qualifiers::Const,
+                                           .data = StandardSignedIntegerRequest{.isCharWithoutSign = true}});
      std::vector<std::uint32_t> values{};
      values.reserve(length + 1);
      for (const auto character : expression.Value()) values.emplace_back(character);
@@ -1803,7 +1809,7 @@ Expression ecpps::ir::IR::ParseStringLiteral(const ast::StringLiteralNode& expre
      const auto* arrayType = GetTypeContext().Get(arrayRequest);
 
      auto node = std::unique_ptr<IntegerArrayNode, IRDeleter>(new (*this->GetContext().nodeAllocator) IntegerArrayNode(
-         std::move(values), elementType->CastTo<typeSystem::IntegralType>(), expression.Source()));
+          std::move(values), elementType->CastTo<typeSystem::IntegralType>(), expression.Source()));
      return std::make_unique<PRValue>(arrayType, std::move(node), true);
 }
 
@@ -1818,9 +1824,9 @@ Expression ecpps::ir::IR::ParseSizeofExpression(const ast::SizeOfNode& expressio
                if (type == nullptr)
                {
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                            std::format("Unknown type `{}` in sizeof expression", expression.Value()->ToString(0)),
-                            expression.Value()->Source()));
+                         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                              std::format("Unknown type `{}` in sizeof expression", expression.Value()->ToString(0)),
+                              expression.Value()->Source()));
                     return nullptr;
                }
                const auto size = type->Size();
@@ -1830,7 +1836,7 @@ Expression ecpps::ir::IR::ParseSizeofExpression(const ast::SizeOfNode& expressio
                sizeTypeRequest.data = PlatformIntegerRequest{.kind = PlatformIntegerKind::Size};
                const auto* sizeType = GetTypeContext().Get(sizeTypeRequest);
                auto node = std::unique_ptr<IntegralNode, IRDeleter>(new (*this->GetContext().nodeAllocator)
-                                                                        IntegralNode(size, expression.Source()));
+                                                                         IntegralNode(size, expression.Source()));
                return std::make_unique<PRValue>(sizeType, std::move(node), true);
           }
      }
@@ -1850,8 +1856,8 @@ Expression ecpps::ir::IR::ParseSizeofExpression(const ast::SizeOfNode& expressio
      if (operandType == nullptr)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot determine the type of the operand in a sizeof expression", expression.Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot determine the type of the operand in a sizeof expression", expression.Value()->Source()));
           return nullptr;
      }
      const auto size = operandType->Size();
@@ -1860,7 +1866,7 @@ Expression ecpps::ir::IR::ParseSizeofExpression(const ast::SizeOfNode& expressio
      sizeTypeRequest.data = PlatformIntegerRequest{.kind = PlatformIntegerKind::Size};
      const auto* sizeType = GetTypeContext().Get(sizeTypeRequest);
      auto node = std::unique_ptr<IntegralNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                              IntegralNode(size, expression.Value()->Source())};
+                                                               IntegralNode(size, expression.Value()->Source())};
      return std::make_unique<PRValue>(sizeType, std::move(node), true);
 }
 Expression ecpps::ir::IR::ParseAlignofExpression(const ast::AlignOfNode& expression)
@@ -1874,9 +1880,9 @@ Expression ecpps::ir::IR::ParseAlignofExpression(const ast::AlignOfNode& express
                if (type == nullptr)
                {
                     this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                            std::format("Unknown type `{}` in alignof expression", expression.Value()->ToString(0)),
-                            expression.Value()->Source()));
+                         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                              std::format("Unknown type `{}` in alignof expression", expression.Value()->ToString(0)),
+                              expression.Value()->Source()));
                     return nullptr;
                }
                const auto size = type->Alignment();
@@ -1886,7 +1892,7 @@ Expression ecpps::ir::IR::ParseAlignofExpression(const ast::AlignOfNode& express
                sizeTypeRequest.data = PlatformIntegerRequest{.kind = PlatformIntegerKind::Size};
                const auto* sizeType = GetTypeContext().Get(sizeTypeRequest);
                auto node = std::unique_ptr<IntegralNode, IRDeleter>(new (*this->GetContext().nodeAllocator)
-                                                                        IntegralNode(size, expression.Source()));
+                                                                         IntegralNode(size, expression.Source()));
                return std::make_unique<PRValue>(sizeType, std::move(node), true);
           }
      }
@@ -1906,8 +1912,8 @@ Expression ecpps::ir::IR::ParseAlignofExpression(const ast::AlignOfNode& express
      if (operandType == nullptr)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot determine the type of the operand in an alignof expression", expression.Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot determine the type of the operand in an alignof expression", expression.Value()->Source()));
           return nullptr;
      }
      const auto size = operandType->Alignment();
@@ -1916,7 +1922,7 @@ Expression ecpps::ir::IR::ParseAlignofExpression(const ast::AlignOfNode& express
      sizeTypeRequest.data = PlatformIntegerRequest{.kind = PlatformIntegerKind::Size};
      const auto* sizeType = GetTypeContext().Get(sizeTypeRequest);
      auto node = std::unique_ptr<IntegralNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                              IntegralNode(size, expression.Value()->Source())};
+                                                               IntegralNode(size, expression.Value()->Source())};
      return std::make_unique<PRValue>(sizeType, std::move(node), true);
 }
 
@@ -1940,10 +1946,11 @@ Expression ecpps::ir::IR::ParseIdExpression(const ast::IdentifierNode& expressio
                          if (variable.Name().value_or("__unknown_local") == name)
                          {
                               return std::make_unique<LValue>(
-                                  variable.type,
-                                  std::unique_ptr<LoadNode, IRDeleter>{new (*this->GetContext().nodeAllocator) LoadNode(
-                                      variable.Name().value_or("__unknown_local"), expression.Source())},
-                                  false);
+                                   variable.type,
+                                   std::unique_ptr<LoadNode, IRDeleter>{
+                                        new (*this->GetContext().nodeAllocator) LoadNode(
+                                             variable.Name().value_or("__unknown_local"), expression.Source())},
+                                   false);
                          }
                     }
                }
@@ -1958,12 +1965,12 @@ Expression ecpps::ir::IR::ParseIdExpression(const ast::IdentifierNode& expressio
      if (!similarNames.empty())
      {
           auto didYouMeanNote =
-              std::make_unique<diagnostics::Information>("note", "Did you mean:", expression.Source());
+               std::make_unique<diagnostics::Information>("note", "Did you mean:", expression.Source());
 
           for (const auto& [similarName, distance] : similarNames)
           {
                didYouMeanNote->SubDiagnostics().push_back(
-                   std::make_unique<diagnostics::Information>("", "    " + similarName, expression.Source()));
+                    std::make_unique<diagnostics::Information>("", "    " + similarName, expression.Source()));
           }
 
           mainError->SubDiagnostics().push_back(std::move(didYouMeanNote));
@@ -1982,17 +1989,17 @@ Expression ecpps::ir::IR::ParseExpression(const ast::NodePointer& expression)
          integerLiteral != nullptr)
           return std::make_unique<PRValue>(typeSystem::g_int.get(),
                                            std::unique_ptr<ir::IntegralNode, IRDeleter>{
-                                               new (*this->GetContext().nodeAllocator)
-                                                   ir::IntegralNode(integerLiteral->Value(), expression->Source())},
+                                                new (*this->GetContext().nodeAllocator)
+                                                     ir::IntegralNode(integerLiteral->Value(), expression->Source())},
                                            true);
 
      if (auto* const characterLiteral = dynamic_cast<ast::CharacterLiteralNode*>(expression.get());
          characterLiteral != nullptr)
           return std::make_unique<PRValue>(
-              typeSystem::g_char.get(),
-              std::unique_ptr<ir::IntegralNode, IRDeleter>{new (*this->GetContext().nodeAllocator) ir::IntegralNode(
-                  static_cast<std::uint64_t>(characterLiteral->Value()), expression->Source())},
-              true);
+               typeSystem::g_char.get(),
+               std::unique_ptr<ir::IntegralNode, IRDeleter>{new (*this->GetContext().nodeAllocator) ir::IntegralNode(
+                    static_cast<std::uint64_t>(characterLiteral->Value()), expression->Source())},
+               true);
      if (auto* const binaryExpression = dynamic_cast<ast::BinaryOperatorNode*>(expression.get());
          binaryExpression != nullptr)
           return this->ParseBinaryExpression(*binaryExpression);
@@ -2011,8 +2018,8 @@ Expression ecpps::ir::IR::ParseExpression(const ast::NodePointer& expression)
           return this->ParseAlignofExpression(*alignofNode);
 
      this->GetContext().diagnostics.get().diagnosticsList.push_back(
-         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-             expression->ToString(0) + " cannot appear in this context.", expression->Source()));
+          diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+               expression->ToString(0) + " cannot appear in this context.", expression->Source()));
 
      return nullptr;
 }
@@ -2035,8 +2042,8 @@ Expression ecpps::ir::IR::PickInitialiser(const ast::NodePointer& expression,
      break;
      default:
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build("Unknown initialisation type",
-                                                                              expression->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build("Unknown initialisation type",
+                                                                               expression->Source()));
           break;
      }
      throw TracedException(std::logic_error("Unknown initialisation type"));
@@ -2055,9 +2062,9 @@ Expression ecpps::ir::IR::ParseDirectInitialisation(const ecpps::ast::NodePointe
      if (converted == nullptr)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot convert initialiser to variable type of '" + desiredType->Name() + "'",
-                  expression->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot convert initialiser to variable type of '" + desiredType->Name() + "'",
+                    expression->Source()));
      }
      return converted;
 }
@@ -2071,9 +2078,9 @@ Expression ecpps::ir::IR::ParseCopyInitialisation(const ecpps::ast::NodePointer&
      if (converted == nullptr)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot convert initialiser to variable type of '" + desiredType->Name() + "'",
-                  expression->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot convert initialiser to variable type of '" + desiredType->Name() + "'",
+                    expression->Source()));
      }
      return converted;
 }
@@ -2085,10 +2092,10 @@ Expression ecpps::ir::IR::ParseZeroInitialisation(typeSystem::NonowningTypePoint
           if (IsIntegral(desiredType))
           {
                return std::make_unique<PRValue>(
-                   desiredType,
-                   std::unique_ptr<IntegralNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                                IntegralNode(0, Location{0, 0, 0})},
-                   true);
+                    desiredType,
+                    std::unique_ptr<IntegralNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                                  IntegralNode(0, Location{0, 0, 0})},
+                    true);
           }
           /*        if (IsPointer(desiredType))
                   {
@@ -2099,8 +2106,8 @@ Expression ecpps::ir::IR::ParseZeroInitialisation(typeSystem::NonowningTypePoint
                   }*/
      }
      this->GetContext().diagnostics.get().diagnosticsList.push_back(
-         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-             "Zero initialisation is not supported for this type", Location{0, 0, 0}));
+          diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+               "Zero initialisation is not supported for this type", Location{0, 0, 0}));
      return nullptr;
 }
 Expression ecpps::ir::IR::ParseValueInitialisation(typeSystem::NonowningTypePointer desiredType)
@@ -2117,8 +2124,8 @@ Expression ecpps::ir::IR::ParseListInitialisation(const ast::NodePointer& expres
      if (initialiserListNode == nullptr)
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Expected an initialiser list for list initialisation", expression->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Expected an initialiser list for list initialisation", expression->Source()));
           return nullptr;
      }
      std::vector<Expression> initialisers{};
@@ -2138,16 +2145,16 @@ Expression ecpps::ir::IR::ParseListInitialisation(const ast::NodePointer& expres
           if (IsNarrowingConversion(initialiserExpression, desiredType))
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                       "Narrowing conversion from '" + initialiserExpression->Type()->Name() + "' to '" +
-                           desiredType->Name() + "' is not allowed in list initialisation",
-                       expression->Source()));
+                    diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                         "Narrowing conversion from '" + initialiserExpression->Type()->Name() + "' to '" +
+                              desiredType->Name() + "' is not allowed in list initialisation",
+                         expression->Source()));
           }
           return ConvertTo(std::move(initialiserExpression), desiredType);
      }
      this->GetContext().diagnostics.get().diagnosticsList.push_back(
-         diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-             "List initialisation with multiple initialisers is not supported yet", expression->Source()));
+          diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+               "List initialisation with multiple initialisers is not supported yet", expression->Source()));
      return nullptr;
 }
 
@@ -2169,7 +2176,7 @@ bool ecpps::ir::IR::IsNarrowingConversion([[maybe_unused]] const Expression& exp
           const auto& value = basicType->Value();
 
           const auto qualifiers = basicType->IsConst() && basicType->IsVolatile()
-                                      ? typeSystem::Qualifiers::ConstVolatile
+                                       ? typeSystem::Qualifiers::ConstVolatile
                                   : basicType->IsConst()    ? typeSystem::Qualifiers::Const
                                   : basicType->IsVolatile() ? typeSystem::Qualifiers::Volatile
                                                             : typeSystem::Qualifiers::None;
@@ -2268,11 +2275,11 @@ bool ecpps::ir::IR::IsNarrowingConversion([[maybe_unused]] const Expression& exp
 
                std::vector<diagnostics::DiagnosticsMessage> diagnosticsList{};
                diagnosticsList.push_back(diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                   "Invalid type specifier: " + value, basicType->Source()));
+                    "Invalid type specifier: " + value, basicType->Source()));
                TypeRequest fallbackRequest{};
                fallbackRequest.kind = TypeKind::Error;
                fallbackRequest.data =
-                   InvalidRequest(std::make_unique<TypeRequest>(request), std::move(diagnosticsList));
+                    InvalidRequest(std::make_unique<TypeRequest>(request), std::move(diagnosticsList));
                return fallbackRequest;
           }
 
@@ -2283,7 +2290,7 @@ bool ecpps::ir::IR::IsNarrowingConversion([[maybe_unused]] const Expression& exp
           else
           {
                signedRequest.signedness =
-                   isUnsigned ? typeSystem::Signedness::Unsigned : typeSystem::Signedness::Signed;
+                    isUnsigned ? typeSystem::Signedness::Unsigned : typeSystem::Signedness::Signed;
 
                if (isChar) signedRequest.size = typeSystem::TypeKind::Char;
                else if (isShort)
@@ -2342,13 +2349,13 @@ Expression ecpps::ir::IR::ConvertTo(Expression expression, typeSystem::Nonowning
           try
           {
                expression =
-                   ConstantEvaluationResultToExpression(value, expression->Type(), *this->GetContext().nodeAllocator);
+                    ConstantEvaluationResultToExpression(value, expression->Type(), *this->GetContext().nodeAllocator);
           }
           catch (...)
           {
                this->GetContext().diagnostics.get().diagnosticsList.push_back(
-                   std::make_unique<diagnostics::ConstantEvaluationWarning>(
-                       "Failed to use the constant expression evaluation result", expression->Value()->Source()));
+                    std::make_unique<diagnostics::ConstantEvaluationWarning>(
+                         "Failed to use the constant expression evaluation result", expression->Value()->Source()));
           }
      }
 
@@ -2357,10 +2364,10 @@ Expression ecpps::ir::IR::ConvertTo(Expression expression, typeSystem::Nonowning
      if (!comparison.IsValid())
      {
           this->GetContext().diagnostics.get().diagnosticsList.push_back(
-              diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
-                  "Cannot convert from " + expression->Type()->Name() + " (aka " + expression->Type()->RawName() +
-                      ") to type " + toType->Name() + " (aka " + toType->RawName() + ")",
-                  expression->Value()->Source()));
+               diagnostics::DiagnosticsBuilder<diagnostics::TypeError>{}.Build(
+                    "Cannot convert from " + expression->Type()->Name() + " (aka " + expression->Type()->RawName() +
+                         ") to type " + toType->Name() + " (aka " + toType->RawName() + ")",
+                    expression->Value()->Source()));
           return nullptr;
      }
 
@@ -2396,8 +2403,8 @@ Expression ecpps::ir::IR::ConvertTo(Expression expression, typeSystem::Nonowning
                          const auto source = intArray->Source();
 
                          decayNode = std::unique_ptr<TemporaryIntegerArrayDecayNode, IRDeleter>(
-                             new (*this->GetContext().nodeAllocator)
-                                 TemporaryIntegerArrayDecayNode(std::move(expression), source));
+                              new (*this->GetContext().nodeAllocator)
+                                   TemporaryIntegerArrayDecayNode(std::move(expression), source));
                     }
                     else
                          throw TracedException("array-to-pointer is not supported yet");
@@ -2413,8 +2420,8 @@ Expression ecpps::ir::IR::ConvertTo(Expression expression, typeSystem::Nonowning
                     {
                          const auto source = loadNode->Source();
 
-                         decayNode = std::unique_ptr<LoadArrayDecayNode, IRDeleter>(
-                             new (*this->GetContext().nodeAllocator) LoadArrayDecayNode(std::move(expression), source));
+                         decayNode = std::unique_ptr<LoadArrayDecayNode, IRDeleter>(new (
+                              *this->GetContext().nodeAllocator) LoadArrayDecayNode(std::move(expression), source));
                     }
                     else
                          throw TracedException("array-to-pointer is not supported yet");
@@ -2434,7 +2441,7 @@ Expression ecpps::ir::IR::ConvertTo(Expression expression, typeSystem::Nonowning
                const bool isLValue = expression->IsLValue();
 
                auto castNode = std::unique_ptr<PointerConversionNode, IRDeleter>(new (
-                   *this->GetContext().nodeAllocator) PointerConversionNode(std::move(expression), toType, source));
+                    *this->GetContext().nodeAllocator) PointerConversionNode(std::move(expression), toType, source));
 
                if (isPRValue) return std::make_unique<PRValue>(toType, std::move(castNode), wasConstexpr);
                if (isXValue) return std::make_unique<XValue>(toType, std::move(castNode), wasConstexpr);
@@ -2465,10 +2472,10 @@ Expression ecpps::ir::IR::ConvertIntegral(Expression expression, const typeSyste
      }
      if (IsArithmetic(expressionType))
           return std::make_unique<PRValue>(
-              type,
-              std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
-                                                          ConvertNode(std::move(expression), type, source)},
-              false);
+               type,
+               std::unique_ptr<ConvertNode, IRDeleter>{new (*this->GetContext().nodeAllocator)
+                                                            ConvertNode(std::move(expression), type, source)},
+               false);
      return nullptr; // TODO: Return implicit conversion node
 }
 

--- a/compiler/ecpps/src/Execution/IR.h
+++ b/compiler/ecpps/src/Execution/IR.h
@@ -71,7 +71,10 @@ namespace ecpps::ir
      [[nodiscard]] ImplicitConversion MatchImplicitConversion(const Expression& expression,
                                                               typeSystem::NonowningTypePointer type);
 
-     constexpr bool operator!(const MatchingScore score) { return score == MatchingScore::NotMatching; }
+     constexpr bool operator!(const MatchingScore score)
+     {
+          return score == MatchingScore::NotMatching;
+     }
      constexpr auto operator<=>(const MatchingScore left, const MatchingScore right)
      {
           return std::to_underlying(left) <=> std::to_underlying(right);
@@ -105,10 +108,15 @@ namespace ecpps::ir
                                                 const std::vector<ast::NodePointer>& ast);
 
      private:
-          explicit IR(Context* context) : _context(context) {}
+          explicit IR(Context* context) : _context(context)
+          {
+          }
           std::vector<NodePointer> _built{};
           Context* _context;
-          [[nodiscard]] Context& GetContext(void) const noexcept { return *this->_context; }
+          [[nodiscard]] Context& GetContext(void) const noexcept
+          {
+               return *this->_context;
+          }
 
           void ParseNode(const ast::NodePointer& node);
           void ParseFunctionDeclaration(const ast::FunctionDeclarationNode& node);

--- a/compiler/ecpps/src/Execution/NodeBase.cpp
+++ b/compiler/ecpps/src/Execution/NodeBase.cpp
@@ -2,31 +2,31 @@
 #include "Context.h"
 
 std::expected<ecpps::ir::ConstantEvaluatedResult, std::stack<ecpps::diagnostics::DiagnosticsMessage>> ecpps::ir::
-    NodeBase::TryConstantEvaluate(const ecpps::ir::EvaluationContext& evaluationContext) const
+     NodeBase::TryConstantEvaluate(const ecpps::ir::EvaluationContext& evaluationContext) const
 {
      auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
      if (ecpps::ir::GetTypeContext().optimisations.maxConstantEvaluationDepth < evaluationContext.currentDepth)
           result.error().push(std::make_unique<diagnostics::ConstantEvaluationWarning>(
-              "Reached the maximum depth of the constant evaluation", this->Source()));
+               "Reached the maximum depth of the constant evaluation", this->Source()));
      else
           result.error().push(std::make_unique<diagnostics::ConstantEvaluationWarning>(
-              std::format("Cannot evaluate `{}` as a constant expression", this->ToString(0)), this->Source()));
+               std::format("Cannot evaluate `{}` as a constant expression", this->ToString(0)), this->Source()));
      return result;
 }
 
 std::expected<ecpps::ir::ConstantEvaluatedResult, std::stack<ecpps::diagnostics::DiagnosticsMessage>> ecpps::ir::
-    IntegerArrayNode::TryConstantEvaluate(const ecpps::ir::EvaluationContext& evaluationContext) const
+     IntegerArrayNode::TryConstantEvaluate(const ecpps::ir::EvaluationContext& evaluationContext) const
 {
      if (ecpps::ir::GetTypeContext().optimisations.maxConstantEvaluationDepth < evaluationContext.currentDepth)
           return NodeBase::TryConstantEvaluate(evaluationContext);
 
      return ConstantEvaluatedResult{ConstantAggregateArray{this->_values |
                                                            std::views::transform(
-                                                               [](const std::uint32_t value)
-                                                               {
-                                                                    return ConstantEvaluatedVariant{
-                                                                        static_cast<std::uint64_t>(value)};
-                                                               }) |
+                                                                [](const std::uint32_t value)
+                                                                {
+                                                                     return ConstantEvaluatedVariant{
+                                                                          static_cast<std::uint64_t>(value)};
+                                                                }) |
                                                            std::ranges::to<std::vector>()},
                                     this->Source()};
 }

--- a/compiler/ecpps/src/Execution/NodeBase.cpp
+++ b/compiler/ecpps/src/Execution/NodeBase.cpp
@@ -20,11 +20,13 @@ std::expected<ecpps::ir::ConstantEvaluatedResult, std::stack<ecpps::diagnostics:
      if (ecpps::ir::GetTypeContext().optimisations.maxConstantEvaluationDepth < evaluationContext.currentDepth)
           return NodeBase::TryConstantEvaluate(evaluationContext);
 
-     return ConstantEvaluatedResult{
-         ConstantAggregateArray{
-             this->_values |
-             std::views::transform([](const std::uint32_t value)
-                                   { return ConstantEvaluatedVariant{static_cast<std::uint64_t>(value)}; }) |
-             std::ranges::to<std::vector>()},
-         this->Source()};
+     return ConstantEvaluatedResult{ConstantAggregateArray{this->_values |
+                                                           std::views::transform(
+                                                               [](const std::uint32_t value)
+                                                               {
+                                                                    return ConstantEvaluatedVariant{
+                                                                        static_cast<std::uint64_t>(value)};
+                                                               }) |
+                                                           std::ranges::to<std::vector>()},
+                                    this->Source()};
 }

--- a/compiler/ecpps/src/Execution/NodeBase.h
+++ b/compiler/ecpps/src/Execution/NodeBase.h
@@ -46,7 +46,7 @@ namespace ecpps::ir
      struct ConstantAggregateArray;
 
      using ConstantEvaluatedVariant =
-         std::variant<std::monostate, std::uint64_t, std::double_t, ConstantAggregateMap, ConstantAggregateArray>;
+          std::variant<std::monostate, std::uint64_t, std::double_t, ConstantAggregateMap, ConstantAggregateArray>;
 
      struct ConstantAggregateMap
      {

--- a/compiler/ecpps/src/Execution/NodeBase.h
+++ b/compiler/ecpps/src/Execution/NodeBase.h
@@ -76,13 +76,21 @@ namespace ecpps::ir
      class NodeBase
      {
      public:
-          explicit NodeBase(const NodeKind kind, const Location& source) : _kind(kind), _source(source) {}
+          explicit NodeBase(const NodeKind kind, const Location& source) : _kind(kind), _source(source)
+          {
+          }
           virtual ~NodeBase(void) = default;
 
           [[nodiscard]] virtual std::string ToString(std::size_t indent) const = 0;
 
-          [[nodiscard]] NodeKind Kind(void) const noexcept { return this->_kind; }
-          [[nodiscard]] const Location& Source(void) const noexcept { return this->_source; }
+          [[nodiscard]] NodeKind Kind(void) const noexcept
+          {
+               return this->_kind;
+          }
+          [[nodiscard]] const Location& Source(void) const noexcept
+          {
+               return this->_source;
+          }
           [[nodiscard]] virtual std::expected<ConstantEvaluatedResult, std::stack<diagnostics::DiagnosticsMessage>>
           TryConstantEvaluate(const EvaluationContext& evaluationContext) const;
 
@@ -103,7 +111,10 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] std::uint64_t Value(void) const noexcept { return this->_value; }
+          [[nodiscard]] std::uint64_t Value(void) const noexcept
+          {
+               return this->_value;
+          }
           [[nodiscard]] std::uint64_t Value(const std::uint64_t newValue) noexcept
           {
                return std::exchange(this->_value, newValue);
@@ -132,8 +143,14 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const std::vector<std::uint32_t>& Values(void) const noexcept { return this->_values; }
-          [[nodiscard]] const typeSystem::IntegralType* Type(void) const noexcept { return this->_type; }
+          [[nodiscard]] const std::vector<std::uint32_t>& Values(void) const noexcept
+          {
+               return this->_values;
+          }
+          [[nodiscard]] const typeSystem::IntegralType* Type(void) const noexcept
+          {
+               return this->_type;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {

--- a/compiler/ecpps/src/Execution/Operations.h
+++ b/compiler/ecpps/src/Execution/Operations.h
@@ -73,39 +73,39 @@ namespace ecpps::ir
                     return NodeBase::TryConstantEvaluate(evaluationContext);
 
                auto leftConstexpr = this->_left->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!leftConstexpr.has_value())
                {
                     leftConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the addition did not evaluate to a constant expression",
-                        this->Source()));
+                         "The left hand side of the addition did not evaluate to a constant expression",
+                         this->Source()));
                     return leftConstexpr;
                }
                auto rightConstexpr = this->_right->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!rightConstexpr.has_value())
                {
                     rightConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the addition did not evaluate to a constant expression",
-                        this->Source()));
+                         "The left hand side of the addition did not evaluate to a constant expression",
+                         this->Source()));
                     return rightConstexpr;
                }
                if (!std::holds_alternative<std::uint64_t>(leftConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the addition did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The left hand side of the addition did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                if (!std::holds_alternative<std::uint64_t>(rightConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The right hand side of the addition did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The right hand side of the addition did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                const auto leftValue = std::get<std::uint64_t>(leftConstexpr->variant);
@@ -253,39 +253,39 @@ namespace ecpps::ir
                     return NodeBase::TryConstantEvaluate(evaluationContext);
 
                auto leftConstexpr = this->_left->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!leftConstexpr.has_value())
                {
                     leftConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the subtraction did not evaluate to a constant expression",
-                        this->Source()));
+                         "The left hand side of the subtraction did not evaluate to a constant expression",
+                         this->Source()));
                     return leftConstexpr;
                }
                auto rightConstexpr = this->_right->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!rightConstexpr.has_value())
                {
                     rightConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the subtraction did not evaluate to a constant expression",
-                        this->Source()));
+                         "The left hand side of the subtraction did not evaluate to a constant expression",
+                         this->Source()));
                     return rightConstexpr;
                }
                if (!std::holds_alternative<std::uint64_t>(leftConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the subtraction did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The left hand side of the subtraction did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                if (!std::holds_alternative<std::uint64_t>(rightConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The right hand side of the subtraction did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The right hand side of the subtraction did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                const auto leftValue = std::get<std::uint64_t>(leftConstexpr->variant);
@@ -328,39 +328,39 @@ namespace ecpps::ir
                     return NodeBase::TryConstantEvaluate(evaluationContext);
 
                auto leftConstexpr = this->_left->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!leftConstexpr.has_value())
                {
                     leftConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the multiplication did not evaluate to a constant expression",
-                        this->Source()));
+                         "The left hand side of the multiplication did not evaluate to a constant expression",
+                         this->Source()));
                     return leftConstexpr;
                }
                auto rightConstexpr = this->_right->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!rightConstexpr.has_value())
                {
                     rightConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the multiplication did not evaluate to a constant expression",
-                        this->Source()));
+                         "The left hand side of the multiplication did not evaluate to a constant expression",
+                         this->Source()));
                     return rightConstexpr;
                }
                if (!std::holds_alternative<std::uint64_t>(leftConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the multiplication did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The left hand side of the multiplication did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                if (!std::holds_alternative<std::uint64_t>(rightConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The right hand side of the multiplication did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The right hand side of the multiplication did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                const auto leftValue = std::get<std::uint64_t>(leftConstexpr->variant);
@@ -404,39 +404,39 @@ namespace ecpps::ir
                     return NodeBase::TryConstantEvaluate(evaluationContext);
 
                auto leftConstexpr = this->_left->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!leftConstexpr.has_value())
                {
                     leftConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the division did not evaluate to a constant expression",
-                        this->Source()));
+                         "The left hand side of the division did not evaluate to a constant expression",
+                         this->Source()));
                     return leftConstexpr;
                }
                auto rightConstexpr = this->_right->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!rightConstexpr.has_value())
                {
                     rightConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the division did not evaluate to a constant expression",
-                        this->Source()));
+                         "The left hand side of the division did not evaluate to a constant expression",
+                         this->Source()));
                     return rightConstexpr;
                }
                if (!std::holds_alternative<std::uint64_t>(leftConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the division did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The left hand side of the division did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                if (!std::holds_alternative<std::uint64_t>(rightConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The right hand side of the division did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The right hand side of the division did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                const auto leftValue = std::get<std::uint64_t>(leftConstexpr->variant);
@@ -445,7 +445,7 @@ namespace ecpps::ir
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(
-                        std::make_unique<diagnostics::ConstantEvaluationError>("Cannot divide by 0", this->Source()));
+                         std::make_unique<diagnostics::ConstantEvaluationError>("Cannot divide by 0", this->Source()));
                     return result;
                }
 
@@ -487,37 +487,37 @@ namespace ecpps::ir
                     return NodeBase::TryConstantEvaluate(evaluationContext);
 
                auto leftConstexpr = this->_left->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!leftConstexpr.has_value())
                {
                     leftConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the modulo did not evaluate to a constant expression", this->Source()));
+                         "The left hand side of the modulo did not evaluate to a constant expression", this->Source()));
                     return leftConstexpr;
                }
                auto rightConstexpr = this->_right->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!rightConstexpr.has_value())
                {
                     rightConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the modulo did not evaluate to a constant expression", this->Source()));
+                         "The left hand side of the modulo did not evaluate to a constant expression", this->Source()));
                     return rightConstexpr;
                }
                if (!std::holds_alternative<std::uint64_t>(leftConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The left hand side of the modulo did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The left hand side of the modulo did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                if (!std::holds_alternative<std::uint64_t>(rightConstexpr->variant))
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "The right hand side of the modulo did not evaluate to an integral or floating-point "
-                        "result",
-                        this->Source()));
+                         "The right hand side of the modulo did not evaluate to an integral or floating-point "
+                         "result",
+                         this->Source()));
                     return result;
                }
                const auto leftValue = std::get<std::uint64_t>(leftConstexpr->variant);
@@ -526,7 +526,7 @@ namespace ecpps::ir
                {
                     auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                     result.error().push(
-                        std::make_unique<diagnostics::ConstantEvaluationError>("Cannot divide by 0", this->Source()));
+                         std::make_unique<diagnostics::ConstantEvaluationError>("Cannot divide by 0", this->Source()));
                     return result;
                }
 
@@ -704,11 +704,11 @@ namespace ecpps::ir
                     return NodeBase::TryConstantEvaluate(evaluationContext);
 
                auto operandConstexpr = this->_operand->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!operandConstexpr.has_value())
                {
                     operandConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "Indirected operand did not evaluate to a constant expression", this->Source()));
+                         "Indirected operand did not evaluate to a constant expression", this->Source()));
                     return operandConstexpr;
                }
                if (std::holds_alternative<ConstantAggregateArray>(operandConstexpr->variant))
@@ -719,7 +719,7 @@ namespace ecpps::ir
 
                auto result = std::unexpected<std::stack<diagnostics::DiagnosticsMessage>>(std::in_place_t{});
                result.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                   "The operand did not evaluate to an an operand eligible for indirection", this->Source()));
+                    "The operand did not evaluate to an an operand eligible for indirection", this->Source()));
                return result;
           }
 
@@ -760,11 +760,11 @@ namespace ecpps::ir
 
                return ConstantEvaluatedResult{ConstantAggregateArray{this->_referencedArray->Values() |
                                                                      std::views::transform(
-                                                                         [](const std::uint32_t value)
-                                                                         {
-                                                                              return ConstantEvaluatedVariant{
-                                                                                  static_cast<std::uint64_t>(value)};
-                                                                         }) |
+                                                                          [](const std::uint32_t value)
+                                                                          {
+                                                                               return ConstantEvaluatedVariant{
+                                                                                    static_cast<std::uint64_t>(value)};
+                                                                          }) |
                                                                      std::ranges::to<std::vector>()},
                                               this->Source()};
           }
@@ -833,11 +833,11 @@ namespace ecpps::ir
                    evaluationContext.currentDepth)
                     return NodeBase::TryConstantEvaluate(evaluationContext);
                auto operandConstexpr = this->_operand->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!operandConstexpr.has_value())
                {
                     operandConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "Converted operand did not evaluate to a constant expression", this->Source()));
+                         "Converted operand did not evaluate to a constant expression", this->Source()));
                     return operandConstexpr;
                }
                const auto& operand = *operandConstexpr;
@@ -879,11 +879,11 @@ namespace ecpps::ir
                    evaluationContext.currentDepth)
                     return NodeBase::TryConstantEvaluate(evaluationContext);
                auto operandConstexpr = this->_operand->Value()->TryConstantEvaluate(
-                   EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
+                    EvaluationContext{.currentDepth = evaluationContext.currentDepth + 1});
                if (!operandConstexpr.has_value())
                {
                     operandConstexpr.error().push(std::make_unique<diagnostics::ConstantEvaluationError>(
-                        "Converted operand did not evaluate to a constant expression", this->Source()));
+                         "Converted operand did not evaluate to a constant expression", this->Source()));
                     return operandConstexpr;
                }
                const auto& operand = *operandConstexpr;

--- a/compiler/ecpps/src/Execution/Operations.h
+++ b/compiler/ecpps/src/Execution/Operations.h
@@ -51,8 +51,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Addition, source), _left(std::move(left)), _right(std::move(right))
           {
           }
-          [[nodiscard]] const Expression& Left(void) const noexcept { return this->_left; }
-          [[nodiscard]] const Expression& Right(void) const noexcept { return this->_right; }
+          [[nodiscard]] const Expression& Left(void) const noexcept
+          {
+               return this->_left;
+          }
+          [[nodiscard]] const Expression& Right(void) const noexcept
+          {
+               return this->_right;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -120,8 +126,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Addition, source), _left(std::move(left)), _right(std::move(right))
           {
           }
-          [[nodiscard]] const Expression& Left(void) const noexcept { return this->_left; }
-          [[nodiscard]] const Expression& Right(void) const noexcept { return this->_right; }
+          [[nodiscard]] const Expression& Left(void) const noexcept
+          {
+               return this->_left;
+          }
+          [[nodiscard]] const Expression& Right(void) const noexcept
+          {
+               return this->_right;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -140,8 +152,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Subtraction, source), _left(std::move(left)), _right(std::move(right))
           {
           }
-          [[nodiscard]] const Expression& Left(void) const noexcept { return this->_left; }
-          [[nodiscard]] const Expression& Right(void) const noexcept { return this->_right; }
+          [[nodiscard]] const Expression& Left(void) const noexcept
+          {
+               return this->_left;
+          }
+          [[nodiscard]] const Expression& Right(void) const noexcept
+          {
+               return this->_right;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -160,8 +178,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Addition, source), _operand(std::move(operand)), _increment(increment)
           {
           }
-          [[nodiscard]] const Expression& Operand(void) const noexcept { return this->_operand; }
-          [[nodiscard]] std::size_t IncrementValue(void) const noexcept { return this->_increment; }
+          [[nodiscard]] const Expression& Operand(void) const noexcept
+          {
+               return this->_operand;
+          }
+          [[nodiscard]] std::size_t IncrementValue(void) const noexcept
+          {
+               return this->_increment;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -180,8 +204,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Subtraction, source), _operand(std::move(operand)), _increment(decrement)
           {
           }
-          [[nodiscard]] const Expression& Operand(void) const noexcept { return this->_operand; }
-          [[nodiscard]] std::size_t IncrementValue(void) const noexcept { return this->_increment; }
+          [[nodiscard]] const Expression& Operand(void) const noexcept
+          {
+               return this->_operand;
+          }
+          [[nodiscard]] std::size_t IncrementValue(void) const noexcept
+          {
+               return this->_increment;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -201,8 +231,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Subtraction, source), _left(std::move(left)), _right(std::move(right))
           {
           }
-          [[nodiscard]] const Expression& Left(void) const noexcept { return this->_left; }
-          [[nodiscard]] const Expression& Right(void) const noexcept { return this->_right; }
+          [[nodiscard]] const Expression& Left(void) const noexcept
+          {
+               return this->_left;
+          }
+          [[nodiscard]] const Expression& Right(void) const noexcept
+          {
+               return this->_right;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -270,8 +306,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Subtraction, source), _left(std::move(left)), _right(std::move(right))
           {
           }
-          [[nodiscard]] const Expression& Left(void) const noexcept { return this->_left; }
-          [[nodiscard]] const Expression& Right(void) const noexcept { return this->_right; }
+          [[nodiscard]] const Expression& Left(void) const noexcept
+          {
+               return this->_left;
+          }
+          [[nodiscard]] const Expression& Right(void) const noexcept
+          {
+               return this->_right;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -340,8 +382,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Subtraction, source), _left(std::move(left)), _right(std::move(right))
           {
           }
-          [[nodiscard]] const Expression& Left(void) const noexcept { return this->_left; }
-          [[nodiscard]] const Expression& Right(void) const noexcept { return this->_right; }
+          [[nodiscard]] const Expression& Left(void) const noexcept
+          {
+               return this->_left;
+          }
+          [[nodiscard]] const Expression& Right(void) const noexcept
+          {
+               return this->_right;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -417,8 +465,14 @@ namespace ecpps::ir
               : NodeBase(NodeKind::Subtraction, source), _left(std::move(left)), _right(std::move(right))
           {
           }
-          [[nodiscard]] const Expression& Left(void) const noexcept { return this->_left; }
-          [[nodiscard]] const Expression& Right(void) const noexcept { return this->_right; }
+          [[nodiscard]] const Expression& Left(void) const noexcept
+          {
+               return this->_left;
+          }
+          [[nodiscard]] const Expression& Right(void) const noexcept
+          {
+               return this->_right;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -495,11 +549,26 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const Expression& Address(void) const noexcept { return _address; }
-          [[nodiscard]] const Expression& Expected(void) const noexcept { return _expected; }
-          [[nodiscard]] const Expression& Replacement(void) const noexcept { return _replacement; }
-          [[nodiscard]] bool IsWeak(void) const noexcept { return _isWeak; }
-          [[nodiscard]] MemoryOrdering OrderingMode(void) const noexcept { return _ordering; }
+          [[nodiscard]] const Expression& Address(void) const noexcept
+          {
+               return _address;
+          }
+          [[nodiscard]] const Expression& Expected(void) const noexcept
+          {
+               return _expected;
+          }
+          [[nodiscard]] const Expression& Replacement(void) const noexcept
+          {
+               return _replacement;
+          }
+          [[nodiscard]] bool IsWeak(void) const noexcept
+          {
+               return _isWeak;
+          }
+          [[nodiscard]] MemoryOrdering OrderingMode(void) const noexcept
+          {
+               return _ordering;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -522,7 +591,10 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const std::string& Address(void) const noexcept { return this->_address; }
+          [[nodiscard]] const std::string& Address(void) const noexcept
+          {
+               return this->_address;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -541,7 +613,10 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] std::uint64_t Index(void) const noexcept { return this->_index; }
+          [[nodiscard]] std::uint64_t Index(void) const noexcept
+          {
+               return this->_index;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -560,8 +635,14 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const std::string& Address(void) const noexcept { return this->_address; }
-          [[nodiscard]] const Expression& Value(void) const noexcept { return this->_value; }
+          [[nodiscard]] const std::string& Address(void) const noexcept
+          {
+               return this->_address;
+          }
+          [[nodiscard]] const Expression& Value(void) const noexcept
+          {
+               return this->_value;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -582,7 +663,10 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const Expression& Operand(void) const noexcept { return this->_operand; }
+          [[nodiscard]] const Expression& Operand(void) const noexcept
+          {
+               return this->_operand;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -602,7 +686,10 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const Expression& Operand(void) const noexcept { return this->_operand; }
+          [[nodiscard]] const Expression& Operand(void) const noexcept
+          {
+               return this->_operand;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -671,13 +758,15 @@ namespace ecpps::ir
                    evaluationContext.currentDepth)
                     return NodeBase::TryConstantEvaluate(evaluationContext);
 
-               return ConstantEvaluatedResult{
-                   ConstantAggregateArray{
-                       this->_referencedArray->Values() |
-                       std::views::transform([](const std::uint32_t value)
-                                             { return ConstantEvaluatedVariant{static_cast<std::uint64_t>(value)}; }) |
-                       std::ranges::to<std::vector>()},
-                   this->Source()};
+               return ConstantEvaluatedResult{ConstantAggregateArray{this->_referencedArray->Values() |
+                                                                     std::views::transform(
+                                                                         [](const std::uint32_t value)
+                                                                         {
+                                                                              return ConstantEvaluatedVariant{
+                                                                                  static_cast<std::uint64_t>(value)};
+                                                                         }) |
+                                                                     std::ranges::to<std::vector>()},
+                                              this->Source()};
           }
 
      private:
@@ -701,8 +790,14 @@ namespace ecpps::ir
                       std::format("__decay({})", this->_loadNode->ToString(0));
           }
 
-          [[nodiscard]] const LoadNode* GetLoadNode(void) const noexcept { return this->_loadNode; }
-          [[nodiscard]] const Expression& GetOperand(void) const noexcept { return this->_operand; }
+          [[nodiscard]] const LoadNode* GetLoadNode(void) const noexcept
+          {
+               return this->_loadNode;
+          }
+          [[nodiscard]] const Expression& GetOperand(void) const noexcept
+          {
+               return this->_operand;
+          }
 
      private:
           Expression _operand;
@@ -717,7 +812,10 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const Expression& Operand(void) const noexcept { return this->_operand; }
+          [[nodiscard]] const Expression& Operand(void) const noexcept
+          {
+               return this->_operand;
+          }
           [[nodiscard]] ecpps::typeSystem::NonowningTypePointer TargetType(void) const noexcept
           {
                return this->_targetType;
@@ -760,7 +858,10 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const Expression& Operand(void) const noexcept { return this->_operand; }
+          [[nodiscard]] const Expression& Operand(void) const noexcept
+          {
+               return this->_operand;
+          }
           [[nodiscard]] ecpps::typeSystem::NonowningTypePointer TargetType(void) const noexcept
           {
                return this->_targetType;

--- a/compiler/ecpps/src/Execution/Procedural.h
+++ b/compiler/ecpps/src/Execution/Procedural.h
@@ -56,7 +56,7 @@ namespace ecpps::ir
           {
                std::string built(indent * ast::PrettyIndent, ' ');
                built +=
-                   this->_returnType->RawName() + " " + ::ToString(this->_callingConvention) + " " + this->_name + "(";
+                    this->_returnType->RawName() + " " + ::ToString(this->_callingConvention) + " " + this->_name + "(";
                built += ")\n" + std::string(indent * ast::PrettyIndent, ' ') + "{\n";
                for (const auto& line : this->_body) built += line->ToString(indent + 1) + "\n";
                return built + std::string(indent * ast::PrettyIndent, ' ') + "}";

--- a/compiler/ecpps/src/Execution/Procedural.h
+++ b/compiler/ecpps/src/Execution/Procedural.h
@@ -30,7 +30,10 @@ namespace ecpps::ir
           {
           }
 
-          [[nodiscard]] const std::string& Name(void) const noexcept { return this->_name; }
+          [[nodiscard]] const std::string& Name(void) const noexcept
+          {
+               return this->_name;
+          }
           [[nodiscard]] const std::vector<std::string>& NamespacePath(void) const noexcept
           {
                return this->_namespacePath;
@@ -44,7 +47,10 @@ namespace ecpps::ir
                runtime_assert(this->_locals != nullptr, "ProcedureNode must have a non-nullptr _locals");
                return *this->_locals;
           }
-          [[nodiscard]] const std::vector<NodePointer>& Body(void) const noexcept { return this->_body; }
+          [[nodiscard]] const std::vector<NodePointer>& Body(void) const noexcept
+          {
+               return this->_body;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -59,8 +65,14 @@ namespace ecpps::ir
           {
                return this->_callingConvention;
           }
-          [[nodiscard]] abi::Linkage Linkage(void) const noexcept { return this->_linkage; }
-          [[nodiscard]] typeSystem::NonowningTypePointer ReturnType(void) const noexcept { return this->_returnType; }
+          [[nodiscard]] abi::Linkage Linkage(void) const noexcept
+          {
+               return this->_linkage;
+          }
+          [[nodiscard]] typeSystem::NonowningTypePointer ReturnType(void) const noexcept
+          {
+               return this->_returnType;
+          }
 
      private:
           abi::Linkage _linkage;
@@ -96,8 +108,14 @@ namespace ecpps::ir
                       "(" + args + ")";
           }
 
-          [[nodiscard]] const std::shared_ptr<FunctionScope>& Function(void) const noexcept { return this->_function; }
-          [[nodiscard]] const std::vector<Expression>& Arguments(void) const noexcept { return this->_arguments; }
+          [[nodiscard]] const std::shared_ptr<FunctionScope>& Function(void) const noexcept
+          {
+               return this->_function;
+          }
+          [[nodiscard]] const std::vector<Expression>& Arguments(void) const noexcept
+          {
+               return this->_arguments;
+          }
 
      private:
           std::shared_ptr<FunctionScope> _function;

--- a/compiler/ecpps/src/Linker/CoffLinker.h
+++ b/compiler/ecpps/src/Linker/CoffLinker.h
@@ -56,7 +56,9 @@ namespace ecpps::linker::win
                _toRelocateWidth = toRelocateWidth;
           }
 
-          explicit CoffLinker([[maybe_unused]] const LinkerOptions<LinkerType::Coff>& options) {}
+          explicit CoffLinker([[maybe_unused]] const LinkerOptions<LinkerType::Coff>& options)
+          {
+          }
 
           std::vector<std::byte> CodeSection(std::vector<std::byte> data,
                                              const codegen::LinkerRelocationMap& relocationMap) override;

--- a/compiler/ecpps/src/Linker/Linker.cpp
+++ b/compiler/ecpps/src/Linker/Linker.cpp
@@ -8,7 +8,7 @@
 #include "dllHelp.h"
 
 std::unique_ptr<ecpps::linker::LinkerBase> ecpps::linker::Linker::CreateLinker(
-    LinkerType type, std::unique_ptr<LinkerOptionsBase> options)
+     LinkerType type, std::unique_ptr<LinkerOptionsBase> options)
 {
      switch (type)
      {
@@ -27,11 +27,11 @@ std::unique_ptr<ecpps::linker::LinkerBase> ecpps::linker::Linker::CreateLinker(
 }
 
 std::vector<std::byte> ecpps::linker::Linker::SelectAndLink(
-    const ecpps::CompilerConfig& config, std::vector<std::byte> generatedMachineCode,
-    const std::vector<std::pair<std::string, std::size_t>>& functions, std::size_t mainOffset,
-    const codegen::LinkerRelocationMap& relocationMap, std::vector<std::byte>& diagnosticsCodeSection,
-    const std::vector<std::size_t>& stringRelocations, std::size_t toRelocateWidth,
-    const std::vector<std::byte>& stringData)
+     const ecpps::CompilerConfig& config, std::vector<std::byte> generatedMachineCode,
+     const std::vector<std::pair<std::string, std::size_t>>& functions, std::size_t mainOffset,
+     const codegen::LinkerRelocationMap& relocationMap, std::vector<std::byte>& diagnosticsCodeSection,
+     const std::vector<std::size_t>& stringRelocations, std::size_t toRelocateWidth,
+     const std::vector<std::byte>& stringData)
 {
      std::unique_ptr<LinkerBase> selectedLinker = nullptr;
 
@@ -41,25 +41,25 @@ std::vector<std::byte> ecpps::linker::Linker::SelectAndLink(
      case LinkerUsed::Windows32:
      {
           selectedLinker = ecpps::linker::Linker::CreateLinker(
-              ecpps::linker::LinkerType::PE,
-              std::make_unique<ecpps::linker::LinkerOptions<ecpps::linker::LinkerType::PE>>(
-                  ecpps::linker::PESubsystem::Console, ecpps::linker::LinkType::Executable,
-                  config.linker == LinkerUsed::Windows32 ? LinkerBitness::x32 : LinkerBitness::x64));
+               ecpps::linker::LinkerType::PE,
+               std::make_unique<ecpps::linker::LinkerOptions<ecpps::linker::LinkerType::PE>>(
+                    ecpps::linker::PESubsystem::Console, ecpps::linker::LinkType::Executable,
+                    config.linker == LinkerUsed::Windows32 ? LinkerBitness::x32 : LinkerBitness::x64));
      }
      break;
      case LinkerUsed::Windows64Coff:
      {
           selectedLinker = ecpps::linker::Linker::CreateLinker(
-              ecpps::linker::LinkerType::Coff,
-              std::make_unique<ecpps::linker::LinkerOptions<ecpps::linker::LinkerType::Coff>>(LinkerBitness::x64));
+               ecpps::linker::LinkerType::Coff,
+               std::make_unique<ecpps::linker::LinkerOptions<ecpps::linker::LinkerType::Coff>>(LinkerBitness::x64));
           break;
      }
      case LinkerUsed::Caosys:
      {
           selectedLinker = ecpps::linker::Linker::CreateLinker(
-              ecpps::linker::LinkerType::PE,
-              std::make_unique<ecpps::linker::LinkerOptions<ecpps::linker::LinkerType::PE>>(
-                  ecpps::linker::PESubsystem::Console, ecpps::linker::LinkType::Executable, LinkerBitness::x64));
+               ecpps::linker::LinkerType::PE,
+               std::make_unique<ecpps::linker::LinkerOptions<ecpps::linker::LinkerType::PE>>(
+                    ecpps::linker::PESubsystem::Console, ecpps::linker::LinkType::Executable, LinkerBitness::x64));
      }
      break;
      default: return {};

--- a/compiler/ecpps/src/Linker/Linker.h
+++ b/compiler/ecpps/src/Linker/Linker.h
@@ -112,10 +112,10 @@ namespace ecpps::linker
           explicit Linker(void) = delete;
 
           static std::vector<std::byte> SelectAndLink(
-              const ecpps::CompilerConfig& config, std::vector<std::byte> generatedMachineCode,
-              const std::vector<std::pair<std::string, std::size_t>>& functions, std::size_t mainOffset,
-              const codegen::LinkerRelocationMap& relocationMap, std::vector<std::byte>& diagnosticsCodeSection,
-              const std::vector<std::size_t>& stringRelocations, std::size_t toRelocateWidth,
-              const std::vector<std::byte>& stringData);
+               const ecpps::CompilerConfig& config, std::vector<std::byte> generatedMachineCode,
+               const std::vector<std::pair<std::string, std::size_t>>& functions, std::size_t mainOffset,
+               const codegen::LinkerRelocationMap& relocationMap, std::vector<std::byte>& diagnosticsCodeSection,
+               const std::vector<std::size_t>& stringRelocations, std::size_t toRelocateWidth,
+               const std::vector<std::byte>& stringData);
      };
 } // namespace ecpps::linker

--- a/compiler/ecpps/src/Linker/Linker.h
+++ b/compiler/ecpps/src/Linker/Linker.h
@@ -81,7 +81,9 @@ namespace ecpps::linker
      {
           LinkerBitness bitness;
 
-          explicit LinkerOptions(const LinkerBitness bitness) : bitness(bitness) {}
+          explicit LinkerOptions(const LinkerBitness bitness) : bitness(bitness)
+          {
+          }
      };
 
      class LinkerBase

--- a/compiler/ecpps/src/Linker/PE.cpp
+++ b/compiler/ecpps/src/Linker/PE.cpp
@@ -290,9 +290,9 @@ ecpps::linker::win::PEImage::PEImage(std::uintptr_t imageBase, std::uint32_t ent
      this->ntHeaders.fileHeader.machine = IMAGE_FILE_MACHINE_AMD64;
      this->ntHeaders.fileHeader.sizeOfOptionalHeader = sizeof(OptionalHeader);
      this->ntHeaders.fileHeader.characteristics =
-         (linkType == LinkType::Executable ? IMAGE_FILE_EXECUTABLE_IMAGE
-                                           : (IMAGE_FILE_EXECUTABLE_IMAGE | IMAGE_FILE_DLL)) |
-         IMAGE_FILE_LARGE_ADDRESS_AWARE;
+          (linkType == LinkType::Executable ? IMAGE_FILE_EXECUTABLE_IMAGE
+                                            : (IMAGE_FILE_EXECUTABLE_IMAGE | IMAGE_FILE_DLL)) |
+          IMAGE_FILE_LARGE_ADDRESS_AWARE;
      const std::time_t currentTime = std::time(nullptr);
      this->ntHeaders.fileHeader.timeDateStamp = static_cast<std::uint32_t>(currentTime);
 
@@ -437,15 +437,15 @@ std::vector<std::byte> ecpps::linker::win::PEImage::ToBytes(const std::string& i
      // Calculate RVAs for the function addresses, names, and ordinals
      exportDirectory.AddressOfFunctions = currentOffset;
      currentOffset +=
-         AlignUp<std::uint32_t>(static_cast<std::uint32_t>(this->exports.size() * sizeof(std::uint32_t)), 1);
+          AlignUp<std::uint32_t>(static_cast<std::uint32_t>(this->exports.size() * sizeof(std::uint32_t)), 1);
 
      exportDirectory.AddressOfNames = currentOffset;
      currentOffset +=
-         AlignUp<std::uint32_t>(static_cast<std::uint32_t>(this->exports.size() * sizeof(std::uint32_t)), 1);
+          AlignUp<std::uint32_t>(static_cast<std::uint32_t>(this->exports.size() * sizeof(std::uint32_t)), 1);
 
      exportDirectory.AddressOfNameOrdinals = currentOffset; // Ensure AddressOfNameOrdinals is set
      currentOffset +=
-         AlignUp<std::uint32_t>(static_cast<std::uint32_t>(this->exports.size() * sizeof(std::uint16_t)), 1);
+          AlignUp<std::uint32_t>(static_cast<std::uint32_t>(this->exports.size() * sizeof(std::uint16_t)), 1);
 
      std::uint32_t offset = 0;
      // Serialise function addresses
@@ -470,7 +470,7 @@ std::vector<std::byte> ecpps::linker::win::PEImage::ToBytes(const std::string& i
      for (const auto& [name, address] : this->exports)
      {
           const std::size_t insertPos = std::max<std::size_t>(
-              address - exportRVA, static_cast<std::size_t>(offset + exportDirectory.AddressOfNames - exportRVA));
+               address - exportRVA, static_cast<std::size_t>(offset + exportDirectory.AddressOfNames - exportRVA));
           if (insertPos + static_cast<std::size_t>(name.size() + 1) > exportData.size())
           {
                exportData.resize(insertPos + static_cast<std::size_t>(name.size() + 1));
@@ -528,10 +528,10 @@ std::vector<std::byte> ecpps::linker::win::PEImage::ToBytes(const std::string& i
 
      // Update directories
      this->ntHeaders.optionalHeader.dataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT] =
-         DataDirectory{.VirtualAddress = importRVA, .Size = static_cast<std::uint32_t>(idataBuffer.size())};
+          DataDirectory{.VirtualAddress = importRVA, .Size = static_cast<std::uint32_t>(idataBuffer.size())};
 
      this->ntHeaders.optionalHeader.dataDirectory[IMAGE_DIRECTORY_ENTRY_IAT] = DataDirectory{
-         .VirtualAddress = iatRVA, .Size = static_cast<std::uint32_t>(totalThunkEntries * sizeof(uint64_t))};
+          .VirtualAddress = iatRVA, .Size = static_cast<std::uint32_t>(totalThunkEntries * sizeof(uint64_t))};
 
      // Update sizeOfImage
      currentRVA = importRVA + static_cast<std::uint32_t>(idataBuffer.size());
@@ -539,7 +539,7 @@ std::vector<std::byte> ecpps::linker::win::PEImage::ToBytes(const std::string& i
 
      this->ntHeaders.optionalHeader.numberOfRvaAndSizes = 14;
      this->ntHeaders.optionalHeader.dataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT] =
-         DataDirectory{.VirtualAddress = exportRVA, .Size = exportSize};
+          DataDirectory{.VirtualAddress = exportRVA, .Size = exportSize};
 
      // this->ntHeaders.optionalHeader.sizeOfImage =
      //     AlignUp(exportRVA + exportSize + static_cast<std::uint32_t>(idataBuf.size()), sectionAlignment);
@@ -548,8 +548,8 @@ std::vector<std::byte> ecpps::linker::win::PEImage::ToBytes(const std::string& i
      constexpr std::uint32_t ntHeadersOffset = AlignUp<std::uint32_t>(sizeof(DosHeader), sizeof(std::uint32_t));
      constexpr std::uint32_t sectionHeadersOffset = ntHeadersOffset + sizeof(NtHeaders);
      const std::uint32_t headersSize =
-         AlignUp(sectionHeadersOffset + static_cast<std::uint32_t>(this->sections.size() * sizeof(SectionHeader)),
-                 this->ntHeaders.optionalHeader.fileAlignment);
+          AlignUp(sectionHeadersOffset + static_cast<std::uint32_t>(this->sections.size() * sizeof(SectionHeader)),
+                  this->ntHeaders.optionalHeader.fileAlignment);
 
      this->ntHeaders.optionalHeader.sizeOfInitializedData = static_cast<std::uint32_t>(idataBuffer.size());
      this->ntHeaders.fileHeader.numberOfSections = static_cast<std::uint16_t>(this->sections.size());
@@ -564,9 +564,9 @@ std::vector<std::byte> ecpps::linker::win::PEImage::ToBytes(const std::string& i
           if (section.name == ".rdata") this->rdataRVA = currentVirtualAddress;
 
           currentVirtualAddress =
-              AlignUp(currentVirtualAddress + AlignUp(static_cast<std::uint32_t>(section.data.size()),
-                                                      this->ntHeaders.optionalHeader.sectionAlignment),
-                      this->ntHeaders.optionalHeader.sectionAlignment);
+               AlignUp(currentVirtualAddress + AlignUp(static_cast<std::uint32_t>(section.data.size()),
+                                                       this->ntHeaders.optionalHeader.sectionAlignment),
+                       this->ntHeaders.optionalHeader.sectionAlignment);
      }
 
      std::uint32_t fileSize = headersSize;
@@ -578,8 +578,8 @@ std::vector<std::byte> ecpps::linker::win::PEImage::ToBytes(const std::string& i
           section.pointerToRawData = fileSize;
           fileSize = AlignUp(fileSize + static_cast<std::uint32_t>(section.data.size()),
                              this->ntHeaders.optionalHeader.fileAlignment);
-          imageSize +=
-              AlignUp(static_cast<std::uint32_t>(section.data.size()), this->ntHeaders.optionalHeader.sectionAlignment);
+          imageSize += AlignUp(static_cast<std::uint32_t>(section.data.size()),
+                               this->ntHeaders.optionalHeader.sectionAlignment);
      }
 
      this->ntHeaders.optionalHeader.sizeOfImage = imageSize;
@@ -602,11 +602,11 @@ std::vector<std::byte> ecpps::linker::win::PEImage::ToBytes(const std::string& i
           memcpy(sectionHeadersPtr->Name, section.name.c_str(),
                  std::min(section.name.size(), sizeof(sectionHeadersPtr->Name)));
           sectionHeadersPtr->VirtualAddress =
-              AlignUp(section.virtualAddress, this->ntHeaders.optionalHeader.sectionAlignment);
+               AlignUp(section.virtualAddress, this->ntHeaders.optionalHeader.sectionAlignment);
           sectionHeadersPtr->PointerToRawData = section.pointerToRawData;
           sectionHeadersPtr->SizeOfRawData = static_cast<std::uint32_t>(section.data.size());
           sectionHeadersPtr->VirtualSize =
-              AlignUp(static_cast<std::uint32_t>(section.data.size()), this->ntHeaders.optionalHeader.fileAlignment);
+               AlignUp(static_cast<std::uint32_t>(section.data.size()), this->ntHeaders.optionalHeader.fileAlignment);
           sectionHeadersPtr->Characteristics = static_cast<std::uint32_t>(section.flags);
           ++sectionHeadersPtr;
      }

--- a/compiler/ecpps/src/Linker/WindowsLinker.cpp
+++ b/compiler/ecpps/src/Linker/WindowsLinker.cpp
@@ -23,7 +23,10 @@ std::vector<std::byte> ecpps::linker::win::WindowsLinker::CodeSection(std::vecto
      std::vector<std::pair<ByteOffset, codegen::Relocation>> sortedRelocations(relocationMap.begin(),
                                                                                relocationMap.end());
      std::ranges::sort(sortedRelocations,
-                       [](const auto& a, const auto& b) { return a.first.Value() > b.first.Value(); });
+                       [](const auto& a, const auto& b)
+                       {
+                            return a.first.Value() > b.first.Value();
+                       });
 
      std::size_t cumulativeShift = 0;
 
@@ -67,7 +70,10 @@ void ecpps::linker::win::WindowsLinker::ImportFunction(const std::string& symbol
      this->_importNameMap[symbolName] = importName;
 }
 
-void ecpps::linker::win::WindowsLinker::AddSection(const PESection& value) { this->_sections.emplace_back(value); }
+void ecpps::linker::win::WindowsLinker::AddSection(const PESection& value)
+{
+     this->_sections.emplace_back(value);
+}
 
 void ecpps::linker::win::WindowsLinker::ExportAt(const std::string& name, std::uint32_t address)
 {

--- a/compiler/ecpps/src/Linker/WindowsLinker.cpp
+++ b/compiler/ecpps/src/Linker/WindowsLinker.cpp
@@ -34,7 +34,7 @@ std::vector<std::byte> ecpps::linker::win::WindowsLinker::CodeSection(std::vecto
      {
           const auto resolvedAddress = this->LookupSymbol(relocation.symbolName, static_cast<std::uint32_t>(codeSize));
           auto toInsert =
-              relocation.apply(Address{resolvedAddress - where.Value() - cumulativeShift}, relocationThunks);
+               relocation.apply(Address{resolvedAddress - where.Value() - cumulativeShift}, relocationThunks);
 
           const auto pos = where.Value();
           for (std::size_t i = 0; i < toInsert.size() && (pos + i) < data.size(); i++) data[pos + i] = toInsert[i];
@@ -85,7 +85,7 @@ std::vector<std::byte> ecpps::linker::win::WindowsLinker::ToBytes(const std::str
                                                                   const std::vector<std::byte>& stringData) const
 {
      return this->Link(static_cast<std::uint32_t>(entryPointAddress) + ExportDisplacement)
-         .ToBytes(imageName, stringData);
+          .ToBytes(imageName, stringData);
 }
 
 template <std::integral T> constexpr static T AlignUp(const T value, const T alignment)

--- a/compiler/ecpps/src/Linker/dllHelp.cpp
+++ b/compiler/ecpps/src/Linker/dllHelp.cpp
@@ -24,7 +24,7 @@ std::unordered_map<std::string, std::vector<std::string>> GetExportsFromDlls(con
 
           ULONG size = 0;
           const auto* exports = static_cast<PIMAGE_EXPORT_DIRECTORY>(
-              ImageDirectoryEntryToData(module, TRUE, IMAGE_DIRECTORY_ENTRY_EXPORT, &size));
+               ImageDirectoryEntryToData(module, TRUE, IMAGE_DIRECTORY_ENTRY_EXPORT, &size));
 
           if (!exports || exports->NumberOfNames == 0)
           {
@@ -50,7 +50,7 @@ std::unordered_map<std::string, std::vector<std::string>> GetExportsFromDlls(con
 
 #elifdef __linux__
 std::unordered_map<std::string, std::vector<std::string>> GetExportsFromDlls(
-    [[maybe_unused]] const std::vector<std::string>& dlls)
+     [[maybe_unused]] const std::vector<std::string>& dlls)
 {
      return {};
 }

--- a/compiler/ecpps/src/Machine/ABI.cpp
+++ b/compiler/ecpps/src/Machine/ABI.cpp
@@ -36,7 +36,7 @@ ecpps::abi::ABI::ABI(ISA isa) : _isa(isa)
 {
      this->_callingConventions.emplace(std::make_unique<MicrosoftX64CallingConvention>());
      auto& specialStringRegister =
-         this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("__string", qwordSize, SIZE_MAX));
+          this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("__string", qwordSize, SIZE_MAX));
      this->_specialStringRegister = std::make_shared<VirtualRegister>("__string", specialStringRegister, 0, 0);
 
      switch (isa)
@@ -48,113 +48,113 @@ ecpps::abi::ABI::ABI(ISA isa) : _isa(isa)
           std::size_t id{};
 
           const auto& rax =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rax", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rax", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("rax", rax, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("eax", rax, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("ax", rax, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("al", rax, byteSize, 0));
 
           const auto& rcx =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rcx", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rcx", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("rcx", rcx, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("ecx", rcx, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("cx", rcx, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("cl", rcx, byteSize, 0));
 
           const auto& rdx =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rdx", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rdx", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("rdx", rdx, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("edx", rdx, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("dx", rdx, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("dl", rdx, byteSize, 0));
 
           const auto& rbx =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rbx", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rbx", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("rbx", rbx, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("ebx", rbx, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("bx", rbx, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("bl", rbx, byteSize, 0));
 
           const auto& rsp =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rsp", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rsp", qwordSize, id++));
           this->_registers.push_back(this->_stackPointerRegister =
-                                         std::make_shared<VirtualRegister>("rsp", rsp, qwordSize, 0));
+                                          std::make_shared<VirtualRegister>("rsp", rsp, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("esp", rsp, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("sp", rsp, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("spl", rsp, byteSize, 0));
 
           const auto& rbp =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rbp", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rbp", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("rbp", rbp, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("ebp", rbp, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("bp", rbp, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("bpl", rbp, byteSize, 0));
 
           const auto& rsi =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rsi", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rsi", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("rsi", rsi, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("esi", rsi, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("si", rsi, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("sil", rsi, byteSize, 0));
 
           const auto& rdi =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rdi", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("rdi", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("rdi", rdi, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("edi", rdi, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("di", rdi, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("dil", rdi, byteSize, 0));
 
           const auto& r8 =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r8", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r8", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r8", r8, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r8d", r8, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r8w", r8, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r8b", r8, byteSize, 0));
 
           const auto& r9 =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r9", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r9", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r9", r9, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r9d", r9, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r9w", r9, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r9b", r9, byteSize, 0));
 
           const auto& r10 =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r10", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r10", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r10", r10, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r10d", r10, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r10w", r10, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r10b", r10, byteSize, 0));
 
           const auto& r11 =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r11", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r11", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r11", r11, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r11d", r11, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r11w", r11, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r11b", r11, byteSize, 0));
 
           const auto& r12 =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r12", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r12", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r12", r12, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r12d", r12, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r12w", r12, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r12b", r12, byteSize, 0));
 
           const auto& r13 =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r13", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r13", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r13", r13, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r13d", r13, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r13w", r13, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r13b", r13, byteSize, 0));
 
           const auto& r14 =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r14", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r14", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r14", r14, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r14d", r14, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r14w", r14, wordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r14b", r14, byteSize, 0));
 
           const auto& r15 =
-              this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r15", qwordSize, id++));
+               this->_physicalRegisters.emplace_back(std::make_shared<PhysicalRegister>("r15", qwordSize, id++));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r15", r15, qwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r15d", r15, dwordSize, 0));
           this->_registers.push_back(std::make_shared<VirtualRegister>("r15w", r15, wordSize, 0));
@@ -178,7 +178,7 @@ void ecpps::abi::ABI::PushSIMDRegisters(const SimdFeatures simd)
                for (std::size_t i = 0; i < 16; i++)
                {
                     const auto& physicalReg = this->_physicalRegisters.emplace_back(
-                        std::make_shared<PhysicalRegister>(std::string("xmm") + std::to_string(i), zmmSize, id++));
+                         std::make_shared<PhysicalRegister>(std::string("xmm") + std::to_string(i), zmmSize, id++));
                     this->_registers.push_back(std::make_shared<VirtualRegister>(std::string("zmm") + std::to_string(i),
                                                                                  physicalReg, zmmSize, 0));
                     this->_registers.push_back(std::make_shared<VirtualRegister>(std::string("ymm") + std::to_string(i),
@@ -192,7 +192,7 @@ void ecpps::abi::ABI::PushSIMDRegisters(const SimdFeatures simd)
                for (std::size_t i = 0; i < 16; i++)
                {
                     const auto& physicalReg = this->_physicalRegisters.emplace_back(
-                        std::make_shared<PhysicalRegister>(std::string("xmm") + std::to_string(i), ymmSize, id++));
+                         std::make_shared<PhysicalRegister>(std::string("xmm") + std::to_string(i), ymmSize, id++));
                     this->_registers.push_back(std::make_shared<VirtualRegister>(std::string("ymm") + std::to_string(i),
                                                                                  physicalReg, ymmSize, 0));
                     this->_registers.push_back(std::make_shared<VirtualRegister>(std::string("xmm") + std::to_string(i),
@@ -206,9 +206,9 @@ void ecpps::abi::ABI::PushSIMDRegisters(const SimdFeatures simd)
                {
                     auto registerName = std::string("xmm") + std::to_string(i);
                     const auto& physicalReg = this->_physicalRegisters.emplace_back(
-                        std::make_shared<PhysicalRegister>(registerName, xmmSize, id++));
+                         std::make_shared<PhysicalRegister>(registerName, xmmSize, id++));
                     this->_registers.push_back(
-                        std::make_shared<VirtualRegister>(registerName, physicalReg, xmmSize, 0));
+                         std::make_shared<VirtualRegister>(registerName, physicalReg, xmmSize, 0));
                }
           }
      }
@@ -352,7 +352,7 @@ ecpps::abi::CallingConvention& ecpps::abi::ABI::CallingConventionFromName(Callin
 }
 
 ecpps::abi::StorageRef ecpps::abi::MicrosoftX64CallingConvention::ReturnValueStorage(
-    StorageRequirement storageSize) const
+     StorageRequirement storageSize) const
 {
      switch (storageSize.kind)
      {
@@ -402,7 +402,7 @@ ecpps::abi::StorageRef ecpps::abi::MicrosoftX64CallingConvention::ReturnValueSto
 }
 
 std::vector<ecpps::abi::StorageRef> ecpps::abi::MicrosoftX64CallingConvention::LocateParameters(
-    [[maybe_unused]] StorageRequirement returnSize, std::vector<StorageRequirement> parameters) const
+     [[maybe_unused]] StorageRequirement returnSize, std::vector<StorageRequirement> parameters) const
 {
      std::vector<ecpps::abi::StorageRef> result{};
      result.reserve(parameters.size());
@@ -451,7 +451,7 @@ std::vector<ecpps::abi::StorageRef> ecpps::abi::MicrosoftX64CallingConvention::L
                if (!registerName.empty())
                {
                     auto allocatedReg =
-                        ABI::Current().AllocateRegister(widthInBits, registerName, abi::RegisterAllocation::Priority);
+                         ABI::Current().AllocateRegister(widthInBits, registerName, abi::RegisterAllocation::Priority);
 
                     if (allocatedReg.Ptr() != nullptr)
                     {
@@ -462,7 +462,7 @@ std::vector<ecpps::abi::StorageRef> ecpps::abi::MicrosoftX64CallingConvention::L
                if (std::holds_alternative<std::monostate>(storage.value))
                {
                     storage = StorageRef{
-                        MemoryLocation{.offset = shadowOffset, .reg = ABI::Current().StackPointerRegister()}};
+                         MemoryLocation{.offset = shadowOffset, .reg = ABI::Current().StackPointerRegister()}};
                }
                shadowOffset += 8;
           }
@@ -479,7 +479,7 @@ std::vector<ecpps::abi::StorageRef> ecpps::abi::MicrosoftX64CallingConvention::L
 }
 
 ecpps::abi::StorageRequirement ecpps::abi::MicrosoftX64CallingConvention::GetRequirementsForType(
-    typeSystem::NonowningTypePointer type) const
+     typeSystem::NonowningTypePointer type) const
 {
      if (IsIntegral(type))
      {
@@ -502,7 +502,7 @@ ecpps::abi::StorageRequirement ecpps::abi::MicrosoftX64CallingConvention::GetReq
 }
 
 std::size_t ecpps::abi::MicrosoftX64CallingConvention::CalculateArgumentStackSpace(
-    [[maybe_unused]] StorageRequirement returnSize, const std::vector<StorageRequirement>& parameters) const
+     [[maybe_unused]] StorageRequirement returnSize, const std::vector<StorageRequirement>& parameters) const
 {
      if (parameters.size() <= 4) return 0;
 
@@ -535,7 +535,7 @@ struct Microsoftx64StackManager final : ecpps::abi::ProcedureStackManager
           this->_currentStackSize += request.size;
 
           return ecpps::abi::StorageRef{
-              ecpps::abi::MemoryLocation{.offset = variableOffset, .reg = ABI::Current().StackPointerRegister()}};
+               ecpps::abi::MemoryLocation{.offset = variableOffset, .reg = ABI::Current().StackPointerRegister()}};
      }
 
      [[nodiscard]] std::size_t GetParameterAdjustment(void) const final
@@ -562,13 +562,13 @@ private:
 };
 
 std::unique_ptr<ecpps::abi::ProcedureStackManager> ecpps::abi::MicrosoftX64CallingConvention::BeginStack(
-    std::vector<ecpps::codegen::Instruction>& instructions) const
+     std::vector<ecpps::codegen::Instruction>& instructions) const
 {
      return std::make_unique<Microsoftx64StackManager>(instructions, *this);
 }
 
 std::unique_ptr<ecpps::abi::CallTemporaryProxy> ecpps::abi::MicrosoftX64CallingConvention::PrepareForCall(
-    std::vector<ecpps::codegen::Instruction>& instructions)
+     std::vector<ecpps::codegen::Instruction>& instructions)
 {
      auto& abi = ABI::Current();
      const auto pointerWidth = abi.PointerSize() * byteSize;
@@ -617,39 +617,39 @@ std::unique_ptr<ecpps::abi::CallTemporaryProxy> ecpps::abi::MicrosoftX64CallingC
      if (wasRcxUsed)
      {
           instructions.emplace_back(ecpps::codegen::MovInstruction{
-              ecpps::codegen::RegisterOperand{rcx},
-              ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, 0, pointerWidth},
-              pointerWidth});
+               ecpps::codegen::RegisterOperand{rcx},
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, 0, pointerWidth},
+               pointerWidth});
           savedRegisters.set(0);
      }
 
      if (wasRdxUsed)
      {
-          instructions.emplace_back(
-              ecpps::codegen::MovInstruction{ecpps::codegen::RegisterOperand{rdx},
-                                             ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp},
-                                                                                   abi.PointerSize(), pointerWidth},
-                                             pointerWidth});
+          instructions.emplace_back(ecpps::codegen::MovInstruction{
+               ecpps::codegen::RegisterOperand{rdx},
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, abi.PointerSize(),
+                                                     pointerWidth},
+               pointerWidth});
           savedRegisters.set(1);
      }
 
      if (wasR8Used)
      {
-          instructions.emplace_back(
-              ecpps::codegen::MovInstruction{ecpps::codegen::RegisterOperand{r8},
-                                             ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp},
-                                                                                   2 * abi.PointerSize(), pointerWidth},
-                                             pointerWidth});
+          instructions.emplace_back(ecpps::codegen::MovInstruction{
+               ecpps::codegen::RegisterOperand{r8},
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, 2 * abi.PointerSize(),
+                                                     pointerWidth},
+               pointerWidth});
           savedRegisters.set(2);
      }
 
      if (wasR9Used)
      {
-          instructions.emplace_back(
-              ecpps::codegen::MovInstruction{ecpps::codegen::RegisterOperand{r8},
-                                             ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp},
-                                                                                   3 * abi.PointerSize(), pointerWidth},
-                                             pointerWidth});
+          instructions.emplace_back(ecpps::codegen::MovInstruction{
+               ecpps::codegen::RegisterOperand{r8},
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, 3 * abi.PointerSize(),
+                                                     pointerWidth},
+               pointerWidth});
           savedRegisters.set(3);
      }
 
@@ -675,9 +675,9 @@ void ecpps::abi::AllocatedRegister::Release(void)
      if (this->_register == nullptr) return;
 
      (*abi::ABI::Current()
-           ._allocatedRegisters.try_emplace(std::exchange(this->_register, nullptr)->physical->id, 1)
-           .first)
-         .second--;
+            ._allocatedRegisters.try_emplace(std::exchange(this->_register, nullptr)->physical->id, 1)
+            .first)
+          .second--;
 }
 
 std::vector<ecpps::codegen::Instruction> Microsoftx64StackManager::GeneratePrologue(void) const
@@ -685,8 +685,8 @@ std::vector<ecpps::codegen::Instruction> Microsoftx64StackManager::GenerateProlo
      std::vector<ecpps::codegen::Instruction> instructions{};
      const auto& stackPointerRegister = ABI::Current().StackPointerRegister();
      instructions.emplace_back(ecpps::codegen::SubInstruction{
-         ecpps::codegen::IntegerOperand{((this->_currentStackSize + 15uz) & ~15uz) + 8, stackPointerRegister->width},
-         ecpps::codegen::RegisterOperand{stackPointerRegister}, stackPointerRegister->width});
+          ecpps::codegen::IntegerOperand{((this->_currentStackSize + 15uz) & ~15uz) + 8, stackPointerRegister->width},
+          ecpps::codegen::RegisterOperand{stackPointerRegister}, stackPointerRegister->width});
      return instructions;
 }
 
@@ -695,8 +695,8 @@ std::vector<ecpps::codegen::Instruction> Microsoftx64StackManager::GenerateEpilo
      std::vector<ecpps::codegen::Instruction> instructions{};
      const auto& stackPointerRegister = ABI::Current().StackPointerRegister();
      instructions.emplace_back(ecpps::codegen::AddInstruction{
-         ecpps::codegen::IntegerOperand{((this->_currentStackSize + 15uz) & ~15uz) + 8, stackPointerRegister->width},
-         ecpps::codegen::RegisterOperand{stackPointerRegister}, stackPointerRegister->width});
+          ecpps::codegen::IntegerOperand{((this->_currentStackSize + 15uz) & ~15uz) + 8, stackPointerRegister->width},
+          ecpps::codegen::RegisterOperand{stackPointerRegister}, stackPointerRegister->width});
      return instructions;
 }
 
@@ -747,24 +747,24 @@ void ecpps::abi::WindowsABICallProxy::End(std::vector<ecpps::codegen::Instructio
 
      if (wasRcxUsed)
           instructions.emplace_back(ecpps::codegen::MovInstruction{
-              ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, 0, pointerWidth},
-              ecpps::codegen::RegisterOperand{rcx}, pointerWidth});
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, 0, pointerWidth},
+               ecpps::codegen::RegisterOperand{rcx}, pointerWidth});
 
      if (wasRdxUsed)
-          instructions.emplace_back(
-              ecpps::codegen::MovInstruction{ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp},
-                                                                                   abi.PointerSize(), pointerWidth},
-                                             ecpps::codegen::RegisterOperand{rdx}, pointerWidth});
+          instructions.emplace_back(ecpps::codegen::MovInstruction{
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, abi.PointerSize(),
+                                                     pointerWidth},
+               ecpps::codegen::RegisterOperand{rdx}, pointerWidth});
 
      if (wasR8Used)
-          instructions.emplace_back(
-              ecpps::codegen::MovInstruction{ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp},
-                                                                                   2 * abi.PointerSize(), pointerWidth},
-                                             ecpps::codegen::RegisterOperand{r8}, pointerWidth});
+          instructions.emplace_back(ecpps::codegen::MovInstruction{
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, 2 * abi.PointerSize(),
+                                                     pointerWidth},
+               ecpps::codegen::RegisterOperand{r8}, pointerWidth});
 
      if (wasR9Used)
-          instructions.emplace_back(
-              ecpps::codegen::MovInstruction{ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp},
-                                                                                   3 * abi.PointerSize(), pointerWidth},
-                                             ecpps::codegen::RegisterOperand{r9}, pointerWidth});
+          instructions.emplace_back(ecpps::codegen::MovInstruction{
+               ecpps::codegen::MemoryLocationOperand{ecpps::codegen::RegisterOperand{rsp}, 3 * abi.PointerSize(),
+                                                     pointerWidth},
+               ecpps::codegen::RegisterOperand{r9}, pointerWidth});
 }

--- a/compiler/ecpps/src/Machine/ABI.cpp
+++ b/compiler/ecpps/src/Machine/ABI.cpp
@@ -217,12 +217,18 @@ void ecpps::abi::ABI::PushSIMDRegisters(const SimdFeatures simd)
      }
 }
 
-ABI& ecpps::abi::ABI::Current(void) { return ABI::_current; }
+ABI& ecpps::abi::ABI::Current(void)
+{
+     return ABI::_current;
+}
 
 template <std::size_t TTo, std::size_t TFrom>
 std::size_t ecpps::abi::ABI::ConvertEndian(std::size_t value) const noexcept
 {
-     if constexpr (TFrom == 1) { return value & ((std::size_t{1} << CHAR_BIT) - 1); }
+     if constexpr (TFrom == 1)
+     {
+          return value & ((std::size_t{1} << CHAR_BIT) - 1);
+     }
 
      std::size_t result = 0;
 
@@ -447,7 +453,10 @@ std::vector<ecpps::abi::StorageRef> ecpps::abi::MicrosoftX64CallingConvention::L
                     auto allocatedReg =
                         ABI::Current().AllocateRegister(widthInBits, registerName, abi::RegisterAllocation::Priority);
 
-                    if (allocatedReg.Ptr() != nullptr) { storage = StorageRef{std::move(allocatedReg)}; }
+                    if (allocatedReg.Ptr() != nullptr)
+                    {
+                         storage = StorageRef{std::move(allocatedReg)};
+                    }
                }
 
                if (std::holds_alternative<std::monostate>(storage.value))
@@ -479,7 +488,10 @@ ecpps::abi::StorageRequirement ecpps::abi::MicrosoftX64CallingConvention::GetReq
           return StorageRequirement{integralType->Size(), integralType->Alignment(), RequiredStorageKind::Integer};
      }
 
-     if (IsPointer(type)) { return StorageRequirement{8, 8, RequiredStorageKind::Integer}; }
+     if (IsPointer(type))
+     {
+          return StorageRequirement{8, 8, RequiredStorageKind::Integer};
+     }
      if (IsFloatingPoint(type))
      {
           // TODO: Implement floating-point types
@@ -495,7 +507,10 @@ std::size_t ecpps::abi::MicrosoftX64CallingConvention::CalculateArgumentStackSpa
      if (parameters.size() <= 4) return 0;
 
      std::size_t stackSpace = 0;
-     for (std::size_t i = 4; i < parameters.size(); i++) { stackSpace += std::max<std::size_t>(parameters[i].size, 8); }
+     for (std::size_t i = 4; i < parameters.size(); i++)
+     {
+          stackSpace += std::max<std::size_t>(parameters[i].size, 8);
+     }
 
      return stackSpace;
 }
@@ -527,7 +542,9 @@ struct Microsoftx64StackManager final : ecpps::abi::ProcedureStackManager
      {
           return (((this->_currentStackSize) + 15uz) & ~15uz) + 16uz;
      }
-     void AfterParameters(void) const override {}
+     void AfterParameters(void) const override
+     {
+     }
      void ReserveCallArgumentSpace(std::size_t argumentStackSpace) final
      {
           this->_maxCallArgumentSpace = std::max(this->_maxCallArgumentSpace, argumentStackSpace);

--- a/compiler/ecpps/src/Machine/ABI.h
+++ b/compiler/ecpps/src/Machine/ABI.h
@@ -116,9 +116,9 @@ namespace ecpps::abi
 
           [[nodiscard]] virtual StorageRef ReturnValueStorage(StorageRequirement storageSize) const = 0;
           [[nodiscard]] virtual std::vector<StorageRef> LocateParameters(
-              StorageRequirement returnSize, std::vector<StorageRequirement> parameters) const = 0;
+               StorageRequirement returnSize, std::vector<StorageRequirement> parameters) const = 0;
           [[nodiscard]] virtual StorageRequirement GetRequirementsForType(
-              typeSystem::NonowningTypePointer type) const = 0;
+               typeSystem::NonowningTypePointer type) const = 0;
 
           [[nodiscard]] CallingConventionName Name(void) const noexcept
           {
@@ -133,11 +133,11 @@ namespace ecpps::abi
                return this->_stackAlignment;
           }
           [[nodiscard]] virtual std::unique_ptr<ProcedureStackManager> BeginStack(
-              std::vector<ecpps::codegen::Instruction>&) const = 0;
+               std::vector<ecpps::codegen::Instruction>&) const = 0;
           [[nodiscard]] virtual std::unique_ptr<CallTemporaryProxy> PrepareForCall(
-              std::vector<ecpps::codegen::Instruction>& instructions) = 0;
+               std::vector<ecpps::codegen::Instruction>& instructions) = 0;
           [[nodiscard]] virtual std::size_t CalculateArgumentStackSpace(
-              StorageRequirement returnSize, const std::vector<StorageRequirement>& parameters) const = 0;
+               StorageRequirement returnSize, const std::vector<StorageRequirement>& parameters) const = 0;
 
      protected:
           CallingConventionName _name;
@@ -153,14 +153,14 @@ namespace ecpps::abi
 
           [[nodiscard]] StorageRef ReturnValueStorage(StorageRequirement storageSize) const override;
           [[nodiscard]] std::vector<StorageRef> LocateParameters(
-              StorageRequirement returnSize, std::vector<StorageRequirement> parameters) const override;
+               StorageRequirement returnSize, std::vector<StorageRequirement> parameters) const override;
           [[nodiscard]] StorageRequirement GetRequirementsForType(typeSystem::NonowningTypePointer type) const override;
           [[nodiscard]] std::unique_ptr<ProcedureStackManager> BeginStack(
-              std::vector<ecpps::codegen::Instruction>& instructions) const final override;
+               std::vector<ecpps::codegen::Instruction>& instructions) const final override;
           [[nodiscard]] std::unique_ptr<CallTemporaryProxy> PrepareForCall(
-              std::vector<ecpps::codegen::Instruction>& instructions) final override;
+               std::vector<ecpps::codegen::Instruction>& instructions) final override;
           [[nodiscard]] std::size_t CalculateArgumentStackSpace(
-              StorageRequirement returnSize, const std::vector<StorageRequirement>& parameters) const final;
+               StorageRequirement returnSize, const std::vector<StorageRequirement>& parameters) const final;
      };
 
      enum struct RegisterAllocation : bool

--- a/compiler/ecpps/src/Machine/ABI.h
+++ b/compiler/ecpps/src/Machine/ABI.h
@@ -75,7 +75,10 @@ namespace ecpps::abi
 
      struct CallTemporaryProxy
      {
-          virtual ~CallTemporaryProxy(void) { runtime_assert(this->_hasFinished, "Finish() was not called"); }
+          virtual ~CallTemporaryProxy(void)
+          {
+               runtime_assert(this->_hasFinished, "Finish() was not called");
+          }
 
           void Finish(std::vector<ecpps::codegen::Instruction>& instructions)
           {
@@ -93,7 +96,9 @@ namespace ecpps::abi
 
      struct WindowsABICallProxy final : CallTemporaryProxy
      {
-          explicit WindowsABICallProxy(const std::bitset<4> savedRegisters) : _savedRegisters(savedRegisters) {}
+          explicit WindowsABICallProxy(const std::bitset<4> savedRegisters) : _savedRegisters(savedRegisters)
+          {
+          }
           void End(std::vector<ecpps::codegen::Instruction>& instructions) override;
 
      private:
@@ -115,9 +120,18 @@ namespace ecpps::abi
           [[nodiscard]] virtual StorageRequirement GetRequirementsForType(
               typeSystem::NonowningTypePointer type) const = 0;
 
-          [[nodiscard]] CallingConventionName Name(void) const noexcept { return this->_name; }
-          [[nodiscard]] std::size_t ShadowSpaceSize(void) const noexcept { return this->_shadowSpace; }
-          [[nodiscard]] std::size_t StackAlignment(void) const noexcept { return this->_stackAlignment; }
+          [[nodiscard]] CallingConventionName Name(void) const noexcept
+          {
+               return this->_name;
+          }
+          [[nodiscard]] std::size_t ShadowSpaceSize(void) const noexcept
+          {
+               return this->_shadowSpace;
+          }
+          [[nodiscard]] std::size_t StackAlignment(void) const noexcept
+          {
+               return this->_stackAlignment;
+          }
           [[nodiscard]] virtual std::unique_ptr<ProcedureStackManager> BeginStack(
               std::vector<ecpps::codegen::Instruction>&) const = 0;
           [[nodiscard]] virtual std::unique_ptr<CallTemporaryProxy> PrepareForCall(
@@ -166,7 +180,10 @@ namespace ecpps::abi
 
           static ABI& Current(void);
 
-          [[nodiscard]] ISA Isa(void) const noexcept { return this->_isa; }
+          [[nodiscard]] ISA Isa(void) const noexcept
+          {
+               return this->_isa;
+          }
           [[nodiscard]] AllocatedRegister AllocateRegister(std::size_t width);
           [[nodiscard]] AllocatedRegister AllocateRegister(std::size_t width, const std::string& name,
                                                            RegisterAllocation allocation);
@@ -202,11 +219,26 @@ namespace ecpps::abi
           {
                return this->_registers;
           }
-          [[nodiscard]] std::size_t PointerSize(void) const noexcept { return this->_pointerSize; }
-          [[nodiscard]] typeSystem::TypeKind SizeSize(void) const noexcept { return this->sizeSize; }
-          [[nodiscard]] typeSystem::TypeKind PtrDiffSize(void) const noexcept { return this->ptrdiffSize; }
-          [[nodiscard]] typeSystem::TypeKind IntPtrSize(void) const noexcept { return this->intptrSize; }
-          [[nodiscard]] typeSystem::TypeKind BoolSize(void) const noexcept { return this->boolSize; }
+          [[nodiscard]] std::size_t PointerSize(void) const noexcept
+          {
+               return this->_pointerSize;
+          }
+          [[nodiscard]] typeSystem::TypeKind SizeSize(void) const noexcept
+          {
+               return this->sizeSize;
+          }
+          [[nodiscard]] typeSystem::TypeKind PtrDiffSize(void) const noexcept
+          {
+               return this->ptrdiffSize;
+          }
+          [[nodiscard]] typeSystem::TypeKind IntPtrSize(void) const noexcept
+          {
+               return this->intptrSize;
+          }
+          [[nodiscard]] typeSystem::TypeKind BoolSize(void) const noexcept
+          {
+               return this->boolSize;
+          }
 
           template <std::size_t TTo, std::size_t TFrom>
           [[nodiscard]] std::size_t ConvertEndian(std::size_t value) const noexcept;

--- a/compiler/ecpps/src/Machine/Machine.h
+++ b/compiler/ecpps/src/Machine/Machine.h
@@ -76,6 +76,8 @@ namespace ecpps::abi
           ISA isa;
           SimdFeatures features;
 
-          explicit CPUFeatures(const ISA isa, const SimdFeatures features) : isa(isa), features(features) {}
+          explicit CPUFeatures(const ISA isa, const SimdFeatures features) : isa(isa), features(features)
+          {
+          }
      };
 } // namespace ecpps::abi

--- a/compiler/ecpps/src/Machine/Storage.h
+++ b/compiler/ecpps/src/Machine/Storage.h
@@ -101,7 +101,7 @@ namespace ecpps::abi
      struct StorageRef
      {
           using ValueType =
-              std::variant<std::monostate, AllocatedRegister, std::vector<AllocatedRegister>, MemoryLocation>;
+               std::variant<std::monostate, AllocatedRegister, std::vector<AllocatedRegister>, MemoryLocation>;
           ValueType value;
           explicit StorageRef(ValueType value) : value(std::move(value))
           {

--- a/compiler/ecpps/src/Machine/Storage.h
+++ b/compiler/ecpps/src/Machine/Storage.h
@@ -23,8 +23,14 @@ namespace ecpps::abi
           std::size_t width;
           std::size_t id;
 
-          constexpr bool operator==(const PhysicalRegister& other) const { return this->id == other.id; }
-          constexpr bool operator!=(const PhysicalRegister& other) const { return this->id != other.id; }
+          constexpr bool operator==(const PhysicalRegister& other) const
+          {
+               return this->id == other.id;
+          }
+          constexpr bool operator!=(const PhysicalRegister& other) const
+          {
+               return this->id != other.id;
+          }
 
           /// <summary>
           /// Constructs a new register object
@@ -63,12 +69,24 @@ namespace ecpps::abi
           ~AllocatedRegister(void);
           void Release(void);
 
-          [[nodiscard]] bool operator!(void) const noexcept { return this->_register != nullptr; }
+          [[nodiscard]] bool operator!(void) const noexcept
+          {
+               return this->_register != nullptr;
+          }
 
-          VirtualRegister* operator->(void) noexcept { return this->_register.get(); }
-          const VirtualRegister* operator->(void) const noexcept { return this->_register.get(); }
+          VirtualRegister* operator->(void) noexcept
+          {
+               return this->_register.get();
+          }
+          const VirtualRegister* operator->(void) const noexcept
+          {
+               return this->_register.get();
+          }
 
-          const std::shared_ptr<VirtualRegister>& Ptr(void) const noexcept { return this->_register; }
+          const std::shared_ptr<VirtualRegister>& Ptr(void) const noexcept
+          {
+               return this->_register;
+          }
 
      private:
           std::shared_ptr<VirtualRegister> _register;
@@ -85,8 +103,12 @@ namespace ecpps::abi
           using ValueType =
               std::variant<std::monostate, AllocatedRegister, std::vector<AllocatedRegister>, MemoryLocation>;
           ValueType value;
-          explicit StorageRef(ValueType value) : value(std::move(value)) {}
-          explicit(false) StorageRef(std::nullptr_t) : value(std::monostate{}) {}
+          explicit StorageRef(ValueType value) : value(std::move(value))
+          {
+          }
+          explicit(false) StorageRef(std::nullptr_t) : value(std::monostate{})
+          {
+          }
 
           StorageRef& operator=(ValueType other)
           {

--- a/compiler/ecpps/src/Parsing/AST.cpp
+++ b/compiler/ecpps/src/Parsing/AST.cpp
@@ -1,7 +1,6 @@
 #include "AST.h"
 #include <RuntimeAssert.h>
 #include <format>
-#include <iterator>
 #include <ranges>
 #include <unordered_set>
 #include <utility>
@@ -30,14 +29,14 @@ std::vector<NodePointer> ecpps::ast::AST::Parse(ASTContext& context)
 }
 
 std::unique_ptr<ecpps::ast::IdentifierNode, ecpps::ast::ASTDeleter> ecpps::ast::AST::ParseIdentifier(
-    ASTContext& context)
+     ASTContext& context)
 {
      if (Peek().type != TokenType::Identifier) return nullptr;
      const auto& identifier = Peek();
      Advance();
      runtime_assert(std::holds_alternative<std::string>(identifier.value), "Identifier was not an identifier");
      return std::unique_ptr<IdentifierNode, ecpps::ast::ASTDeleter>(
-         new (context) IdentifierNode(std::get<std::string>(identifier.value), identifier.location));
+          new (context) IdentifierNode(std::get<std::string>(identifier.value), identifier.location));
 }
 
 NodePointer ecpps::ast::AST::ParseSimpleTypeSpecifier(ASTContext& context, bool isConst, bool isVolatile)
@@ -49,11 +48,11 @@ NodePointer ecpps::ast::AST::ParseSimpleTypeSpecifier(ASTContext& context, bool 
           source.endPosition = Peek().location.endPosition;
           Advance();
           return std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(
-              new (context) BasicType(std::get<std::string>(Peek(-1).value), source, isConst, isVolatile));
+               new (context) BasicType(std::get<std::string>(Peek(-1).value), source, isConst, isVolatile));
      }
      const auto& peek = Peek();
      this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-         std::format("Expected a simple-type-specifier, found "), peek.location));
+          std::format("Expected a simple-type-specifier, found "), peek.location));
      Advance();
      return nullptr; // TODO: Error
 }
@@ -103,7 +102,7 @@ ecpps::ast::ASTExpected ecpps::ast::AST::ParseTypeId(ASTContext& context)
           std::string combinedType = CombineTypeWords(typeWords);
 
           type = std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(
-              new (context) BasicType(combinedType, source, leadConst, leadVolatile));
+               new (context) BasicType(combinedType, source, leadConst, leadVolatile));
      }
      else if (Peek().type == TokenType::Identifier)
      {
@@ -112,7 +111,7 @@ ecpps::ast::ASTExpected ecpps::ast::AST::ParseTypeId(ASTContext& context)
           source.endPosition = peekSource.endPosition;
           Advance();
           type = std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(
-              new (context) BasicType(typeName, source, leadConst, leadVolatile));
+               new (context) BasicType(typeName, source, leadConst, leadVolatile));
      }
      else
           type = ParseSimpleTypeSpecifier(context, leadConst, leadVolatile);
@@ -126,21 +125,21 @@ ecpps::ast::ASTExpected ecpps::ast::AST::ParseTypeId(ASTContext& context)
                source.endPosition = peekSource.endPosition;
 
                type = std::unique_ptr<PointerType, ASTDeleter>(
-                   new (context) PointerType(std::move(type), isConst, isVolatile, source));
+                    new (context) PointerType(std::move(type), isConst, isVolatile, source));
           }
           else if (Peek().type == TokenType::Operator && std::get<std::string>(Peek().value) == "&") // lvalue ref
           {
                const auto& peekSource = Peek().location;
                source.endPosition = peekSource.endPosition;
                type = std::unique_ptr<ReferenceType, ASTDeleter>(
-                   new (context) ReferenceType(std::move(type), ReferenceType::Kind::LValue, source));
+                    new (context) ReferenceType(std::move(type), ReferenceType::Kind::LValue, source));
           }
           else if (Peek().type == TokenType::Operator && std::get<std::string>(Peek().value) == "&&") // rvalue ref
           {
                const auto& peekSource = Peek().location;
                source.endPosition = peekSource.endPosition;
                type = std::unique_ptr<ReferenceType, ASTDeleter>(
-                   new (context) ReferenceType(std::move(type), ReferenceType::Kind::RValue, source));
+                    new (context) ReferenceType(std::move(type), ReferenceType::Kind::RValue, source));
           }
           else
           {
@@ -207,7 +206,7 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                     }
                     source.endPosition = Peek(-1).location.endPosition;
                     return std::unique_ptr<NamespaceAliasNode, ecpps::ast::ASTDeleter>(
-                        new (context) NamespaceAliasNode(std::move(name), std::move(aliased), source));
+                         new (context) NamespaceAliasNode(std::move(name), std::move(aliased), source));
                }
                std::vector<std::pair<std::unique_ptr<IdentifierNode, ecpps::ast::ASTDeleter>, bool>> nestedNames;
                nestedNames.emplace_back(std::move(name), false);
@@ -219,7 +218,7 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                     if (nestedName == nullptr)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Expected identifier in nested namespace declaration", Peek().location));
+                              "Expected identifier in nested namespace declaration", Peek().location));
                          return nullptr;
                     }
                     nestedNames.emplace_back(std::move(nestedName), false);
@@ -239,7 +238,7 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                     if (!Match(TokenType::RightBrace))
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Expected '}' at end of namespace definition", Peek().location));
+                              "Expected '}' at end of namespace definition", Peek().location));
                          return nullptr;
                     }
 
@@ -248,14 +247,14 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                     auto back = std::move(nestedNames.back());
                     nestedNames.pop_back();
                     std::unique_ptr<NamespaceNode, ecpps::ast::ASTDeleter> currentNode =
-                        std::unique_ptr<NamespaceNode, ecpps::ast::ASTDeleter>(
-                            new (context) NamespaceNode(std::move(back.first), std::move(declarations), source));
+                         std::unique_ptr<NamespaceNode, ecpps::ast::ASTDeleter>(
+                              new (context) NamespaceNode(std::move(back.first), std::move(declarations), source));
                     for (auto& nestedName : std::ranges::reverse_view(nestedNames) | std::views::keys)
                     {
                          SBOVector<NodePointer> decls{};
                          decls.Push(std::move(currentNode));
                          currentNode = std::unique_ptr<NamespaceNode, ecpps::ast::ASTDeleter>(
-                             new (context) NamespaceNode(std::move(nestedName), std::move(decls), source));
+                              new (context) NamespaceNode(std::move(nestedName), std::move(decls), source));
                     }
                     return currentNode;
                }
@@ -268,14 +267,14 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                if (aliasName == nullptr)
                {
                     this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                        "Expected identifier after 'using'", Peek().location));
+                         "Expected identifier after 'using'", Peek().location));
                     return nullptr;
                }
 
                if (Peek().type != TokenType::Operator || std::get<std::string>(Peek().value) != "=")
                {
                     this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                        "Expected '=' in using alias-declaration", Peek().location));
+                         "Expected '=' in using alias-declaration", Peek().location));
                     return nullptr;
                }
                Advance(); // =
@@ -315,14 +314,14 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                     std::string combinedType = CombineTypeWords(typeWords);
 
                     targetType = std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(
-                        new (context) BasicType(combinedType, source, nextConst, nextVolatile));
+                         new (context) BasicType(combinedType, source, nextConst, nextVolatile));
                }
                else if (Peek().type == TokenType::Identifier)
                {
                     while (true)
                     {
                          NodePointer part = std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(new (context) BasicType(
-                             std::get<std::string>(Peek().value), Peek().location, nextConst, nextVolatile));
+                              std::get<std::string>(Peek().value), Peek().location, nextConst, nextVolatile));
                          Advance();
                          nextConst = false;
                          nextVolatile = false;
@@ -332,7 +331,7 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                          {
                               // TODO: Implement template arguments parsing
                               part = std::unique_ptr<QualifiedType, ecpps::ast::ASTDeleter>(new (context) QualifiedType(
-                                  SBOVector<QualifiedType::Section>{}, std::move(part), Peek().location));
+                                   SBOVector<QualifiedType::Section>{}, std::move(part), Peek().location));
                               isTemplate = true;
                          }
 
@@ -344,7 +343,7 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                          else
                          {
                               targetType = std::unique_ptr<QualifiedType, ecpps::ast::ASTDeleter>(
-                                  new (context) QualifiedType(std::move(sections), std::move(part), Peek().location));
+                                   new (context) QualifiedType(std::move(sections), std::move(part), Peek().location));
                               break;
                          }
                     }
@@ -352,7 +351,7 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                else
                {
                     this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                        "Expected type-id after '=' in using alias-declaration", Peek().location));
+                         "Expected type-id after '=' in using alias-declaration", Peek().location));
                     return nullptr;
                }
 
@@ -373,19 +372,19 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                     }
 
                     targetType = std::unique_ptr<PointerType, ecpps::ast::ASTDeleter>(
-                        new (context) PointerType(std::move(targetType), source));
+                         new (context) PointerType(std::move(targetType), source));
                }
 
                if (!Match(TokenType::SemiColon))
                {
                     this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                        "Expected ';' at end of using alias-declaration", Peek().location));
+                         "Expected ';' at end of using alias-declaration", Peek().location));
                     return nullptr;
                }
 
                source.endPosition = Peek(-1).location.endPosition;
                return std::unique_ptr<TypeAliasNode, ecpps::ast::ASTDeleter>(
-                   new (context) TypeAliasNode(std::move(aliasName), std::move(targetType), source));
+                    new (context) TypeAliasNode(std::move(aliasName), std::move(targetType), source));
           }
      }
 
@@ -464,19 +463,19 @@ NodePointer ecpps::ast::AST::ParseFunctionDefinition(ASTContext& context)
                          }
                          else
                               this->_diagnostics.get().diagnosticsList.push_back(
-                                  std::make_unique<diagnostics::SyntaxError>("Expected ) in attribute",
-                                                                             Peek().location));
+                                   std::make_unique<diagnostics::SyntaxError>("Expected ) in attribute",
+                                                                              Peek().location));
                     }
 
                     attributeSource.endPosition = Peek(-1).location.endPosition;
                     attributes.EmplaceBack(std::unique_ptr<AttributeNode, ecpps::ast::ASTDeleter>(
-                        new (context) AttributeNode(name, arguments, attributeSource)));
+                         new (context) AttributeNode(name, arguments, attributeSource)));
                }
 
                if (!Match(TokenType::RightBracket) || !Match(TokenType::RightBracket))
                {
                     this->_diagnostics.get().diagnosticsList.push_back(
-                        std::make_unique<diagnostics::SyntaxError>("Expected ]]", Peek().location));
+                         std::make_unique<diagnostics::SyntaxError>("Expected ]]", Peek().location));
                }
           }
           else
@@ -515,7 +514,7 @@ NodePointer ecpps::ast::AST::ParseFunctionDefinition(ASTContext& context)
           auto typeSource = Peek().location;
           Advance();
           type = std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(new (context)
-                                                                        BasicType(typeName, typeSource, false, false));
+                                                                         BasicType(typeName, typeSource, false, false));
      }
      else
           type = ParseSimpleTypeSpecifier(context); // should generate an error if any
@@ -526,7 +525,7 @@ NodePointer ecpps::ast::AST::ParseFunctionDefinition(ASTContext& context)
      {
           Advance();
           type =
-              std::unique_ptr<PointerType, ecpps::ast::ASTDeleter>(new (context) PointerType(std::move(type), source));
+               std::unique_ptr<PointerType, ecpps::ast::ASTDeleter>(new (context) PointerType(std::move(type), source));
      }
 
      abi::CallingConventionName callingConvention = abi::ABI::Current().DefaultCallingConventionName();
@@ -543,8 +542,8 @@ NodePointer ecpps::ast::AST::ParseFunctionDefinition(ASTContext& context)
      auto name = ParseIdentifier(context);
 
      FunctionSignature signature{
-         std::move(type),  false, false, ConstantExpressionSpecifier::None, std::move(attributes), std::move(name),
-         callingConvention}; // TODO: Allow id-expression
+          std::move(type),  false, false, ConstantExpressionSpecifier::None, std::move(attributes), std::move(name),
+          callingConvention}; // TODO: Allow id-expression
 
      signature.isExtern = isExtern;
      signature.externOptional = externOptional;
@@ -569,7 +568,7 @@ NodePointer ecpps::ast::AST::ParseFunctionDefinition(ASTContext& context)
           {
                source.endPosition = Peek(-1).location.endPosition;
                return std::unique_ptr<FunctionDeclarationNode, ecpps::ast::ASTDeleter>(
-                   new (context) FunctionDeclarationNode(std::move(signature), source));
+                    new (context) FunctionDeclarationNode(std::move(signature), source));
           }
           return nullptr; // TODO: Error
      }
@@ -584,7 +583,7 @@ NodePointer ecpps::ast::AST::ParseFunctionDefinition(ASTContext& context)
 
      source.endPosition = Peek(-1).location.endPosition;
      return std::unique_ptr<FunctionDefinitionNode, ecpps::ast::ASTDeleter>(
-         new (context) FunctionDefinitionNode(std::move(signature), std::move(body), source));
+          new (context) FunctionDefinitionNode(std::move(signature), std::move(body), source));
 }
 
 bool ecpps::ast::AST::IsDeclarationStart([[maybe_unused]] ASTContext& context)
@@ -673,7 +672,7 @@ std::tuple<NodePointer, ecpps::ast::InitialisationType> ecpps::ast::AST::ParseIn
           if (!Match(TokenType::RightParenthesis))
           {
                this->_diagnostics.get().diagnosticsList.push_back(
-                   std::make_unique<diagnostics::SyntaxError>("Expected )", Peek().location));
+                    std::make_unique<diagnostics::SyntaxError>("Expected )", Peek().location));
           }
      }
      else if (Peek().type == TokenType::LeftBrace) // braced-init-list
@@ -689,7 +688,7 @@ NodePointer ecpps::ast::AST::ParseInitialiserList(ASTContext& context)
      if (!Match(TokenType::LeftBrace))
      {
           this->_diagnostics.get().diagnosticsList.push_back(
-              std::make_unique<diagnostics::SyntaxError>("Expected {", Peek().location));
+               std::make_unique<diagnostics::SyntaxError>("Expected {", Peek().location));
           return nullptr;
      }
 
@@ -709,11 +708,11 @@ NodePointer ecpps::ast::AST::ParseInitialiserList(ASTContext& context)
      if (!Match(TokenType::RightBrace))
      {
           this->_diagnostics.get().diagnosticsList.push_back(
-              std::make_unique<diagnostics::SyntaxError>("Expected }", Peek().location));
+               std::make_unique<diagnostics::SyntaxError>("Expected }", Peek().location));
           return nullptr;
      }
      return std::unique_ptr<InitialiserListNode, ecpps::ast::ASTDeleter>(
-         new (context) InitialiserListNode(std::move(initialisers), Peek(-1).location));
+          new (context) InitialiserListNode(std::move(initialisers), Peek(-1).location));
 }
 NodePointer ecpps::ast::AST::ParseInitialiserClause(ASTContext& context)
 {
@@ -756,7 +755,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isFriend)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'friend' specifier", Peek().location));
+                              "Duplicate 'friend' specifier", Peek().location));
                     }
                     isFriend = true;
                }
@@ -765,7 +764,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isTypedef)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'typedef' specifier", Peek().location));
+                              "Duplicate 'typedef' specifier", Peek().location));
                     }
                     isTypedef = true;
                }
@@ -774,7 +773,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isConstexpr)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'constexpr' specifier", Peek().location));
+                              "Duplicate 'constexpr' specifier", Peek().location));
                     }
                     isConstexpr = true;
                }
@@ -783,7 +782,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isConsteval)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'consteval' specifier", Peek().location));
+                              "Duplicate 'consteval' specifier", Peek().location));
                     }
                     isConsteval = true;
                }
@@ -792,7 +791,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isConstinit)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'constinit' specifier", Peek().location));
+                              "Duplicate 'constinit' specifier", Peek().location));
                     }
                     isConstinit = true;
                }
@@ -801,7 +800,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isInline)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'inline' specifier", Peek().location));
+                              "Duplicate 'inline' specifier", Peek().location));
                     }
                     isInline = true;
                }
@@ -810,7 +809,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isStatic)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'static' specifier", Peek().location));
+                              "Duplicate 'static' specifier", Peek().location));
                     }
                     isStatic = true;
                }
@@ -819,7 +818,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isThreadLocal)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'thread_local' specifier", Peek().location));
+                              "Duplicate 'thread_local' specifier", Peek().location));
                     }
                     isThreadLocal = true;
                }
@@ -828,7 +827,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isExtern)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'extern' specifier", Peek().location));
+                              "Duplicate 'extern' specifier", Peek().location));
                     }
                     isExtern = true;
                }
@@ -837,7 +836,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (isMutable)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'mutable' specifier", Peek().location));
+                              "Duplicate 'mutable' specifier", Peek().location));
                     }
                     isMutable = true;
                }
@@ -846,7 +845,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (optExplicitSpecifier.has_value())
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'explicit' specifier", Peek().location));
+                              "Duplicate 'explicit' specifier", Peek().location));
                     }
                     optExplicitSpecifier = ParseLogicalOrExpression(context);
                }
@@ -855,7 +854,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (nextConst)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'const' specifier", Peek().location));
+                              "Duplicate 'const' specifier", Peek().location));
                     }
                     nextConst = true;
                }
@@ -864,7 +863,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     if (nextVolatile)
                     {
                          this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                             "Duplicate 'volatile' specifier", Peek().location));
+                              "Duplicate 'volatile' specifier", Peek().location));
                     }
                     nextVolatile = true;
                }
@@ -896,13 +895,13 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
 
                     // Build the base type
                     NodePointer base = std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(new (context) BasicType(
-                        combinedType, source, std::exchange(nextConst, false), std::exchange(nextVolatile, false)));
+                         combinedType, source, std::exchange(nextConst, false), std::exchange(nextVolatile, false)));
 
                     // Wrap it in PointerType layers
                     for (std::size_t i = 0; i < pointerLevel; i++)
                     {
                          base = std::unique_ptr<PointerType, ecpps::ast::ASTDeleter>(
-                             new (context) PointerType(std::move(base), source));
+                              new (context) PointerType(std::move(base), source));
                     }
 
                     typeSpecifier = std::move(base);
@@ -918,7 +917,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                while (true)
                {
                     NodePointer part = std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(new (context) BasicType(
-                        std::get<std::string>(Peek().value), Peek().location, nextConst, nextVolatile));
+                         std::get<std::string>(Peek().value), Peek().location, nextConst, nextVolatile));
                     Advance();
                     nextConst = false;
                     nextVolatile = false;
@@ -928,7 +927,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     {
                          // TODO: Implement
                          part = std::unique_ptr<QualifiedType, ecpps::ast::ASTDeleter>(new (context) QualifiedType(
-                             SBOVector<QualifiedType::Section>{}, std::move(part), Peek().location));
+                              SBOVector<QualifiedType::Section>{}, std::move(part), Peek().location));
                          isTemplate = true;
                     }
 
@@ -940,7 +939,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                     else
                     {
                          typeSpecifier = std::unique_ptr<QualifiedType, ecpps::ast::ASTDeleter>(
-                             new (context) QualifiedType(std::move(sections), std::move(part), Peek().location));
+                              new (context) QualifiedType(std::move(sections), std::move(part), Peek().location));
                          break;
                     }
                }
@@ -955,7 +954,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                for (std::size_t i = 0; i < pointerLevel; i++)
                {
                     typeSpecifier = std::unique_ptr<PointerType, ecpps::ast::ASTDeleter>(
-                        new (context) PointerType(std::move(typeSpecifier), source));
+                         new (context) PointerType(std::move(typeSpecifier), source));
                }
 
                break;
@@ -998,7 +997,7 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                if (Peek().type != TokenType::RightBracket)
                {
                     this->_diagnostics.get().diagnosticsList.push_back(
-                        std::make_unique<diagnostics::SyntaxError>("Expected ]", Peek().location));
+                         std::make_unique<diagnostics::SyntaxError>("Expected ]", Peek().location));
                     break;
                }
                Advance();
@@ -1016,19 +1015,19 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
      }
 
      return std::unique_ptr<VariableDeclarationNode, ecpps::ast::ASTDeleter>(
-         new (context) VariableDeclarationNode(std::move(typeSpecifier), std::move(declarators),
-                                               /*flags*/
-                                               VariableDeclarationNode::Flags{.isTypedef = isTypedef,
-                                                                              .isFriend = isFriend,
-                                                                              .isConstexpr = isConstexpr,
-                                                                              .isConsteval = isConsteval,
-                                                                              .isConstinit = isConstinit,
-                                                                              .isInline = isInline,
-                                                                              .isStatic = isStatic,
-                                                                              .isThreadLocal = isThreadLocal,
-                                                                              .isExtern = isExtern,
-                                                                              .isMutable = isMutable},
-                                               std::move(optExplicitSpecifier), source));
+          new (context) VariableDeclarationNode(std::move(typeSpecifier), std::move(declarators),
+                                                /*flags*/
+                                                VariableDeclarationNode::Flags{.isTypedef = isTypedef,
+                                                                               .isFriend = isFriend,
+                                                                               .isConstexpr = isConstexpr,
+                                                                               .isConsteval = isConsteval,
+                                                                               .isConstinit = isConstinit,
+                                                                               .isInline = isInline,
+                                                                               .isStatic = isStatic,
+                                                                               .isThreadLocal = isThreadLocal,
+                                                                               .isExtern = isExtern,
+                                                                               .isMutable = isMutable},
+                                                std::move(optExplicitSpecifier), source));
 }
 
 NodePointer ecpps::ast::AST::TryParseDeclSpecifier([[maybe_unused]] ASTContext& context)
@@ -1073,31 +1072,31 @@ NodePointer ecpps::ast::AST::ParsePrimaryExpression([[maybe_unused]] ASTContext&
      {
           this->Advance();
           return std::visit(
-              OverloadedVisitor{[&currentToken, &context](const bool boolean) -> NodePointer
-                                {
-                                     return std::unique_ptr<BooleanLiteralNode, ecpps::ast::ASTDeleter>(
-                                         new (context) BooleanLiteralNode(boolean, currentToken.location));
-                                },
-                                [&currentToken, &context](const StringLiteral& literal) -> NodePointer
-                                {
-                                     return std::unique_ptr<StringLiteralNode, ecpps::ast::ASTDeleter>(
-                                         new (context) StringLiteralNode(literal.value, currentToken.location));
-                                },
-                                [&currentToken, &context](const IntegerLiteral& literal) -> NodePointer
-                                {
-                                     return std::unique_ptr<IntegerLiteralNode, ecpps::ast::ASTDeleter>(
-                                         new (context) IntegerLiteralNode(literal.value, currentToken.location));
-                                },
-                                [&currentToken, &context](const char literal) -> NodePointer
-                                {
-                                     return std::unique_ptr<CharacterLiteralNode, ecpps::ast::ASTDeleter>(
-                                         new (context) CharacterLiteralNode(literal, currentToken.location));
-                                },
-                                [](auto&&) static -> NodePointer
-                                {
-                                     return nullptr;
-                                }},
-              currentToken.value);
+               OverloadedVisitor{[&currentToken, &context](const bool boolean) -> NodePointer
+                                 {
+                                      return std::unique_ptr<BooleanLiteralNode, ecpps::ast::ASTDeleter>(
+                                           new (context) BooleanLiteralNode(boolean, currentToken.location));
+                                 },
+                                 [&currentToken, &context](const StringLiteral& literal) -> NodePointer
+                                 {
+                                      return std::unique_ptr<StringLiteralNode, ecpps::ast::ASTDeleter>(
+                                           new (context) StringLiteralNode(literal.value, currentToken.location));
+                                 },
+                                 [&currentToken, &context](const IntegerLiteral& literal) -> NodePointer
+                                 {
+                                      return std::unique_ptr<IntegerLiteralNode, ecpps::ast::ASTDeleter>(
+                                           new (context) IntegerLiteralNode(literal.value, currentToken.location));
+                                 },
+                                 [&currentToken, &context](const char literal) -> NodePointer
+                                 {
+                                      return std::unique_ptr<CharacterLiteralNode, ecpps::ast::ASTDeleter>(
+                                           new (context) CharacterLiteralNode(literal, currentToken.location));
+                                 },
+                                 [](auto&&) static -> NodePointer
+                                 {
+                                      return nullptr;
+                                 }},
+               currentToken.value);
      }
      case TokenType::Keyword:
      {
@@ -1140,10 +1139,10 @@ NodePointer ecpps::ast::AST::ParsePrimaryExpression([[maybe_unused]] ASTContext&
      }
      default:
           this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-              std::format("Expected a primary expression (literal, identifier, "
-                          "'this', or parenthesized expression), "
-                          "but found an unexpected token"),
-              currentToken.location));
+               std::format("Expected a primary expression (literal, identifier, "
+                           "'this', or parenthesized expression), "
+                           "but found an unexpected token"),
+               currentToken.location));
           Advance();
           return nullptr;
      }
@@ -1168,7 +1167,7 @@ NodePointer ecpps::ast::AST::ParseIdExpression([[maybe_unused]] ASTContext& cont
      if (isGlobalScope)
      {
           parts.push_back(
-              std::unique_ptr<GlobalScopeNode, ecpps::ast::ASTDeleter>(new (context) GlobalScopeNode(source)));
+               std::unique_ptr<GlobalScopeNode, ecpps::ast::ASTDeleter>(new (context) GlobalScopeNode(source)));
      }
 
      while (true)
@@ -1225,8 +1224,8 @@ NodePointer ecpps::ast::AST::ParseIdExpression([[maybe_unused]] ASTContext& cont
 
                // TODO: Implement template-id nodes
                this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                   std::format("Template syntax is not yet supported: '{}<...>'", identifierName),
-                   currentToken.location));
+                    std::format("Template syntax is not yet supported: '{}<...>'", identifierName),
+                    currentToken.location));
                return nullptr;
                // parts.push_back(std::make_unique<TemplateIdNode>(identifierName,
                // std::move(templateArguments),
@@ -1235,15 +1234,15 @@ NodePointer ecpps::ast::AST::ParseIdExpression([[maybe_unused]] ASTContext& cont
           }
 
           parts.push_back(std::unique_ptr<IdentifierNode, ecpps::ast::ASTDeleter>(
-              new (context) IdentifierNode(identifierName, currentToken.location)));
+               new (context) IdentifierNode(identifierName, currentToken.location)));
 
           if (sawTemplateKeyword)
           {
                // TODO: Implement template keyword disambiguation
                this->_diagnostics.get().diagnosticsList.push_back(
-                   std::make_unique<diagnostics::SyntaxError>(std::format("The 'template' keyword for dependent name "
-                                                                          "disambiguation is not yet supported"),
-                                                              currentToken.location));
+                    std::make_unique<diagnostics::SyntaxError>(std::format("The 'template' keyword for dependent name "
+                                                                           "disambiguation is not yet supported"),
+                                                               currentToken.location));
                return nullptr;
           }
 
@@ -1258,7 +1257,7 @@ NodePointer ecpps::ast::AST::ParseIdExpression([[maybe_unused]] ASTContext& cont
                if (AtEnd() || Peek().type != TokenType::Identifier) // TODO: template & operator op
                {
                     this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                        "Expected an identifier after '::' in qualified-id", Peek().location));
+                         "Expected an identifier after '::' in qualified-id", Peek().location));
                     return nullptr;
                }
 
@@ -1271,7 +1270,7 @@ NodePointer ecpps::ast::AST::ParseIdExpression([[maybe_unused]] ASTContext& cont
      if (parts.empty()) return nullptr;
      if (parts.size() == 1) return std::move(parts.front());
      return std::unique_ptr<QualifiedIdNode, ecpps::ast::ASTDeleter>(new (context)
-                                                                         QualifiedIdNode(std::move(parts), source));
+                                                                          QualifiedIdNode(std::move(parts), source));
 }
 
 NodePointer ecpps::ast::AST::ParsePostfixExpresssion([[maybe_unused]] ASTContext& context)
@@ -1342,10 +1341,10 @@ NodePointer ecpps::ast::AST::ParsePostfixExpresssion([[maybe_unused]] ASTContext
                     Advance();
                     source.endPosition = currentToken.location.endPosition;
                     Operator operatorId =
-                        std::get<std::string>(currentToken.value) == "++" ? Operator::Increment : Operator::Decrement;
+                         std::get<std::string>(currentToken.value) == "++" ? Operator::Increment : Operator::Decrement;
                     expression = std::unique_ptr<UnaryOperatorNode, ecpps::ast::ASTDeleter>(
-                        new (context)
-                            UnaryOperatorNode(operatorId, std::move(expression), UnaryOperatorType::Postfix, source));
+                         new (context)
+                              UnaryOperatorNode(operatorId, std::move(expression), UnaryOperatorType::Postfix, source));
                     continue;
                }
                if (std::get<std::string>(currentToken.value) == "." ||
@@ -1355,10 +1354,10 @@ NodePointer ecpps::ast::AST::ParsePostfixExpresssion([[maybe_unused]] ASTContext
                     // TODO: template
                     source.endPosition = currentToken.location.endPosition;
                     Operator operatorId =
-                        std::get<std::string>(currentToken.value) == "." ? Operator::FullStop : Operator::Arrow;
-                    expression = std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(
-                        new (context)
-                            BinaryOperatorNode(std::move(expression), operatorId, ParseIdExpression(context), source));
+                         std::get<std::string>(currentToken.value) == "." ? Operator::FullStop : Operator::Arrow;
+                    expression =
+                         std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
+                              std::move(expression), operatorId, ParseIdExpression(context), source));
                     continue;
                }
           }
@@ -1369,14 +1368,14 @@ NodePointer ecpps::ast::AST::ParsePostfixExpresssion([[maybe_unused]] ASTContext
                if (!Match(TokenType::RightBracket))
                {
                     this->_diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
-                            "Expected a closing bracket in subscript expression", currentToken.location));
+                         diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
+                              "Expected a closing bracket in subscript expression", currentToken.location));
                     return nullptr;
                }
                source.endPosition = currentToken.location.endPosition;
                expression =
-                   std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
-                       std::move(expression), Operator::Subscript, std::move(subscriptExpression), source));
+                    std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
+                         std::move(expression), Operator::Subscript, std::move(subscriptExpression), source));
                continue;
           }
           if (currentToken.type == TokenType::LeftParenthesis)
@@ -1392,14 +1391,14 @@ NodePointer ecpps::ast::AST::ParsePostfixExpresssion([[maybe_unused]] ASTContext
                     if (token.type == TokenType::Operator && std::get<std::string>(token.value) == ",") continue;
 
                     this->_diagnostics.get().diagnosticsList.push_back(
-                        diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
-                            "Expected a comma in function argument list", token.location));
+                         diagnostics::DiagnosticsBuilder<diagnostics::SyntaxError>{}.Build(
+                              "Expected a comma in function argument list", token.location));
                     return nullptr;
                }
 
                source.endPosition = currentToken.location.endPosition;
                expression = std::unique_ptr<CallOperatorNode, ecpps::ast::ASTDeleter>(
-                   new (context) CallOperatorNode(std::move(expression), std::move(argumentList), source));
+                    new (context) CallOperatorNode(std::move(expression), std::move(argumentList), source));
 
                continue;
           }
@@ -1421,9 +1420,9 @@ NodePointer ecpps::ast::AST::ParseUnaryExpression(ASTContext& context)
                auto expression = ParseCastExpression(context);
                source.endPosition = Peek().location.endPosition;
                const auto operatorId =
-                   std::get<std::string>(currentToken.value) == "++" ? Operator::Increment : Operator::Decrement;
+                    std::get<std::string>(currentToken.value) == "++" ? Operator::Increment : Operator::Decrement;
                return std::unique_ptr<UnaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) UnaryOperatorNode(
-                   operatorId, std::move(expression), UnaryOperatorType::Prefix, source));
+                    operatorId, std::move(expression), UnaryOperatorType::Prefix, source));
           }
      }
      if (currentToken.type == TokenType::Operator)
@@ -1435,9 +1434,9 @@ NodePointer ecpps::ast::AST::ParseUnaryExpression(ASTContext& context)
                auto expression = ParseCastExpression(context);
                source.endPosition = Peek().location.endPosition;
                const auto operatorId =
-                   std::get<std::string>(currentToken.value) == "+" ? Operator::Plus : Operator::Minus;
+                    std::get<std::string>(currentToken.value) == "+" ? Operator::Plus : Operator::Minus;
                return std::unique_ptr<UnaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) UnaryOperatorNode(
-                   operatorId, std::move(expression), UnaryOperatorType::Prefix, source));
+                    operatorId, std::move(expression), UnaryOperatorType::Prefix, source));
           }
           if (std::get<std::string>(currentToken.value) == "*" || std::get<std::string>(currentToken.value) == "&")
           {
@@ -1446,9 +1445,9 @@ NodePointer ecpps::ast::AST::ParseUnaryExpression(ASTContext& context)
                auto expression = ParseCastExpression(context);
                source.endPosition = Peek().location.endPosition;
                const auto operatorId =
-                   std::get<std::string>(currentToken.value) == "*" ? Operator::Asterisk : Operator::Ampersand;
+                    std::get<std::string>(currentToken.value) == "*" ? Operator::Asterisk : Operator::Ampersand;
                return std::unique_ptr<UnaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) UnaryOperatorNode(
-                   operatorId, std::move(expression), UnaryOperatorType::Prefix, source));
+                    operatorId, std::move(expression), UnaryOperatorType::Prefix, source));
           }
           if (std::get<std::string>(currentToken.value) == "~" || std::get<std::string>(currentToken.value) == "!")
           {
@@ -1457,9 +1456,9 @@ NodePointer ecpps::ast::AST::ParseUnaryExpression(ASTContext& context)
                auto expression = ParseCastExpression(context);
                source.endPosition = Peek().location.endPosition;
                const auto operatorId =
-                   std::get<std::string>(currentToken.value) == "!" ? Operator::Exclamation : Operator::Tilde;
+                    std::get<std::string>(currentToken.value) == "!" ? Operator::Exclamation : Operator::Tilde;
                return std::unique_ptr<UnaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) UnaryOperatorNode(
-                   operatorId, std::move(expression), UnaryOperatorType::Prefix, source));
+                    operatorId, std::move(expression), UnaryOperatorType::Prefix, source));
           }
      }
      // sizeof / alignof
@@ -1508,10 +1507,10 @@ NodePointer ecpps::ast::AST::ParseUnaryExpression(ASTContext& context)
           source.endPosition = Peek().location.endPosition;
           if (std::get<std::string>(currentToken.value) == "alignof")
                return std::unique_ptr<AlignOfNode, ecpps::ast::ASTDeleter>(
-                   new (context) AlignOfNode(std::move(typeOrExpressionInside), canHoldTypeId, source));
+                    new (context) AlignOfNode(std::move(typeOrExpressionInside), canHoldTypeId, source));
 
           return std::unique_ptr<SizeOfNode, ecpps::ast::ASTDeleter>(
-              new (context) SizeOfNode(std::move(typeOrExpressionInside), canHoldTypeId, source));
+               new (context) SizeOfNode(std::move(typeOrExpressionInside), canHoldTypeId, source));
      }
 
      // TODO:
@@ -1556,11 +1555,11 @@ NodePointer ecpps::ast::AST::ParsePmExpression(ASTContext& context)
                     // TODO: implement PM and not.. that placeholder
                     source.endPosition = currentToken.location.endPosition;
                     const auto operatorId = std::get<std::string>(currentToken.value) == ".*"
-                                                ? Operator::PointerToMemberObject
-                                                : Operator::PointerToMember;
+                                                 ? Operator::PointerToMemberObject
+                                                 : Operator::PointerToMember;
                     expression =
-                        std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
-                            std::move(expression), operatorId, ParseCastExpression(context), source));
+                         std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
+                              std::move(expression), operatorId, ParseCastExpression(context), source));
                     continue;
                }
           }
@@ -1590,9 +1589,9 @@ NodePointer ecpps::ast::AST::ParseMultiplicativeExpression(ASTContext& context)
                                             : std::get<std::string>(currentToken.value) == "/" ? Operator::Solidus
                                                                                                : Operator::Percent;
 
-                    expression = std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(
-                        new (context)
-                            BinaryOperatorNode(std::move(expression), operatorId, ParsePmExpression(context), source));
+                    expression =
+                         std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
+                              std::move(expression), operatorId, ParsePmExpression(context), source));
                     continue;
                }
           }
@@ -1618,10 +1617,10 @@ NodePointer ecpps::ast::AST::ParseAdditiveExpression(ASTContext& context)
                     Advance();
                     source.endPosition = currentToken.location.endPosition;
                     const auto operatorId =
-                        std::get<std::string>(currentToken.value) == "+" ? Operator::Plus : Operator::Minus;
+                         std::get<std::string>(currentToken.value) == "+" ? Operator::Plus : Operator::Minus;
                     expression =
-                        std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
-                            std::move(expression), operatorId, ParseMultiplicativeExpression(context), source));
+                         std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
+                              std::move(expression), operatorId, ParseMultiplicativeExpression(context), source));
                     continue;
                }
           }
@@ -1648,10 +1647,10 @@ NodePointer ecpps::ast::AST::ParseShiftExpression(ASTContext& context)
                     Advance();
                     source.endPosition = currentToken.location.endPosition;
                     const auto operatorId =
-                        std::get<std::string>(currentToken.value) == ">>" ? Operator::RightShift : Operator::LeftShift;
+                         std::get<std::string>(currentToken.value) == ">>" ? Operator::RightShift : Operator::LeftShift;
                     expression =
-                        std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
-                            std::move(expression), operatorId, ParseAdditiveExpression(context), source));
+                         std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
+                              std::move(expression), operatorId, ParseAdditiveExpression(context), source));
                     continue;
                }
           }
@@ -1677,8 +1676,8 @@ NodePointer ecpps::ast::AST::ParseCompareExpression(ASTContext& context)
                     Advance();
                     source.endPosition = currentToken.location.endPosition;
                     expression =
-                        std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
-                            std::move(expression), Operator::Spaceship, ParseShiftExpression(context), source));
+                         std::unique_ptr<BinaryOperatorNode, ecpps::ast::ASTDeleter>(new (context) BinaryOperatorNode(
+                              std::move(expression), Operator::Spaceship, ParseShiftExpression(context), source));
                     continue;
                }
           }
@@ -1803,7 +1802,7 @@ NodePointer ecpps::ast::AST::ParseStatement(ASTContext& context)
                return nullptr;
           }
           return std::unique_ptr<ReturnNode, ecpps::ast::ASTDeleter>(new (context)
-                                                                         ReturnNode(std::move(value), source));
+                                                                          ReturnNode(std::move(value), source));
      }
      if (IsDeclarationStart(context)) return ParseDeclarationStatement(context);
      return ParseExpressionStatement(context);
@@ -1859,7 +1858,7 @@ ecpps::ast::FunctionParameter ecpps::ast::AST::ParseFunctionParameter(ASTContext
           auto typeSource = Peek().location;
           Advance();
           type = std::unique_ptr<BasicType, ecpps::ast::ASTDeleter>(
-              new (context) BasicType(typeName, typeSource, isConst, isVolatile));
+               new (context) BasicType(typeName, typeSource, isConst, isVolatile));
      }
      else
           type = ParseSimpleTypeSpecifier(context, isConst, isVolatile);
@@ -1871,7 +1870,7 @@ ecpps::ast::FunctionParameter ecpps::ast::AST::ParseFunctionParameter(ASTContext
      {
           Advance();
           type = std::unique_ptr<PointerType, ecpps::ast::ASTDeleter>(
-              new (context) PointerType(std::move(type), Peek().location));
+               new (context) PointerType(std::move(type), Peek().location));
      }
 
      parameter.type = std::move(type);

--- a/compiler/ecpps/src/Parsing/AST.cpp
+++ b/compiler/ecpps/src/Parsing/AST.cpp
@@ -364,7 +364,10 @@ NodePointer ecpps::ast::AST::ParseBlockDeclaration(ASTContext& context)
                     while (Peek().type == TokenType::Keyword)
                     {
                          const auto& qual = std::get<std::string>(Peek().value);
-                         if (qual == "const" || qual == "volatile") { Advance(); }
+                         if (qual == "const" || qual == "volatile")
+                         {
+                              Advance();
+                         }
                          else
                               break;
                     }
@@ -397,7 +400,10 @@ NodePointer ecpps::ast::AST::ParseNameDeclaration(ASTContext& context)
      {
           const auto& keyword = std::get<std::string>(Peek().value);
 
-          if (keyword == "using" || keyword == "namespace") { return ParseBlockDeclaration(context); }
+          if (keyword == "using" || keyword == "namespace")
+          {
+               return ParseBlockDeclaration(context);
+          }
 
           if (keyword == "typedef" || keyword == "const" || keyword == "volatile" || keyword == "static" ||
               keyword == "inline" || keyword == "constexpr" || keyword == "consteval" || keyword == "constinit" ||
@@ -605,7 +611,10 @@ bool ecpps::ast::AST::IsDeclarationStart([[maybe_unused]] ASTContext& context)
                if (hasSignedness) break;
                hasSignedness = true;
           }
-          else if (kw == "short" || kw == "long") { hasLong = true; }
+          else if (kw == "short" || kw == "long")
+          {
+               hasLong = true;
+          }
           else if (kw == "int" || kw == "char" || kw == "float" || kw == "double")
           {
                hasType = true;
@@ -690,7 +699,10 @@ NodePointer ecpps::ast::AST::ParseInitialiserList(ASTContext& context)
      {
           auto initialiser = ParseInitialiserClause(context);
           initialisers.push_back(std::move(initialiser));
-          if (Peek().type == TokenType::Operator && std::get<std::string>(Peek().value) == ",") { Advance(); }
+          if (Peek().type == TokenType::Operator && std::get<std::string>(Peek().value) == ",")
+          {
+               Advance();
+          }
           else
                break;
      }
@@ -1019,17 +1031,35 @@ NodePointer ecpps::ast::AST::ParseSimpleDeclaration(ASTContext& context)
                                                std::move(optExplicitSpecifier), source));
 }
 
-NodePointer ecpps::ast::AST::TryParseDeclSpecifier([[maybe_unused]] ASTContext& context) { return {}; }
+NodePointer ecpps::ast::AST::TryParseDeclSpecifier([[maybe_unused]] ASTContext& context)
+{
+     return {};
+}
 
-NodePointer ecpps::ast::AST::TryParseDefiningTypeSpecifier([[maybe_unused]] ASTContext& context) { return {}; }
+NodePointer ecpps::ast::AST::TryParseDefiningTypeSpecifier([[maybe_unused]] ASTContext& context)
+{
+     return {};
+}
 
-NodePointer ecpps::ast::AST::ParseInitDeclarator([[maybe_unused]] ASTContext& context) { return {}; }
+NodePointer ecpps::ast::AST::ParseInitDeclarator([[maybe_unused]] ASTContext& context)
+{
+     return {};
+}
 
-NodePointer ecpps::ast::AST::TryParseDeclarator([[maybe_unused]] ASTContext& context) { return {}; }
+NodePointer ecpps::ast::AST::TryParseDeclarator([[maybe_unused]] ASTContext& context)
+{
+     return {};
+}
 
-NodePointer ecpps::ast::AST::TryParsePtrDeclarator([[maybe_unused]] ASTContext& context) { return {}; }
+NodePointer ecpps::ast::AST::TryParsePtrDeclarator([[maybe_unused]] ASTContext& context)
+{
+     return {};
+}
 
-NodePointer ecpps::ast::AST::TryParseNoPtrDeclarator([[maybe_unused]] ASTContext& context) { return {}; }
+NodePointer ecpps::ast::AST::TryParseNoPtrDeclarator([[maybe_unused]] ASTContext& context)
+{
+     return {};
+}
 
 NodePointer ecpps::ast::AST::ParsePrimaryExpression([[maybe_unused]] ASTContext& context)
 {
@@ -1063,7 +1093,10 @@ NodePointer ecpps::ast::AST::ParsePrimaryExpression([[maybe_unused]] ASTContext&
                                      return std::unique_ptr<CharacterLiteralNode, ecpps::ast::ASTDeleter>(
                                          new (context) CharacterLiteralNode(literal, currentToken.location));
                                 },
-                                [](auto&&) static -> NodePointer { return nullptr; }},
+                                [](auto&&) static -> NodePointer
+                                {
+                                     return nullptr;
+                                }},
               currentToken.value);
      }
      case TokenType::Keyword:
@@ -1093,7 +1126,10 @@ NodePointer ecpps::ast::AST::ParsePrimaryExpression([[maybe_unused]] ASTContext&
           if (std::get<std::string>(currentToken.value) == "::")
           {
                auto idExpr = ParseIdExpression(context);
-               if (!idExpr) { return nullptr; }
+               if (!idExpr)
+               {
+                    return nullptr;
+               }
                return idExpr;
           }
           break;
@@ -1104,7 +1140,8 @@ NodePointer ecpps::ast::AST::ParsePrimaryExpression([[maybe_unused]] ASTContext&
      }
      default:
           this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-              std::format("Expected a primary expression (literal, identifier, 'this', or parenthesized expression), "
+              std::format("Expected a primary expression (literal, identifier, "
+                          "'this', or parenthesized expression), "
                           "but found an unexpected token"),
               currentToken.location));
           Advance();
@@ -1191,8 +1228,10 @@ NodePointer ecpps::ast::AST::ParseIdExpression([[maybe_unused]] ASTContext& cont
                    std::format("Template syntax is not yet supported: '{}<...>'", identifierName),
                    currentToken.location));
                return nullptr;
-               // parts.push_back(std::make_unique<TemplateIdNode>(identifierName, std::move(templateArguments),
-               //                                                  sawTemplateKeyword, currentToken.location));
+               // parts.push_back(std::make_unique<TemplateIdNode>(identifierName,
+               // std::move(templateArguments),
+               //                                                  sawTemplateKeyword,
+               //                                                  currentToken.location));
           }
 
           parts.push_back(std::unique_ptr<IdentifierNode, ecpps::ast::ASTDeleter>(
@@ -1201,9 +1240,10 @@ NodePointer ecpps::ast::AST::ParseIdExpression([[maybe_unused]] ASTContext& cont
           if (sawTemplateKeyword)
           {
                // TODO: Implement template keyword disambiguation
-               this->_diagnostics.get().diagnosticsList.push_back(std::make_unique<diagnostics::SyntaxError>(
-                   std::format("The 'template' keyword for dependent name disambiguation is not yet supported"),
-                   currentToken.location));
+               this->_diagnostics.get().diagnosticsList.push_back(
+                   std::make_unique<diagnostics::SyntaxError>(std::format("The 'template' keyword for dependent name "
+                                                                          "disambiguation is not yet supported"),
+                                                              currentToken.location));
                return nullptr;
           }
 
@@ -1280,8 +1320,9 @@ NodePointer ecpps::ast::AST::ParsePostfixExpresssion([[maybe_unused]] ASTContext
                     }
 
                     // TODO: Error
-                    // "Cannot perform an explicit type conversion using a functional notation on `" + built + "`, as it
-                    // is not a simple-type-specifier as mandated in [expr.type.conv]. See [expr.post.general] and
+                    // "Cannot perform an explicit type conversion using a functional
+                    // notation on `" + built + "`, as it is not a simple-type-specifier as
+                    // mandated in [expr.type.conv]. See [expr.post.general] and
                     // [dcl.type.general] for the grammar."
                     return nullptr;
                }

--- a/compiler/ecpps/src/Parsing/AST.h
+++ b/compiler/ecpps/src/Parsing/AST.h
@@ -161,8 +161,8 @@ namespace ecpps::ast
 
                     for (const auto& arg : this->_arguments)
                          built +=
-                             (std::holds_alternative<std::string>(arg.value) ? std::get<std::string>(arg.value) : "") +
-                             ", ";
+                              (std::holds_alternative<std::string>(arg.value) ? std::get<std::string>(arg.value) : "") +
+                              ", ";
 
                     built.pop_back();
                     built.pop_back();
@@ -419,8 +419,8 @@ namespace ecpps::ast
           [[nodiscard]] std::string ToString([[maybe_unused]] const std::size_t indent) const override
           {
                return this->_type == UnaryOperatorType::Postfix
-                          ? (this->_operand->ToString(0) + ecpps::ast::ToString(this->_value))
-                          : (ecpps::ast::ToString(this->_value) + this->_operand->ToString(0));
+                           ? (this->_operand->ToString(0) + ecpps::ast::ToString(this->_value))
+                           : (ecpps::ast::ToString(this->_value) + this->_operand->ToString(0));
           }
 
      private:

--- a/compiler/ecpps/src/Parsing/AST.h
+++ b/compiler/ecpps/src/Parsing/AST.h
@@ -21,12 +21,17 @@ namespace ecpps::ast
      class Node
      {
      public:
-          explicit Node(Location location) : _location(location) {}
+          explicit Node(Location location) : _location(location)
+          {
+          }
           virtual ~Node(void);
 
           [[nodiscard]] virtual std::string ToString(std::size_t indent) const = 0;
 
-          [[nodiscard]] const Location& Source(void) const noexcept { return this->_location; }
+          [[nodiscard]] const Location& Source(void) const noexcept
+          {
+               return this->_location;
+          }
 
      private:
           Location _location;
@@ -165,8 +170,14 @@ namespace ecpps::ast
                }
                return built + "]]";
           }
-          [[nodiscard]] const std::string& Name(void) const noexcept { return this->_name; }
-          [[nodiscard]] const SBOVector<Token>& Arguments(void) const noexcept { return this->_arguments; }
+          [[nodiscard]] const std::string& Name(void) const noexcept
+          {
+               return this->_name;
+          }
+          [[nodiscard]] const SBOVector<Token>& Arguments(void) const noexcept
+          {
+               return this->_arguments;
+          }
 
      private:
           std::string _name;
@@ -282,7 +293,10 @@ namespace ecpps::ast
                return built + ";";
           }
 
-          [[nodiscard]] const FunctionSignature& Signature(void) const noexcept { return this->_signature; }
+          [[nodiscard]] const FunctionSignature& Signature(void) const noexcept
+          {
+               return this->_signature;
+          }
 
      private:
           FunctionSignature _signature;
@@ -310,8 +324,14 @@ namespace ecpps::ast
                return built + "\n" + std::string(indent * PrettyIndent, ' ') + "}";
           }
 
-          [[nodiscard]] const FunctionSignature& Signature(void) const noexcept { return this->_signature; }
-          [[nodiscard]] const SBOVector<NodePointer>& Body(void) const noexcept { return this->_body; }
+          [[nodiscard]] const FunctionSignature& Signature(void) const noexcept
+          {
+               return this->_signature;
+          }
+          [[nodiscard]] const SBOVector<NodePointer>& Body(void) const noexcept
+          {
+               return this->_body;
+          }
 
      private:
           FunctionSignature _signature;
@@ -343,8 +363,14 @@ namespace ecpps::ast
                       ")";
           }
 
-          [[nodiscard]] const NodePointer& Function(void) const noexcept { return this->_function; }
-          [[nodiscard]] const SBOVector<NodePointer>& Arguments(void) const noexcept { return this->_arguments; }
+          [[nodiscard]] const NodePointer& Function(void) const noexcept
+          {
+               return this->_function;
+          }
+          [[nodiscard]] const SBOVector<NodePointer>& Arguments(void) const noexcept
+          {
+               return this->_arguments;
+          }
 
      private:
           NodePointer _function;
@@ -356,7 +382,9 @@ namespace ecpps::ast
      class ThisNode final : public Node
      {
      public:
-          explicit ThisNode(Location source) : Node(source) {}
+          explicit ThisNode(Location source) : Node(source)
+          {
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + "this";
@@ -376,9 +404,18 @@ namespace ecpps::ast
               : Node(source), _value(value), _operand(std::move(operand)), _type(type)
           {
           }
-          [[nodiscard]] const Operator& Value(void) const noexcept { return this->_value; }
-          [[nodiscard]] const NodePointer& Operand(void) const noexcept { return this->_operand; }
-          [[nodiscard]] UnaryOperatorType UnaryType(void) const noexcept { return this->_type; }
+          [[nodiscard]] const Operator& Value(void) const noexcept
+          {
+               return this->_value;
+          }
+          [[nodiscard]] const NodePointer& Operand(void) const noexcept
+          {
+               return this->_operand;
+          }
+          [[nodiscard]] UnaryOperatorType UnaryType(void) const noexcept
+          {
+               return this->_type;
+          }
           [[nodiscard]] std::string ToString([[maybe_unused]] const std::size_t indent) const override
           {
                return this->_type == UnaryOperatorType::Postfix
@@ -399,9 +436,18 @@ namespace ecpps::ast
               : Node(source), _left(std::move(left)), _value(value), _right(std::move(right))
           {
           }
-          [[nodiscard]] const Operator& Value(void) const noexcept { return this->_value; }
-          [[nodiscard]] const NodePointer& Left(void) const noexcept { return this->_left; }
-          [[nodiscard]] const NodePointer& Right(void) const noexcept { return this->_right; }
+          [[nodiscard]] const Operator& Value(void) const noexcept
+          {
+               return this->_value;
+          }
+          [[nodiscard]] const NodePointer& Left(void) const noexcept
+          {
+               return this->_left;
+          }
+          [[nodiscard]] const NodePointer& Right(void) const noexcept
+          {
+               return this->_right;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + "(" + this->_left->ToString(0) + " " +
@@ -422,7 +468,10 @@ namespace ecpps::ast
           {
           }
 
-          [[nodiscard]] const NodePointer& Value(void) const noexcept { return this->_expression; }
+          [[nodiscard]] const NodePointer& Value(void) const noexcept
+          {
+               return this->_expression;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                if (this->_expression == nullptr) return std::string(indent * PrettyIndent, ' ') + "return";
@@ -441,8 +490,14 @@ namespace ecpps::ast
           {
           }
 
-          [[nodiscard]] const NodePointer& AliasName(void) const noexcept { return this->_aliasName; }
-          [[nodiscard]] const NodePointer& TargetType(void) const noexcept { return this->_targetType; }
+          [[nodiscard]] const NodePointer& AliasName(void) const noexcept
+          {
+               return this->_aliasName;
+          }
+          [[nodiscard]] const NodePointer& TargetType(void) const noexcept
+          {
+               return this->_targetType;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -502,9 +557,18 @@ namespace ecpps::ast
           {
           }
 
-          [[nodiscard]] const NodePointer& Type(void) const noexcept { return this->_type; }
-          [[nodiscard]] const std::vector<Declarator>& Declarators(void) const noexcept { return this->_declarators; }
-          [[nodiscard]] const Flags& GetFlags(void) const noexcept { return this->_flags; }
+          [[nodiscard]] const NodePointer& Type(void) const noexcept
+          {
+               return this->_type;
+          }
+          [[nodiscard]] const std::vector<Declarator>& Declarators(void) const noexcept
+          {
+               return this->_declarators;
+          }
+          [[nodiscard]] const Flags& GetFlags(void) const noexcept
+          {
+               return this->_flags;
+          }
           [[nodiscard]] const std::optional<NodePointer>& ExplicitSpecifier(void) const noexcept
           {
                return this->_explicitSpecifier;
@@ -551,8 +615,13 @@ namespace ecpps::ast
      class BooleanLiteralNode final : public Node
      {
      public:
-          explicit BooleanLiteralNode(const bool value, Location source) : Node(source), _value(value) {}
-          [[nodiscard]] bool Value(void) const noexcept { return this->_value; }
+          explicit BooleanLiteralNode(const bool value, Location source) : Node(source), _value(value)
+          {
+          }
+          [[nodiscard]] bool Value(void) const noexcept
+          {
+               return this->_value;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + (this->_value ? "true" : "false");
@@ -564,13 +633,18 @@ namespace ecpps::ast
      class StringLiteralNode final : public Node
      {
      public:
-          explicit StringLiteralNode(std::string value, Location source) : Node(source), _value(std::move(value)) {}
+          explicit StringLiteralNode(std::string value, Location source) : Node(source), _value(std::move(value))
+          {
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + "\"" + this->_value + "\"";
           }
-          [[nodiscard]] const std::string& Value(void) const noexcept { return this->_value; }
+          [[nodiscard]] const std::string& Value(void) const noexcept
+          {
+               return this->_value;
+          }
 
      private:
           std::string _value;
@@ -579,8 +653,13 @@ namespace ecpps::ast
      class IntegerLiteralNode final : public Node
      {
      public:
-          explicit IntegerLiteralNode(const unsigned long long value, Location source) : Node(source), _value(value) {}
-          [[nodiscard]] unsigned long long Value(void) const noexcept { return this->_value; }
+          explicit IntegerLiteralNode(const unsigned long long value, Location source) : Node(source), _value(value)
+          {
+          }
+          [[nodiscard]] unsigned long long Value(void) const noexcept
+          {
+               return this->_value;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + std::to_string(this->_value);
@@ -593,8 +672,13 @@ namespace ecpps::ast
      class CharacterLiteralNode final : public Node
      {
      public:
-          explicit CharacterLiteralNode(const char value, Location source) : Node(source), _value(value) {}
-          [[nodiscard]] char Value(void) const noexcept { return this->_value; }
+          explicit CharacterLiteralNode(const char value, Location source) : Node(source), _value(value)
+          {
+          }
+          [[nodiscard]] char Value(void) const noexcept
+          {
+               return this->_value;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + std::to_string(this->_value);
@@ -607,7 +691,9 @@ namespace ecpps::ast
      class GlobalScopeNode final : public Node
      {
      public:
-          explicit GlobalScopeNode(Location source) : Node(source) {}
+          explicit GlobalScopeNode(Location source) : Node(source)
+          {
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' '); // NOLINT
@@ -621,9 +707,18 @@ namespace ecpps::ast
               : Node(source), _node(std::move(node)), _canBeTypeId(canBeTypeId)
           {
           }
-          [[nodiscard]] const NodePointer& Value(void) const noexcept { return this->_node; }
-          [[nodiscard]] NodePointer&& Value(void) noexcept { return std::move(this->_node); }
-          [[nodiscard]] bool CanBeTypeId(void) const noexcept { return this->_canBeTypeId; }
+          [[nodiscard]] const NodePointer& Value(void) const noexcept
+          {
+               return this->_node;
+          }
+          [[nodiscard]] NodePointer&& Value(void) noexcept
+          {
+               return std::move(this->_node);
+          }
+          [[nodiscard]] bool CanBeTypeId(void) const noexcept
+          {
+               return this->_canBeTypeId;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + "sizeof(" +
@@ -642,9 +737,18 @@ namespace ecpps::ast
               : Node(source), _node(std::move(node)), _canBeTypeId(canBeTypeId)
           {
           }
-          [[nodiscard]] const NodePointer& Value(void) const noexcept { return this->_node; }
-          [[nodiscard]] NodePointer&& Value(void) noexcept { return std::move(this->_node); }
-          [[nodiscard]] bool CanBeTypeId(void) const noexcept { return this->_canBeTypeId; }
+          [[nodiscard]] const NodePointer& Value(void) const noexcept
+          {
+               return this->_node;
+          }
+          [[nodiscard]] NodePointer&& Value(void) noexcept
+          {
+               return std::move(this->_node);
+          }
+          [[nodiscard]] bool CanBeTypeId(void) const noexcept
+          {
+               return this->_canBeTypeId;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + "alignof(" +
@@ -690,9 +794,17 @@ namespace ecpps::ast
      {
           NodePointer value{};
           std::vector<diagnostics::DiagnosticsMessage> diagnostics{};
-          bool HasValue(void) const noexcept { return this->value != nullptr; }
-          bool WasSuccessful(void) const noexcept { return this->wasSuccessful; }
-          explicit ASTExpected(NodePointer value) : value(std::move(value)), wasSuccessful(true) {}
+          bool HasValue(void) const noexcept
+          {
+               return this->value != nullptr;
+          }
+          bool WasSuccessful(void) const noexcept
+          {
+               return this->wasSuccessful;
+          }
+          explicit ASTExpected(NodePointer value) : value(std::move(value)), wasSuccessful(true)
+          {
+          }
           explicit ASTExpected(NodePointer value, std::vector<diagnostics::DiagnosticsMessage> diagnostics)
               : value(std::move(value)), diagnostics(std::move(diagnostics)), wasSuccessful(false)
           {
@@ -715,7 +827,10 @@ namespace ecpps::ast
           std::size_t _position{};
           std::reference_wrapper<Diagnostics> _diagnostics;
 
-          [[nodiscard]] bool AtEnd(void) const { return this->_position >= this->_tokens.size(); }
+          [[nodiscard]] bool AtEnd(void) const
+          {
+               return this->_position >= this->_tokens.size();
+          }
           [[nodiscard]] const Token& Peek(const std::ptrdiff_t offset = 0) const noexcept
           {
                return this->_tokens[this->_position + static_cast<std::size_t>(offset)];
@@ -724,10 +839,22 @@ namespace ecpps::ast
           {
                return this->_tokens[this->_position + static_cast<std::size_t>(offset)];
           }
-          void Advance(void) noexcept { this->_position++; }
-          void Retreat(void) noexcept { this->_position--; }
-          [[nodiscard]] std::size_t CurrentPosition(void) const noexcept { return this->_position; }
-          void SetPosition(const std::size_t newPosition) noexcept { this->_position = newPosition; }
+          void Advance(void) noexcept
+          {
+               this->_position++;
+          }
+          void Retreat(void) noexcept
+          {
+               this->_position--;
+          }
+          [[nodiscard]] std::size_t CurrentPosition(void) const noexcept
+          {
+               return this->_position;
+          }
+          void SetPosition(const std::size_t newPosition) noexcept
+          {
+               this->_position = newPosition;
+          }
           [[nodiscard]] bool Match(const TokenType type) noexcept
           {
                if (Peek().type != type) return false;
@@ -784,7 +911,10 @@ namespace ecpps::ast
 
           // Statements
           NodePointer ParseStatement(ASTContext& context);
-          NodePointer ParseDeclarationStatement(ASTContext& context) { return ParseBlockDeclaration(context); }
+          NodePointer ParseDeclarationStatement(ASTContext& context)
+          {
+               return ParseBlockDeclaration(context);
+          }
           NodePointer ParseExpressionStatement(ASTContext& context);
 
           // Helpers (parse sub-components)

--- a/compiler/ecpps/src/Parsing/ASTs/General.h
+++ b/compiler/ecpps/src/Parsing/ASTs/General.h
@@ -5,8 +5,13 @@ namespace ecpps::ast
      class IdentifierNode final : public Node
      {
      public:
-          explicit IdentifierNode(std::string value, Location where) : Node(where), _value(std::move(value)) {}
-          [[nodiscard]] const std::string& Value(void) const noexcept { return this->_value; }
+          explicit IdentifierNode(std::string value, Location where) : Node(where), _value(std::move(value))
+          {
+          }
+          [[nodiscard]] const std::string& Value(void) const noexcept
+          {
+               return this->_value;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + this->_value;
@@ -19,9 +24,14 @@ namespace ecpps::ast
      class OperatorFunctionId final : Node
      {
      public:
-          explicit OperatorFunctionId(Operator op, Location where) : Node(where), _operator(op) {}
+          explicit OperatorFunctionId(Operator op, Location where) : Node(where), _operator(op)
+          {
+          }
 
-          [[nodiscard]] Operator GetOperator(void) const noexcept { return this->_operator; }
+          [[nodiscard]] Operator GetOperator(void) const noexcept
+          {
+               return this->_operator;
+          }
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
                return std::string(indent * PrettyIndent, ' ') + "operator" + ecpps::ast::ToString(this->_operator);
@@ -49,7 +59,10 @@ namespace ecpps::ast
                return std::string(indent * PrettyIndent, ' ') + built;
           }
 
-          [[nodiscard]] const std::vector<NodePointer>& Path(void) const noexcept { return this->_path; }
+          [[nodiscard]] const std::vector<NodePointer>& Path(void) const noexcept
+          {
+               return this->_path;
+          }
 
      private:
           std::vector<NodePointer> _path;

--- a/compiler/ecpps/src/Parsing/ASTs/Type.h
+++ b/compiler/ecpps/src/Parsing/ASTs/Type.h
@@ -57,7 +57,10 @@ namespace ecpps::ast
           {
                return this->_name;
           }
-          [[nodiscard]] const SBOVector<NodePointer>& Declarations(void) const noexcept { return this->_declarations; }
+          [[nodiscard]] const SBOVector<NodePointer>& Declarations(void) const noexcept
+          {
+               return this->_declarations;
+          }
 
           [[nodiscard]] std::string ToString(const std::size_t indent) const override
           {
@@ -93,11 +96,26 @@ namespace ecpps::ast
                if (this->_isVolatile) cv += "volatile ";
                return std::string(indent * PrettyIndent, ' ') + cv + this->_name;
           }
-          [[nodiscard]] const std::string& Value(void) const noexcept { return this->_name; }
-          [[nodiscard]] bool IsConst(void) const noexcept { return this->_isConst; }
-          [[nodiscard]] bool IsVolatile(void) const noexcept { return this->_isVolatile; }
-          void SetConst(const bool newValue) noexcept { this->_isConst = newValue; }
-          void SetVolatile(const bool newValue) noexcept { this->_isVolatile = newValue; }
+          [[nodiscard]] const std::string& Value(void) const noexcept
+          {
+               return this->_name;
+          }
+          [[nodiscard]] bool IsConst(void) const noexcept
+          {
+               return this->_isConst;
+          }
+          [[nodiscard]] bool IsVolatile(void) const noexcept
+          {
+               return this->_isVolatile;
+          }
+          void SetConst(const bool newValue) noexcept
+          {
+               this->_isConst = newValue;
+          }
+          void SetVolatile(const bool newValue) noexcept
+          {
+               this->_isVolatile = newValue;
+          }
 
      private:
           std::string _name;
@@ -125,12 +143,27 @@ namespace ecpps::ast
                return std::string(indent * PrettyIndent, ' ') + _baseType->ToString(0) + "*" + cv;
           }
 
-          [[nodiscard]] const NodePointer& BaseType(void) const noexcept { return _baseType; }
+          [[nodiscard]] const NodePointer& BaseType(void) const noexcept
+          {
+               return _baseType;
+          }
 
-          [[nodiscard]] bool IsConst(void) const noexcept { return this->_isConst; }
-          [[nodiscard]] bool IsVolatile(void) const noexcept { return this->_isVolatile; }
-          void SetConst(const bool newValue) noexcept { this->_isConst = newValue; }
-          void SetVolatile(const bool newValue) noexcept { this->_isVolatile = newValue; }
+          [[nodiscard]] bool IsConst(void) const noexcept
+          {
+               return this->_isConst;
+          }
+          [[nodiscard]] bool IsVolatile(void) const noexcept
+          {
+               return this->_isVolatile;
+          }
+          void SetConst(const bool newValue) noexcept
+          {
+               this->_isConst = newValue;
+          }
+          void SetVolatile(const bool newValue) noexcept
+          {
+               this->_isVolatile = newValue;
+          }
 
      private:
           bool _isConst;
@@ -158,8 +191,14 @@ namespace ecpps::ast
                       (_kind == Kind::LValue ? "&" : "&&");
           }
 
-          [[nodiscard]] const NodePointer& BaseType() const noexcept { return _baseType; }
-          [[nodiscard]] Kind GetKind() const noexcept { return _kind; }
+          [[nodiscard]] const NodePointer& BaseType() const noexcept
+          {
+               return _baseType;
+          }
+          [[nodiscard]] Kind GetKind() const noexcept
+          {
+               return _kind;
+          }
 
      private:
           NodePointer _baseType;
@@ -173,7 +212,9 @@ namespace ecpps::ast
           {
                NodePointer node;
                bool isTemplate;
-               explicit Section(NodePointer node, bool isTemplate) : node(std::move(node)), isTemplate(isTemplate) {}
+               explicit Section(NodePointer node, bool isTemplate) : node(std::move(node)), isTemplate(isTemplate)
+               {
+               }
           };
 
           explicit QualifiedType(SBOVector<Section> sections, NodePointer unqualified, Location source)
@@ -189,8 +230,14 @@ namespace ecpps::ast
 
                return built + this->_unqualifiedType->ToString(0);
           }
-          [[nodiscard]] const SBOVector<Section>& Sections(void) const noexcept { return this->_sections; }
-          [[nodiscard]] const NodePointer& UnqualifiedType(void) const noexcept { return this->_unqualifiedType; }
+          [[nodiscard]] const SBOVector<Section>& Sections(void) const noexcept
+          {
+               return this->_sections;
+          }
+          [[nodiscard]] const NodePointer& UnqualifiedType(void) const noexcept
+          {
+               return this->_unqualifiedType;
+          }
 
      private:
           SBOVector<Section> _sections;

--- a/compiler/ecpps/src/Parsing/ASTs/Type.h
+++ b/compiler/ecpps/src/Parsing/ASTs/Type.h
@@ -20,7 +20,7 @@ namespace ecpps::ast
                return this->_aliasName;
           }
           [[nodiscard]] const SBOVector<std::unique_ptr<IdentifierNode, ASTDeleter>>& AliasedNamespace(
-              void) const noexcept
+               void) const noexcept
           {
                return this->_aliasedNamespace;
           }

--- a/compiler/ecpps/src/Parsing/Preprocessor.cpp
+++ b/compiler/ecpps/src/Parsing/Preprocessor.cpp
@@ -161,14 +161,14 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                     }
 
                     std::filesystem::path resolvedPath = ecpps::fs::GetSourceScanner().ResolveInclude(
-                        fileName, header,
-                        (delimiter == '"') ? ecpps::fs::IncludeType::Local : ecpps::fs::IncludeType::System);
+                         fileName, header,
+                         (delimiter == '"') ? ecpps::fs::IncludeType::Local : ecpps::fs::IncludeType::System);
                     if (std::ranges::find(includedFiles, resolvedPath) == includedFiles.end())
                     {
                          const auto& includedSource = ecpps::fs::GetSourceScanner().GetFileContents(resolvedPath);
 
                          tokens.append_range(
-                             Parse(includedSource, macros, resolvedPath.string(), includedFiles, includeDirectories));
+                              Parse(includedSource, macros, resolvedPath.string(), includedFiles, includeDirectories));
                     }
                }
                else if (directive == "define")
@@ -274,8 +274,8 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                               }
 
                               bool isDirective =
-                                  (nextDirective == "else" || nextDirective == "endif" || nextDirective == "elif" ||
-                                   nextDirective == "elifdef" || nextDirective == "elifndef");
+                                   (nextDirective == "else" || nextDirective == "endif" || nextDirective == "elif" ||
+                                    nextDirective == "elifdef" || nextDirective == "elifndef");
                               if (isDirective)
                               {
 
@@ -698,9 +698,9 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
           else
           {
                this->diagnostics.push_back(std::make_unique<diagnostics::SyntaxError>(
-                   std::format("Invalid character '{:x}'",
-                               static_cast<std::uint32_t>(static_cast<unsigned char>(character))),
-                   location));
+                    std::format("Invalid character '{:x}'",
+                                static_cast<std::uint32_t>(static_cast<unsigned char>(character))),
+                    location));
           }
      }
 
@@ -742,9 +742,9 @@ void ecpps::Preprocessor::Print(const std::vector<PreprocessingToken>& ppTokens)
 bool ecpps::Preprocessor::IsOperatorOrPunctuator([[maybe_unused]] const std::string& string)
 {
      static std::unordered_set<std::string> OperatorsAndPunctuators{
-         "{",  "}",  "[", "]", "(",  ")",  ";",   ":",  "...", "?",  "::", ".",   ".*",  "->", "->*", "~",  "!",
-         "+",  "-",  "*", "/", "%",  "^",  "&",   "|",  "=",   "+=", "-=", "*=",  "/=",  "%=", "^=",  "&=", "|=",
-         "==", "!=", "<", ">", "<=", ">=", "<=>", "&&", "||",  "<<", ">>", "<<=", ">>=", "++", "--",  ","};
+          "{",  "}",  "[", "]", "(",  ")",  ";",   ":",  "...", "?",  "::", ".",   ".*",  "->", "->*", "~",  "!",
+          "+",  "-",  "*", "/", "%",  "^",  "&",   "|",  "=",   "+=", "-=", "*=",  "/=",  "%=", "^=",  "&=", "|=",
+          "==", "!=", "<", ">", "<=", ">=", "<=>", "&&", "||",  "<<", ">>", "<<=", ">>=", "++", "--",  ","};
 
      return OperatorsAndPunctuators.contains(string);
 }
@@ -871,14 +871,14 @@ static std::vector<ecpps::PreprocessingToken> TokeniseExpandedMacro(const std::s
 }
 
 std::vector<ecpps::PreprocessingToken> ecpps::MacroReplacement::ProcessObjectLike(
-    const Location& location, const std::vector<ecpps::MacroReplacement>& macros) const
+     const Location& location, const std::vector<ecpps::MacroReplacement>& macros) const
 {
      return TokeniseExpandedMacro(ExpandMacroString(contents, {}, {}), location, macros);
 }
 
 std::vector<ecpps::PreprocessingToken> ecpps::MacroReplacement::ProcessFunctionLike(
-    const std::vector<std::vector<PreprocessingToken>>& arguments, const std::vector<std::string>& rawArgs,
-    const Location& location, const std::vector<ecpps::MacroReplacement>& macros) const
+     const std::vector<std::vector<PreprocessingToken>>& arguments, const std::vector<std::string>& rawArgs,
+     const Location& location, const std::vector<ecpps::MacroReplacement>& macros) const
 {
      std::unordered_map<std::string, std::string> parameterMap;
      std::unordered_map<std::string, std::string> rawParameterMap;
@@ -912,7 +912,7 @@ std::vector<ecpps::PreprocessingToken> ecpps::MacroReplacement::ProcessFunctionL
                     auto rf = raw.find_first_not_of(" \t\n\r");
                     auto rl = raw.find_last_not_of(" \t\n\r");
                     rawParameterMap[parameterName] =
-                        (rf != std::string::npos) ? raw.substr(rf, rl - rf + 1) : std::string{};
+                         (rf != std::string::npos) ? raw.substr(rf, rl - rf + 1) : std::string{};
                }
                else
                     rawParameterMap[parameterName] = {};

--- a/compiler/ecpps/src/Parsing/Preprocessor.cpp
+++ b/compiler/ecpps/src/Parsing/Preprocessor.cpp
@@ -239,11 +239,16 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                     while (sourceIterator != source.end() && IsCharacterContinuation(*sourceIterator))
                          macroName += *sourceIterator++;
 
-                    bool wasConditionMet = isIfndef
-                                               ? std::ranges::none_of(macros, [&macroName](const MacroReplacement& m)
-                                                                      { return m.name == macroName; })
-                                               : std::ranges::any_of(macros, [&macroName](const MacroReplacement& m)
-                                                                     { return m.name == macroName; });
+                    bool wasConditionMet = isIfndef ? std::ranges::none_of(macros,
+                                                                           [&macroName](const MacroReplacement& m)
+                                                                           {
+                                                                                return m.name == macroName;
+                                                                           })
+                                                    : std::ranges::any_of(macros,
+                                                                          [&macroName](const MacroReplacement& m)
+                                                                          {
+                                                                               return m.name == macroName;
+                                                                          });
 
                     std::vector<PreprocessingToken> branchTokens;
                     std::string builtSource{};
@@ -297,7 +302,9 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                                         {
                                              auto it = std::ranges::find_if(macros,
                                                                             [&elifCondition](const MacroReplacement& m)
-                                                                            { return m.name == elifCondition; });
+                                                                            {
+                                                                                 return m.name == elifCondition;
+                                                                            });
                                              wasConditionMet = (it != macros.end());
                                         }
                                         sourceIterator = peekIt;
@@ -318,7 +325,9 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                                         {
                                              auto it = std::ranges::find_if(macros,
                                                                             [&elifMacroName](const MacroReplacement& m)
-                                                                            { return m.name == elifMacroName; });
+                                                                            {
+                                                                                 return m.name == elifMacroName;
+                                                                            });
                                              wasConditionMet = isElifndef ? (it == macros.end()) : (it != macros.end());
                                         }
                                         sourceIterator = peekIt;
@@ -357,8 +366,11 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                          location.position++;
                     }
 
-                    auto it = std::ranges::find_if(macros, [&macroName](const MacroReplacement& m)
-                                                   { return m.name == macroName; });
+                    auto it = std::ranges::find_if(macros,
+                                                   [&macroName](const MacroReplacement& m)
+                                                   {
+                                                        return m.name == macroName;
+                                                   });
                     if (it != macros.end()) macros.erase(it);
                }
                else if (directive == "error")
@@ -454,8 +466,11 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                {
 
                     location.endPosition = location.position;
-                    auto it = std::ranges::find_if(macros, [&identifier](const MacroReplacement& m)
-                                                   { return m.name == identifier; });
+                    auto it = std::ranges::find_if(macros,
+                                                   [&identifier](const MacroReplacement& m)
+                                                   {
+                                                        return m.name == identifier;
+                                                   });
 
                     if (it != macros.end())
                     {

--- a/compiler/ecpps/src/Parsing/Preprocessor.h
+++ b/compiler/ecpps/src/Parsing/Preprocessor.h
@@ -84,9 +84,18 @@ namespace ecpps
           std::vector<diagnostics::DiagnosticsMessage> diagnostics{};
 
      private:
-          static bool IsDigit(const char ch) { return std::isdigit(ch) != 0; }
-          static bool IsCharacterBeginning(const char ch) { return std::isalpha(ch) != 0 || ch == '_'; }
-          static bool IsCharacterContinuation(const char ch) { return std::isalnum(ch) != 0 || ch == '_'; }
+          static bool IsDigit(const char ch)
+          {
+               return std::isdigit(ch) != 0;
+          }
+          static bool IsCharacterBeginning(const char ch)
+          {
+               return std::isalpha(ch) != 0 || ch == '_';
+          }
+          static bool IsCharacterContinuation(const char ch)
+          {
+               return std::isalnum(ch) != 0 || ch == '_';
+          }
           static bool IsOperatorOrPunctuator(const std::string& string);
           static bool IsOperatorOrPunctuatorBeginning(char ch);
 

--- a/compiler/ecpps/src/Parsing/Preprocessor.h
+++ b/compiler/ecpps/src/Parsing/Preprocessor.h
@@ -49,10 +49,10 @@ namespace ecpps
           }
 
           [[nodiscard]] std::vector<PreprocessingToken> ProcessObjectLike(
-              const Location& location, const std::vector<ecpps::MacroReplacement>& macros) const;
+               const Location& location, const std::vector<ecpps::MacroReplacement>& macros) const;
           [[nodiscard]] std::vector<PreprocessingToken> ProcessFunctionLike(
-              const std::vector<std::vector<PreprocessingToken>>& arguments, const std::vector<std::string>& rawArgs,
-              const Location& location, const std::vector<ecpps::MacroReplacement>& macros) const;
+               const std::vector<std::vector<PreprocessingToken>>& arguments, const std::vector<std::string>& rawArgs,
+               const Location& location, const std::vector<ecpps::MacroReplacement>& macros) const;
 
           explicit MacroReplacement(std::string name, std::optional<std::vector<std::string>> parameters,
                                     std::string contents, const bool isVariadic)

--- a/compiler/ecpps/src/Parsing/Tokeniser.cpp
+++ b/compiler/ecpps/src/Parsing/Tokeniser.cpp
@@ -177,9 +177,9 @@ std::vector<ecpps::Token> ecpps::Tokeniser::Tokenise(const std::vector<Preproces
                     {
                          if (auto val = ParseFloat(numericPart))
                               tokens.emplace_back(
-                                  TokenType::Literal,
-                                  UserDefinedLiteral{.value = FloatingPointLiteral{*val}, .name = suffix},
-                                  preprocessorToken.source);
+                                   TokenType::Literal,
+                                   UserDefinedLiteral{.value = FloatingPointLiteral{*val}, .name = suffix},
+                                   preprocessorToken.source);
                     }
                     else
                     {
@@ -270,55 +270,55 @@ void ecpps::Tokeniser::Print(const std::vector<ecpps::Token>& tokens)
           {
                colour = "\x1b[32m";
                value = std::visit(
-                   OverloadedVisitor{[](const bool& boolean) -> std::string
-                                     {
-                                          return boolean ? "true" : "false";
-                                     },
-                                     [](const StringLiteral& literal) -> std::string
-                                     {
-                                          return "\"" + literal.value + "\"";
-                                     },
-                                     [](const IntegerLiteral& literal) -> std::string
-                                     {
-                                          return std::to_string(literal.value);
-                                     },
-                                     [](const char literal) -> std::string
-                                     {
-                                          return "'"s + literal + "'";
-                                     },
-                                     [](const FloatingPointLiteral& literal) -> std::string
-                                     {
-                                          return std::to_string(literal.value);
-                                     },
-                                     [](const UserDefinedLiteral& udl) -> std::string
-                                     {
-                                          return std::visit(
-                                                     OverloadedVisitor{
-                                                         [](const StringLiteral& literal) -> std::string
-                                                         {
-                                                              return "\"" + literal.value + "\"";
-                                                         },
-                                                         [](const IntegerLiteral& literal) -> std::string
-                                                         {
-                                                              return std::to_string(literal.value);
-                                                         },
-                                                         [](const char& literal) -> std::string
-                                                         {
-                                                              return "'"s + literal + "'";
-                                                         },
-                                                         [](const FloatingPointLiteral& literal) -> std::string
-                                                         {
-                                                              return std::to_string(literal.value);
-                                                         },
-                                                     },
-                                                     udl.value) +
-                                                 udl.name;
-                                     },
-                                     [](auto&&) -> std::string
-                                     {
-                                          return "?";
-                                     }},
-                   token.value);
+                    OverloadedVisitor{[](const bool& boolean) -> std::string
+                                      {
+                                           return boolean ? "true" : "false";
+                                      },
+                                      [](const StringLiteral& literal) -> std::string
+                                      {
+                                           return "\"" + literal.value + "\"";
+                                      },
+                                      [](const IntegerLiteral& literal) -> std::string
+                                      {
+                                           return std::to_string(literal.value);
+                                      },
+                                      [](const char literal) -> std::string
+                                      {
+                                           return "'"s + literal + "'";
+                                      },
+                                      [](const FloatingPointLiteral& literal) -> std::string
+                                      {
+                                           return std::to_string(literal.value);
+                                      },
+                                      [](const UserDefinedLiteral& udl) -> std::string
+                                      {
+                                           return std::visit(
+                                                       OverloadedVisitor{
+                                                            [](const StringLiteral& literal) -> std::string
+                                                            {
+                                                                 return "\"" + literal.value + "\"";
+                                                            },
+                                                            [](const IntegerLiteral& literal) -> std::string
+                                                            {
+                                                                 return std::to_string(literal.value);
+                                                            },
+                                                            [](const char& literal) -> std::string
+                                                            {
+                                                                 return "'"s + literal + "'";
+                                                            },
+                                                            [](const FloatingPointLiteral& literal) -> std::string
+                                                            {
+                                                                 return std::to_string(literal.value);
+                                                            },
+                                                       },
+                                                       udl.value) +
+                                                  udl.name;
+                                      },
+                                      [](auto&&) -> std::string
+                                      {
+                                           return "?";
+                                      }},
+                    token.value);
           }
           break;
           case TokenType::Operator:
@@ -378,11 +378,11 @@ void ecpps::Tokeniser::Print(const std::vector<ecpps::Token>& tokens)
           default: colour = "\x1b[38m";
           }
           const std::string spaces(
-              static_cast<std::size_t>(std::max(static_cast<std::ptrdiff_t>(token.location.position) -
-                                                    static_cast<std::ptrdiff_t>(previous.endPosition),
-                                                1z) -
-                                       1z),
-              ' ');
+               static_cast<std::size_t>(std::max(static_cast<std::ptrdiff_t>(token.location.position) -
+                                                      static_cast<std::ptrdiff_t>(previous.endPosition),
+                                                 1z) -
+                                        1z),
+               ' ');
           previous = token.location;
 
           std::print("{}{}{}", spaces, colour, value);
@@ -393,20 +393,20 @@ void ecpps::Tokeniser::Print(const std::vector<ecpps::Token>& tokens)
 bool ecpps::Tokeniser::IsKeyword(const std::string& identifier)
 {
      static std::unordered_set<std::string> Keywords = {
-         "alignas",       "alignof",     "asm",       "auto",      "bool",         "break",
-         "case",          "catch",       "char",      "char8_t",   "char16_t",     "char32_t",
-         "class",         "concept",     "const",     "consteval", "constexpr",    "constinit",
-         "const_cast",    "continue",    "co_await",  "co_return", "co_yield",     "decltype",
-         "default",       "delete",      "do",        "double",    "dynamic_cast", "else",
-         "enum",          "explicit",    "export",    "extern",    "false",        "float",
-         "for",           "friend",      "goto",      "if",        "inline",       "int",
-         "long",          "mutable",     "namespace", "new",       "noexcept",     "nullptr",
-         "operator",      "private",     "protected", "public",    "register",     "reinterpret_cast",
-         "requires",      "return",      "short",     "signed",    "sizeof",       "static",
-         "static_assert", "static_cast", "struct",    "switch",    "template",     "this",
-         "thread_local",  "throw",       "true",      "try",       "typedef",      "typeid",
-         "typename",      "union",       "unsigned",  "using",     "virtual",      "void",
-         "volatile",      "wchar_t",     "while"};
+          "alignas",       "alignof",     "asm",       "auto",      "bool",         "break",
+          "case",          "catch",       "char",      "char8_t",   "char16_t",     "char32_t",
+          "class",         "concept",     "const",     "consteval", "constexpr",    "constinit",
+          "const_cast",    "continue",    "co_await",  "co_return", "co_yield",     "decltype",
+          "default",       "delete",      "do",        "double",    "dynamic_cast", "else",
+          "enum",          "explicit",    "export",    "extern",    "false",        "float",
+          "for",           "friend",      "goto",      "if",        "inline",       "int",
+          "long",          "mutable",     "namespace", "new",       "noexcept",     "nullptr",
+          "operator",      "private",     "protected", "public",    "register",     "reinterpret_cast",
+          "requires",      "return",      "short",     "signed",    "sizeof",       "static",
+          "static_assert", "static_cast", "struct",    "switch",    "template",     "this",
+          "thread_local",  "throw",       "true",      "try",       "typedef",      "typeid",
+          "typename",      "union",       "unsigned",  "using",     "virtual",      "void",
+          "volatile",      "wchar_t",     "while"};
 
      return Keywords.contains(identifier);
 }

--- a/compiler/ecpps/src/Parsing/Tokeniser.cpp
+++ b/compiler/ecpps/src/Parsing/Tokeniser.cpp
@@ -270,28 +270,54 @@ void ecpps::Tokeniser::Print(const std::vector<ecpps::Token>& tokens)
           {
                colour = "\x1b[32m";
                value = std::visit(
-                   OverloadedVisitor{
-                       [](const bool& boolean) -> std::string { return boolean ? "true" : "false"; },
-                       [](const StringLiteral& literal) -> std::string { return "\"" + literal.value + "\""; },
-                       [](const IntegerLiteral& literal) -> std::string { return std::to_string(literal.value); },
-                       [](const char literal) -> std::string { return "'"s + literal + "'"; },
-                       [](const FloatingPointLiteral& literal) -> std::string { return std::to_string(literal.value); },
-                       [](const UserDefinedLiteral& udl) -> std::string
-                       {
-                            return std::visit(
-                                       OverloadedVisitor{
-                                           [](const StringLiteral& literal) -> std::string
-                                           { return "\"" + literal.value + "\""; },
-                                           [](const IntegerLiteral& literal) -> std::string
-                                           { return std::to_string(literal.value); },
-                                           [](const char& literal) -> std::string { return "'"s + literal + "'"; },
-                                           [](const FloatingPointLiteral& literal) -> std::string
-                                           { return std::to_string(literal.value); },
-                                       },
-                                       udl.value) +
-                                   udl.name;
-                       },
-                       [](auto&&) -> std::string { return "?"; }},
+                   OverloadedVisitor{[](const bool& boolean) -> std::string
+                                     {
+                                          return boolean ? "true" : "false";
+                                     },
+                                     [](const StringLiteral& literal) -> std::string
+                                     {
+                                          return "\"" + literal.value + "\"";
+                                     },
+                                     [](const IntegerLiteral& literal) -> std::string
+                                     {
+                                          return std::to_string(literal.value);
+                                     },
+                                     [](const char literal) -> std::string
+                                     {
+                                          return "'"s + literal + "'";
+                                     },
+                                     [](const FloatingPointLiteral& literal) -> std::string
+                                     {
+                                          return std::to_string(literal.value);
+                                     },
+                                     [](const UserDefinedLiteral& udl) -> std::string
+                                     {
+                                          return std::visit(
+                                                     OverloadedVisitor{
+                                                         [](const StringLiteral& literal) -> std::string
+                                                         {
+                                                              return "\"" + literal.value + "\"";
+                                                         },
+                                                         [](const IntegerLiteral& literal) -> std::string
+                                                         {
+                                                              return std::to_string(literal.value);
+                                                         },
+                                                         [](const char& literal) -> std::string
+                                                         {
+                                                              return "'"s + literal + "'";
+                                                         },
+                                                         [](const FloatingPointLiteral& literal) -> std::string
+                                                         {
+                                                              return std::to_string(literal.value);
+                                                         },
+                                                     },
+                                                     udl.value) +
+                                                 udl.name;
+                                     },
+                                     [](auto&&) -> std::string
+                                     {
+                                          return "?";
+                                     }},
                    token.value);
           }
           break;

--- a/compiler/ecpps/src/Parsing/Tokeniser.h
+++ b/compiler/ecpps/src/Parsing/Tokeniser.h
@@ -151,58 +151,59 @@ namespace ecpps
                case TokenType::Operator: return std::get<std::string>(this->value);
                case TokenType::Literal:
                     return std::visit(
-                        OverloadedVisitor{[](const std::monostate&) -> std::string
-                                          {
-                                               return std::string{};
-                                          },
-                                          [](const std::string& str)
-                                          {
-                                               return str;
-                                          },
-                                          [](const bool b) -> std::string
-                                          {
-                                               return b ? "true" : "false";
-                                          },
-                                          [](const StringLiteral& strLit) -> std::string
-                                          {
-                                               return strLit.value;
-                                          },
-                                          [](const char c)
-                                          {
-                                               return std::string(1, c);
-                                          },
-                                          [](const IntegerLiteral& intLit) -> std::string
-                                          {
-                                               return std::to_string(intLit.value);
-                                          },
-                                          [](const FloatingPointLiteral& floatLit) -> std::string
-                                          {
-                                               return std::to_string(floatLit.value);
-                                          },
-                                          [](const UserDefinedLiteral& udLit) -> std::string
-                                          {
-                                               return std::visit(
-                                                   OverloadedVisitor{
-                                                       [](const StringLiteral& strLit) -> std::string
-                                                       {
-                                                            return std::format("\"{}\"", strLit.value);
-                                                       },
-                                                       [](const IntegerLiteral& intLit) -> std::string
-                                                       {
-                                                            return std::to_string(intLit.value);
-                                                       },
-                                                       [](const FloatingPointLiteral& floatLit) -> std::string
-                                                       {
-                                                            return std::to_string(floatLit.value);
-                                                       },
-                                                       [](auto&&) -> std::string
-                                                       {
-                                                            runtime_assert(false, "Invalid user-defined literal value");
-                                                            std::terminate();
-                                                       }},
-                                                   udLit.value);
-                                          }},
-                        this->value);
+                         OverloadedVisitor{[](const std::monostate&) -> std::string
+                                           {
+                                                return std::string{};
+                                           },
+                                           [](const std::string& str)
+                                           {
+                                                return str;
+                                           },
+                                           [](const bool b) -> std::string
+                                           {
+                                                return b ? "true" : "false";
+                                           },
+                                           [](const StringLiteral& strLit) -> std::string
+                                           {
+                                                return strLit.value;
+                                           },
+                                           [](const char c)
+                                           {
+                                                return std::string(1, c);
+                                           },
+                                           [](const IntegerLiteral& intLit) -> std::string
+                                           {
+                                                return std::to_string(intLit.value);
+                                           },
+                                           [](const FloatingPointLiteral& floatLit) -> std::string
+                                           {
+                                                return std::to_string(floatLit.value);
+                                           },
+                                           [](const UserDefinedLiteral& udLit) -> std::string
+                                           {
+                                                return std::visit(
+                                                     OverloadedVisitor{
+                                                          [](const StringLiteral& strLit) -> std::string
+                                                          {
+                                                               return std::format("\"{}\"", strLit.value);
+                                                          },
+                                                          [](const IntegerLiteral& intLit) -> std::string
+                                                          {
+                                                               return std::to_string(intLit.value);
+                                                          },
+                                                          [](const FloatingPointLiteral& floatLit) -> std::string
+                                                          {
+                                                               return std::to_string(floatLit.value);
+                                                          },
+                                                          [](auto&&) -> std::string
+                                                          {
+                                                               runtime_assert(false,
+                                                                              "Invalid user-defined literal value");
+                                                               std::terminate();
+                                                          }},
+                                                     udLit.value);
+                                           }},
+                         this->value);
                case TokenType::LeftParenthesis: return "(";
                case TokenType::RightParenthesis: return ")";
                case TokenType::LeftBracket: return "[";

--- a/compiler/ecpps/src/Parsing/Tokeniser.h
+++ b/compiler/ecpps/src/Parsing/Tokeniser.h
@@ -119,7 +119,10 @@ namespace ecpps
                runtime_assert(this->type == TokenType::Operator, "Token is not an operator");
                return std::get<std::string>(this->value);
           }
-          [[nodiscard]] bool IsLiteral(void) const { return this->type == TokenType::Literal; }
+          [[nodiscard]] bool IsLiteral(void) const
+          {
+               return this->type == TokenType::Literal;
+          }
 
           [[nodiscard]] std::optional<std::string> TryIdentifier(void) const
           {
@@ -148,30 +151,57 @@ namespace ecpps
                case TokenType::Operator: return std::get<std::string>(this->value);
                case TokenType::Literal:
                     return std::visit(
-                        OverloadedVisitor{
-                            [](const std::monostate&) -> std::string { return std::string{}; },
-                            [](const std::string& str) { return str; }, [](const bool b) -> std::string
-                            { return b ? "true" : "false"; }, [](const StringLiteral& strLit) -> std::string
-                            { return strLit.value; }, [](const char c) { return std::string(1, c); },
-                            [](const IntegerLiteral& intLit) -> std::string { return std::to_string(intLit.value); },
-                            [](const FloatingPointLiteral& floatLit) -> std::string
-                            { return std::to_string(floatLit.value); },
-                            [](const UserDefinedLiteral& udLit) -> std::string
-                            {
-                                 return std::visit(
-                                     OverloadedVisitor{[](const StringLiteral& strLit) -> std::string
-                                                       { return std::format("\"{}\"", strLit.value); },
+                        OverloadedVisitor{[](const std::monostate&) -> std::string
+                                          {
+                                               return std::string{};
+                                          },
+                                          [](const std::string& str)
+                                          {
+                                               return str;
+                                          },
+                                          [](const bool b) -> std::string
+                                          {
+                                               return b ? "true" : "false";
+                                          },
+                                          [](const StringLiteral& strLit) -> std::string
+                                          {
+                                               return strLit.value;
+                                          },
+                                          [](const char c)
+                                          {
+                                               return std::string(1, c);
+                                          },
+                                          [](const IntegerLiteral& intLit) -> std::string
+                                          {
+                                               return std::to_string(intLit.value);
+                                          },
+                                          [](const FloatingPointLiteral& floatLit) -> std::string
+                                          {
+                                               return std::to_string(floatLit.value);
+                                          },
+                                          [](const UserDefinedLiteral& udLit) -> std::string
+                                          {
+                                               return std::visit(
+                                                   OverloadedVisitor{
+                                                       [](const StringLiteral& strLit) -> std::string
+                                                       {
+                                                            return std::format("\"{}\"", strLit.value);
+                                                       },
                                                        [](const IntegerLiteral& intLit) -> std::string
-                                                       { return std::to_string(intLit.value); },
+                                                       {
+                                                            return std::to_string(intLit.value);
+                                                       },
                                                        [](const FloatingPointLiteral& floatLit) -> std::string
-                                                       { return std::to_string(floatLit.value); },
+                                                       {
+                                                            return std::to_string(floatLit.value);
+                                                       },
                                                        [](auto&&) -> std::string
                                                        {
                                                             runtime_assert(false, "Invalid user-defined literal value");
                                                             std::terminate();
                                                        }},
-                                     udLit.value);
-                            }},
+                                                   udLit.value);
+                                          }},
                         this->value);
                case TokenType::LeftParenthesis: return "(";
                case TokenType::RightParenthesis: return ")";

--- a/compiler/ecpps/src/Shared/BumpAllocator.cpp
+++ b/compiler/ecpps/src/Shared/BumpAllocator.cpp
@@ -82,7 +82,10 @@ std::byte* ecpps::BumpAllocator::Allocate(std::size_t size) noexcept
      return address;
 }
 
-ecpps::BumpAllocator::~BumpAllocator(void) { Release(); }
+ecpps::BumpAllocator::~BumpAllocator(void)
+{
+     Release();
+}
 
 void ecpps::BumpAllocator::Release(void)
 {

--- a/compiler/ecpps/src/Shared/BumpAllocator.h
+++ b/compiler/ecpps/src/Shared/BumpAllocator.h
@@ -14,7 +14,10 @@ namespace ecpps
 
           template <typename T> struct Deleter
           {
-               static void operator()(T* lpT) noexcept(noexcept(std::declval<T>().~T())) { lpT->~T(); }
+               static void operator()(T* lpT) noexcept(noexcept(std::declval<T>().~T()))
+               {
+                    lpT->~T();
+               }
           };
           std::byte* Allocate(std::size_t size) noexcept;
           ~BumpAllocator(void);

--- a/compiler/ecpps/src/Shared/Config.cpp
+++ b/compiler/ecpps/src/Shared/Config.cpp
@@ -43,16 +43,20 @@ ecpps::CompilerConfig::CompilerConfig(
                auto flag = fullArgument.substr(1);
                auto value = flag.find(':') == std::string::npos ? "" : flag.substr(flag.find(':') + 1);
                flag = flag.substr(0, flag.find(':'));
-               const auto lowerFlag =
-                   flag |
-                   std::views::transform([](const char ch) -> char
-                                         { return static_cast<char>(std::tolower(static_cast<int>(ch))); }) |
-                   std::ranges::to<std::string>();
-               const auto lowerValue =
-                   value |
-                   std::views::transform([](const char ch) -> char
-                                         { return static_cast<char>(std::tolower(static_cast<int>(ch))); }) |
-                   std::ranges::to<std::string>();
+               const auto lowerFlag = flag |
+                                      std::views::transform(
+                                          [](const char ch) -> char
+                                          {
+                                               return static_cast<char>(std::tolower(static_cast<int>(ch)));
+                                          }) |
+                                      std::ranges::to<std::string>();
+               const auto lowerValue = value |
+                                       std::views::transform(
+                                           [](const char ch) -> char
+                                           {
+                                                return static_cast<char>(std::tolower(static_cast<int>(ch)));
+                                           }) |
+                                       std::ranges::to<std::string>();
 
                if (flag == "WX") this->warningsAreErrors = true;
                else if (flag == "-WX")
@@ -69,10 +73,15 @@ ecpps::CompilerConfig::CompilerConfig(
                     else
                          this->verboseStatus = VerboseStatus::Verbose;
                }
-               else if (flag == "V") { this->verboseStatus = VerboseStatus::ExtraVerbose; }
+               else if (flag == "V")
+               {
+                    this->verboseStatus = VerboseStatus::ExtraVerbose;
+               }
                else if (lowerFlag == "output" || lowerFlag == "out")
                {
-                    if (!this->outputImage.empty()) {} // TODO: Warning
+                    if (!this->outputImage.empty())
+                    {
+                    } // TODO: Warning
                     this->outputImage = value;
                }
                else if (lowerFlag == "I" || lowerFlag == "include")
@@ -110,7 +119,10 @@ ecpps::CompilerConfig::CompilerConfig(
                     const auto [ptr, ec] = std::from_chars(value.data(), value.data() + value.size(),
                                                            this->optimisations.maxConstantEvaluationDepth);
 
-                    if (ec != std::errc()) { std::println("Invalid value for /Oconst-depth: `{}`", value); }
+                    if (ec != std::errc())
+                    {
+                         std::println("Invalid value for /Oconst-depth: `{}`", value);
+                    }
                }
                else if (flag == "?" || lowerFlag == "help")
                     PrintHelpAndExit();

--- a/compiler/ecpps/src/Shared/Config.cpp
+++ b/compiler/ecpps/src/Shared/Config.cpp
@@ -13,7 +13,7 @@
 ecpps::CompilerStrategy ecpps::g_compilerStrategy{};
 
 ecpps::CompilerConfig::CompilerConfig(
-    int argc, char* argv[]) // NOLINT(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
+     int argc, char* argv[]) // NOLINT(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
 {
      using std::string_literals::operator""s;
 
@@ -45,17 +45,17 @@ ecpps::CompilerConfig::CompilerConfig(
                flag = flag.substr(0, flag.find(':'));
                const auto lowerFlag = flag |
                                       std::views::transform(
-                                          [](const char ch) -> char
-                                          {
-                                               return static_cast<char>(std::tolower(static_cast<int>(ch)));
-                                          }) |
-                                      std::ranges::to<std::string>();
-               const auto lowerValue = value |
-                                       std::views::transform(
                                            [](const char ch) -> char
                                            {
                                                 return static_cast<char>(std::tolower(static_cast<int>(ch)));
                                            }) |
+                                      std::ranges::to<std::string>();
+               const auto lowerValue = value |
+                                       std::views::transform(
+                                            [](const char ch) -> char
+                                            {
+                                                 return static_cast<char>(std::tolower(static_cast<int>(ch)));
+                                            }) |
                                        std::ranges::to<std::string>();
 
                if (flag == "WX") this->warningsAreErrors = true;

--- a/compiler/ecpps/src/Shared/Config.h
+++ b/compiler/ecpps/src/Shared/Config.h
@@ -26,11 +26,11 @@ namespace ecpps
 
      constexpr LinkerUsed DefaultLinker = LinkerUsed::
 #ifdef _WIN64
-         Windows64;
+          Windows64;
 #elif defined(_WIN32)
-         Windows32;
+          Windows32;
 #else
-         Undefined;
+          Undefined;
 #endif
 
      enum struct DiagnosticType : std::uint_fast8_t

--- a/compiler/ecpps/src/Shared/Diagnostics.cpp
+++ b/compiler/ecpps/src/Shared/Diagnostics.cpp
@@ -53,9 +53,18 @@ static void ReportICE(std::string_view message, const std::stacktrace& trace)
      {
           std::print("  0x{:016x}", frame.instruction);
 
-          if (!frame.function.empty()) { std::print(" {}+0x{:x}", frame.function, frame.displacement); }
-          if (!frame.sourceFile.empty()) { std::print(" ({}:{})", frame.sourceFile, frame.sourceLine); }
-          if (!frame.module.empty()) { std::print(" [{}]", frame.module); }
+          if (!frame.function.empty())
+          {
+               std::print(" {}+0x{:x}", frame.function, frame.displacement);
+          }
+          if (!frame.sourceFile.empty())
+          {
+               std::print(" ({}:{})", frame.sourceFile, frame.sourceLine);
+          }
+          if (!frame.module.empty())
+          {
+               std::print(" [{}]", frame.module);
+          }
 
           std::println("");
      }
@@ -65,7 +74,10 @@ static void ReportICE(std::string_view message, const std::stacktrace& trace)
 
 #ifdef _WIN32
 
-static HANDLE GetCurrentProcessHandle(void) noexcept { return ::GetCurrentProcess(); }
+static HANDLE GetCurrentProcessHandle(void) noexcept
+{
+     return ::GetCurrentProcess();
+}
 
 static bool InitialiseSymbols(void)
 {
@@ -285,7 +297,10 @@ ecpps::TracedException::TracedException(std::string message, const std::exceptio
      TerminatePostICE();
 }
 
-[[noreturn]] void ecpps::IssueICE(std::string_view message) { IssueICE(message, std::stacktrace::current(1)); }
+[[noreturn]] void ecpps::IssueICE(std::string_view message)
+{
+     IssueICE(message, std::stacktrace::current(1));
+}
 
 [[noreturn]] void ecpps::IssueICE(std::string_view message, const std::stacktrace& trace)
 {

--- a/compiler/ecpps/src/Shared/Diagnostics.cpp
+++ b/compiler/ecpps/src/Shared/Diagnostics.cpp
@@ -262,8 +262,8 @@ static LONG WINAPI WinExceptionHandler(EXCEPTION_POINTERS* exceptionInfo)
      case EXCEPTION_INT_DIVIDE_BY_ZERO: ecpps::IssueICE("Divide by zero", exceptionInfo->ContextRecord);
      default:
           ecpps::IssueICE(
-              std::format("Unhandled exception has occurred: {}", exceptionInfo->ExceptionRecord->ExceptionCode),
-              exceptionInfo->ContextRecord);
+               std::format("Unhandled exception has occurred: {}", exceptionInfo->ExceptionRecord->ExceptionCode),
+               exceptionInfo->ContextRecord);
      }
 }
 

--- a/compiler/ecpps/src/Shared/Diagnostics.h
+++ b/compiler/ecpps/src/Shared/Diagnostics.h
@@ -30,9 +30,18 @@ namespace ecpps
           {
           }
 
-          [[nodiscard]] const char* what(void) const noexcept override { return this->_message.c_str(); }
-          [[nodiscard]] const std::stacktrace& Trace(void) const noexcept { return this->_trace; }
-          [[nodiscard]] const std::exception_ptr& Inner(void) const noexcept { return this->_inner; }
+          [[nodiscard]] const char* what(void) const noexcept override
+          {
+               return this->_message.c_str();
+          }
+          [[nodiscard]] const std::stacktrace& Trace(void) const noexcept
+          {
+               return this->_trace;
+          }
+          [[nodiscard]] const std::exception_ptr& Inner(void) const noexcept
+          {
+               return this->_inner;
+          }
 
      private:
           std::string _message;

--- a/compiler/ecpps/src/Shared/Error.cpp
+++ b/compiler/ecpps/src/Shared/Error.cpp
@@ -12,16 +12,28 @@ std::string ecpps::diagnostics::InternalCompilerError::Message(void) const noexc
      return built;
 }
 
-std::string ecpps::diagnostics::TypeError::Message(void) const noexcept { return this->_message; }
-std::string ecpps::diagnostics::ConstantEvaluationError::Message(void) const noexcept { return this->_message; }
-std::string ecpps::diagnostics::ConstantEvaluationWarning::Message(void) const noexcept { return this->_message; }
+std::string ecpps::diagnostics::TypeError::Message(void) const noexcept
+{
+     return this->_message;
+}
+std::string ecpps::diagnostics::ConstantEvaluationError::Message(void) const noexcept
+{
+     return this->_message;
+}
+std::string ecpps::diagnostics::ConstantEvaluationWarning::Message(void) const noexcept
+{
+     return this->_message;
+}
 
 std::string ecpps::diagnostics::UnresolvedSymbolError::Message(void) const noexcept
 {
      return "Unresolved symbol " + this->_symbol + ": " + this->_message;
 }
 
-std::string ecpps::diagnostics::SyntaxError::Message(void) const noexcept { return this->_message; }
+std::string ecpps::diagnostics::SyntaxError::Message(void) const noexcept
+{
+     return this->_message;
+}
 
 void ecpps::diagnostics::PrintDiagnostic(const std::string& fileName, const DiagnosticsMessage& diagnostic,
                                          std::size_t indent, std::size_t lastPrintedLine)

--- a/compiler/ecpps/src/Shared/Error.cpp
+++ b/compiler/ecpps/src/Shared/Error.cpp
@@ -95,11 +95,11 @@ void ecpps::diagnostics::PrintDiagnostic(const std::string& fileName, const Diag
                          positionMap[line.size()] = pos; // For end position handling
 
                          std::size_t startPos = positionMap.size() > (diagnostic->Source().position)
-                                                    ? positionMap.at(diagnostic->Source().position)
-                                                    : diagnostic->Source().position;
+                                                     ? positionMap.at(diagnostic->Source().position)
+                                                     : diagnostic->Source().position;
                          std::size_t endPos = positionMap.size() > (diagnostic->Source().endPosition)
-                                                  ? positionMap.at(diagnostic->Source().endPosition)
-                                                  : diagnostic->Source().endPosition;
+                                                   ? positionMap.at(diagnostic->Source().endPosition)
+                                                   : diagnostic->Source().endPosition;
 
                          std::println("{}{:<{}} {}", diagnostic->Source().line, '|', indent * 5uz, expandedLine);
                          std::println("{}   {}{}{}\x1b[0m", std::string(indent * 5uz, ' '), "   ",

--- a/compiler/ecpps/src/Shared/Error.h
+++ b/compiler/ecpps/src/Shared/Error.h
@@ -64,15 +64,30 @@ namespace ecpps::diagnostics
               : _name(std::move(name)), _message(std::move(message)), _source(source)
           {
           }
-          [[nodiscard]] DiagnosticsLevel Level(void) const noexcept override { return TLevel; }
-          [[nodiscard]] std::string Name(void) const noexcept override { return this->_name; }
-          [[nodiscard]] std::string Message(void) const noexcept override { return this->_message; }
-          [[nodiscard]] Location Source(void) const noexcept override { return this->_source; }
+          [[nodiscard]] DiagnosticsLevel Level(void) const noexcept override
+          {
+               return TLevel;
+          }
+          [[nodiscard]] std::string Name(void) const noexcept override
+          {
+               return this->_name;
+          }
+          [[nodiscard]] std::string Message(void) const noexcept override
+          {
+               return this->_message;
+          }
+          [[nodiscard]] Location Source(void) const noexcept override
+          {
+               return this->_source;
+          }
           [[nodiscard]] const std::vector<DiagnosticsMessage>& SubDiagnostics(void) const noexcept final
           {
                return this->_subDiagnostics;
           }
-          [[nodiscard]] std::vector<DiagnosticsMessage>& SubDiagnostics(void) noexcept { return this->_subDiagnostics; }
+          [[nodiscard]] std::vector<DiagnosticsMessage>& SubDiagnostics(void) noexcept
+          {
+               return this->_subDiagnostics;
+          }
 
      protected:
           std::string _name;

--- a/compiler/ecpps/src/Shared/Error.h
+++ b/compiler/ecpps/src/Shared/Error.h
@@ -52,7 +52,7 @@ namespace ecpps::diagnostics
           [[nodiscard]] virtual std::string Name(void) const noexcept = 0;
           [[nodiscard]] virtual Location Source(void) const noexcept = 0;
           [[nodiscard]] virtual const std::vector<std::unique_ptr<IDiagnosticsBase>>& SubDiagnostics(
-              void) const noexcept = 0;
+               void) const noexcept = 0;
      };
 
      using DiagnosticsMessage = std::unique_ptr<IDiagnosticsBase>;

--- a/compiler/ecpps/src/TypeSystem/ArithmeticTypes.cpp
+++ b/compiler/ecpps/src/TypeSystem/ArithmeticTypes.cpp
@@ -209,9 +209,15 @@ const ecpps::typeSystem::IntegralType* ecpps::typeSystem::PromoteInteger(const I
      return integer;
 }
 
-std::size_t ecpps::typeSystem::PointerType::Size(void) const noexcept { return abi::ABI::Current().PointerSize(); }
+std::size_t ecpps::typeSystem::PointerType::Size(void) const noexcept
+{
+     return abi::ABI::Current().PointerSize();
+}
 
-std::size_t ecpps::typeSystem::PointerType::Alignment(void) const noexcept { return abi::ABI::Current().PointerSize(); }
+std::size_t ecpps::typeSystem::PointerType::Alignment(void) const noexcept
+{
+     return abi::ABI::Current().PointerSize();
+}
 
 ecpps::typeSystem::ConversionSequence ecpps::typeSystem::PointerType::CompareTo(NonowningTypePointer other) const
 {
@@ -303,7 +309,10 @@ ecpps::typeSystem::NonowningTypePointer ecpps::typeSystem::PointerType::CommonWi
      return nullptr;
 }
 
-std::size_t ecpps::typeSystem::ReferenceType::Size(void) const noexcept { return abi::ABI::Current().PointerSize(); }
+std::size_t ecpps::typeSystem::ReferenceType::Size(void) const noexcept
+{
+     return abi::ABI::Current().PointerSize();
+}
 
 std::size_t ecpps::typeSystem::ReferenceType::Alignment(void) const noexcept
 {

--- a/compiler/ecpps/src/TypeSystem/ArithmeticTypes.cpp
+++ b/compiler/ecpps/src/TypeSystem/ArithmeticTypes.cpp
@@ -61,7 +61,7 @@ ecpps::typeSystem::ConversionSequence ecpps::typeSystem::IntegralType::CompareTo
 }
 
 ecpps::typeSystem::NonowningTypePointer ecpps::typeSystem::IntegralType::CommonWith(
-    const ecpps::typeSystem::NonowningTypePointer other) const
+     const ecpps::typeSystem::NonowningTypePointer other) const
 {
      if (other == nullptr) return nullptr;
 
@@ -81,7 +81,7 @@ ecpps::typeSystem::NonowningTypePointer ecpps::typeSystem::IntegralType::CommonW
           request.kind = ir::TypeKind::Fundamental;
           request.qualifiers = signedType->qualifiers();
           request.data =
-              ir::StandardSignedIntegerRequest{.size = signedType->Kind(), .signedness = Signedness::Unsigned};
+               ir::StandardSignedIntegerRequest{.size = signedType->Kind(), .signedness = Signedness::Unsigned};
 
           return ir::GetTypeContext().Get(request);
           // return ecpps::ir::GetTypeContext().Get(ecpps::ir::GetTypeContext().PushType(
@@ -94,7 +94,7 @@ ecpps::typeSystem::NonowningTypePointer ecpps::typeSystem::IntegralType::CommonW
 }
 
 ecpps::typeSystem::ConversionSequence ecpps::typeSystem::CharacterType::CompareTo(
-    const NonowningTypePointer other) const
+     const NonowningTypePointer other) const
 {
      if (!this->_isUnqualified || !IsCharacter(other)) return IntegralType::CompareTo(other);
 
@@ -122,53 +122,53 @@ std::string ecpps::typeSystem::CharacterType::RawName(void) const noexcept
 // predefined builtin types
 // void
 std::unique_ptr<ecpps::typeSystem::VoidType> ecpps::typeSystem::g_void =
-    std::make_unique<typeSystem::VoidType>("void", ecpps::typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::VoidType>("void", ecpps::typeSystem::Qualifiers::None);
 
 // char
 std::unique_ptr<ecpps::typeSystem::CharacterType> ecpps::typeSystem::g_char =
-    std::make_unique<typeSystem::CharacterType>(ecpps::typeSystem::CharacterSign::Char, "char",
-                                                ecpps::typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::CharacterType>(ecpps::typeSystem::CharacterSign::Char, "char",
+                                                 ecpps::typeSystem::Qualifiers::None);
 std::unique_ptr<ecpps::typeSystem::CharacterType> ecpps::typeSystem::g_signedChar =
-    std::make_unique<typeSystem::CharacterType>(ecpps::typeSystem::CharacterSign::SignedChar, "signed char",
-                                                ecpps::typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::CharacterType>(ecpps::typeSystem::CharacterSign::SignedChar, "signed char",
+                                                 ecpps::typeSystem::Qualifiers::None);
 std::unique_ptr<ecpps::typeSystem::CharacterType> ecpps::typeSystem::g_unsignedChar =
-    std::make_unique<typeSystem::CharacterType>(ecpps::typeSystem::CharacterSign::UnsignedChar, "unsigned char",
-                                                ecpps::typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::CharacterType>(ecpps::typeSystem::CharacterSign::UnsignedChar, "unsigned char",
+                                                 ecpps::typeSystem::Qualifiers::None);
 
 // short
 std::unique_ptr<ecpps::typeSystem::IntegralType> ecpps::typeSystem::g_short =
-    std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Signed, typeSystem::TypeKind::Short, "short",
-                                               typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Signed, typeSystem::TypeKind::Short, "short",
+                                                typeSystem::Qualifiers::None);
 std::unique_ptr<ecpps::typeSystem::IntegralType> ecpps::typeSystem::g_unsignedShort =
-    std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Unsigned, typeSystem::TypeKind::Short,
-                                               "unsigned short", typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Unsigned, typeSystem::TypeKind::Short,
+                                                "unsigned short", typeSystem::Qualifiers::None);
 
 // int
 std::unique_ptr<ecpps::typeSystem::IntegralType> ecpps::typeSystem::g_int = std::make_unique<typeSystem::IntegralType>(
-    typeSystem::Signedness::Signed, typeSystem::TypeKind::Int, "int", typeSystem::Qualifiers::None);
+     typeSystem::Signedness::Signed, typeSystem::TypeKind::Int, "int", typeSystem::Qualifiers::None);
 std::unique_ptr<ecpps::typeSystem::IntegralType> ecpps::typeSystem::g_unsignedInt =
-    std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Unsigned, typeSystem::TypeKind::Int,
-                                               "unsigned int", typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Unsigned, typeSystem::TypeKind::Int,
+                                                "unsigned int", typeSystem::Qualifiers::None);
 
 // long
 std::unique_ptr<ecpps::typeSystem::IntegralType> ecpps::typeSystem::g_long = std::make_unique<typeSystem::IntegralType>(
-    typeSystem::Signedness::Signed, typeSystem::TypeKind::Long, "long", typeSystem::Qualifiers::None);
+     typeSystem::Signedness::Signed, typeSystem::TypeKind::Long, "long", typeSystem::Qualifiers::None);
 std::unique_ptr<ecpps::typeSystem::IntegralType> ecpps::typeSystem::g_unsignedLong =
-    std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Unsigned, typeSystem::TypeKind::Long,
-                                               "unsigned long", typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Unsigned, typeSystem::TypeKind::Long,
+                                                "unsigned long", typeSystem::Qualifiers::None);
 
 // long long
 std::unique_ptr<ecpps::typeSystem::IntegralType> ecpps::typeSystem::g_longLong =
-    std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Signed, typeSystem::TypeKind::LongLong,
-                                               "long long", typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Signed, typeSystem::TypeKind::LongLong,
+                                                "long long", typeSystem::Qualifiers::None);
 std::unique_ptr<ecpps::typeSystem::IntegralType> ecpps::typeSystem::g_unsignedLongLong =
-    std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Unsigned, typeSystem::TypeKind::LongLong,
-                                               "unsigned long long", typeSystem::Qualifiers::None);
+     std::make_unique<typeSystem::IntegralType>(typeSystem::Signedness::Unsigned, typeSystem::TypeKind::LongLong,
+                                                "unsigned long long", typeSystem::Qualifiers::None);
 
 // commonly used types
 std::unique_ptr<ecpps::typeSystem::CharacterType> ecpps::typeSystem::g_constChar =
-    std::make_unique<typeSystem::CharacterType>(ecpps::typeSystem::CharacterSign::Char, "const char",
-                                                ecpps::typeSystem::Qualifiers::Const);
+     std::make_unique<typeSystem::CharacterType>(ecpps::typeSystem::CharacterSign::Char, "const char",
+                                                 ecpps::typeSystem::Qualifiers::Const);
 
 ecpps::typeSystem::IntegerConversionRank ecpps::typeSystem::RankInteger(const IntegralType* integer)
 {
@@ -303,7 +303,7 @@ ecpps::typeSystem::TypeTraits ecpps::typeSystem::PointerType::Traits(void) const
 }
 
 ecpps::typeSystem::NonowningTypePointer ecpps::typeSystem::PointerType::CommonWith(
-    [[maybe_unused]] NonowningTypePointer other) const
+     [[maybe_unused]] NonowningTypePointer other) const
 {
      // TODO: Implement
      return nullptr;
@@ -320,7 +320,7 @@ std::size_t ecpps::typeSystem::ReferenceType::Alignment(void) const noexcept
 }
 
 ecpps::typeSystem::ConversionSequence ecpps::typeSystem::ReferenceType::CompareTo(
-    [[maybe_unused]] NonowningTypePointer other) const
+     [[maybe_unused]] NonowningTypePointer other) const
 {
      // TODO: Implement
      throw nullptr;
@@ -332,7 +332,7 @@ ecpps::typeSystem::TypeTraits ecpps::typeSystem::ReferenceType::Traits(void) con
 }
 
 ecpps::typeSystem::NonowningTypePointer ecpps::typeSystem::ReferenceType::CommonWith(
-    [[maybe_unused]] NonowningTypePointer other) const
+     [[maybe_unused]] NonowningTypePointer other) const
 {
      // TODO: Implement
      return nullptr;

--- a/compiler/ecpps/src/TypeSystem/ArithmeticTypes.h
+++ b/compiler/ecpps/src/TypeSystem/ArithmeticTypes.h
@@ -31,9 +31,15 @@ namespace ecpps::typeSystem
           {
           }
 
-          [[nodiscard]] Signedness Sign(void) const noexcept { return this->_sign; }
+          [[nodiscard]] Signedness Sign(void) const noexcept
+          {
+               return this->_sign;
+          }
           [[nodiscard]] std::size_t Size(void) const noexcept final;
-          [[nodiscard]] std::size_t Alignment(void) const noexcept final { return Size(); }
+          [[nodiscard]] std::size_t Alignment(void) const noexcept final
+          {
+               return Size();
+          }
 
           [[nodiscard]] std::string RawName(void) const override;
 
@@ -49,7 +55,10 @@ namespace ecpps::typeSystem
           }
 
           [[nodiscard]] ConversionSequence CompareTo(ecpps::typeSystem::NonowningTypePointer other) const override;
-          [[nodiscard]] TypeKind Kind(void) const noexcept { return this->_kind; }
+          [[nodiscard]] TypeKind Kind(void) const noexcept
+          {
+               return this->_kind;
+          }
 
           [[nodiscard]] NonowningTypePointer CommonWith(ecpps::typeSystem::NonowningTypePointer other) const final;
 
@@ -97,13 +106,19 @@ namespace ecpps::typeSystem
           {
           }
 
-          [[nodiscard]] NonowningTypePointer BaseType(void) const noexcept { return this->_baseType; }
+          [[nodiscard]] NonowningTypePointer BaseType(void) const noexcept
+          {
+               return this->_baseType;
+          }
 
           [[nodiscard]] std::size_t Size(void) const noexcept override;
 
           [[nodiscard]] std::size_t Alignment(void) const noexcept override;
 
-          [[nodiscard]] std::string RawName(void) const override { return this->_baseType->RawName() + "*"; }
+          [[nodiscard]] std::string RawName(void) const override
+          {
+               return this->_baseType->RawName() + "*";
+          }
 
           [[nodiscard]] ConversionSequence CompareTo(NonowningTypePointer other) const override;
 
@@ -128,8 +143,14 @@ namespace ecpps::typeSystem
           {
           }
 
-          [[nodiscard]] NonowningTypePointer BaseType(void) const noexcept { return this->_baseType; }
-          [[nodiscard]] Kind GetKind(void) const noexcept { return this->_kind; }
+          [[nodiscard]] NonowningTypePointer BaseType(void) const noexcept
+          {
+               return this->_baseType;
+          }
+          [[nodiscard]] Kind GetKind(void) const noexcept
+          {
+               return this->_kind;
+          }
 
           [[nodiscard]] std::size_t Size(void) const noexcept override;
           [[nodiscard]] std::size_t Alignment(void) const noexcept override;

--- a/compiler/ecpps/src/TypeSystem/CompoundTypes.cpp
+++ b/compiler/ecpps/src/TypeSystem/CompoundTypes.cpp
@@ -8,7 +8,7 @@ std::size_t ecpps::typeSystem::ArrayType::Size(void) const noexcept
 }
 
 ecpps::typeSystem::ConversionSequence ecpps::typeSystem::ArrayType::CompareTo(
-    [[maybe_unused]] NonowningTypePointer other) const
+     [[maybe_unused]] NonowningTypePointer other) const
 {
      return ConversionSequence{std::nullopt};
 }
@@ -19,7 +19,7 @@ ecpps::typeSystem::TypeTraits ecpps::typeSystem::ArrayType::Traits(void) const n
 }
 
 ecpps::typeSystem::NonowningTypePointer ecpps::typeSystem::ArrayType::CommonWith(
-    [[maybe_unused]] NonowningTypePointer other) const
+     [[maybe_unused]] NonowningTypePointer other) const
 {
      return nullptr;
 }

--- a/compiler/ecpps/src/TypeSystem/CompoundTypes.h
+++ b/compiler/ecpps/src/TypeSystem/CompoundTypes.h
@@ -16,12 +16,21 @@ namespace ecpps::typeSystem
                 _alignmentRequirements(std::max(alignmentRequirements, _elementType->Alignment()))
           {
           }
-          [[nodiscard]] std::size_t ElementCount(void) const noexcept { return this->_nElements; }
-          [[nodiscard]] NonowningTypePointer ElementType(void) const noexcept { return this->_elementType; }
+          [[nodiscard]] std::size_t ElementCount(void) const noexcept
+          {
+               return this->_nElements;
+          }
+          [[nodiscard]] NonowningTypePointer ElementType(void) const noexcept
+          {
+               return this->_elementType;
+          }
 
           [[nodiscard]] std::size_t Size(void) const noexcept override;
 
-          [[nodiscard]] std::size_t Alignment(void) const noexcept override { return this->_alignmentRequirements; }
+          [[nodiscard]] std::size_t Alignment(void) const noexcept override
+          {
+               return this->_alignmentRequirements;
+          }
 
           [[nodiscard]] std::string RawName(void) const override
           {

--- a/compiler/ecpps/src/TypeSystem/TypeBase.cpp
+++ b/compiler/ecpps/src/TypeSystem/TypeBase.cpp
@@ -3,7 +3,7 @@
 #include "ArithmeticTypes.h"
 
 ecpps::typeSystem::NonowningTypePointer ecpps::typeSystem::VoidType::CommonWith(
-    typeSystem::NonowningTypePointer other) const
+     typeSystem::NonowningTypePointer other) const
 {
      {
           return IsIncomplete(other) ? ecpps::typeSystem::g_void.get() : nullptr;

--- a/compiler/ecpps/src/TypeSystem/TypeBase.h
+++ b/compiler/ecpps/src/TypeSystem/TypeBase.h
@@ -287,7 +287,7 @@ namespace ecpps::typeSystem
                return this->_qualifiers;
           }
           [[nodiscard]] Qualifiers qualifiers( // NOLINT(readability-identifier-naming)
-              const Qualifiers newQualifiers) noexcept
+               const Qualifiers newQualifiers) noexcept
           {
                return std::exchange(this->_qualifiers, newQualifiers);
           }
@@ -336,8 +336,8 @@ namespace ecpps::typeSystem
           [[nodiscard]] ConversionSequence CompareTo(NonowningTypePointer other) const override
           {
                return typeid(*other) == typeid(VoidType) // NOLINT
-                          ? ConversionSequence{SBOVector<ConversionSequence::ConversionKind>{}}
-                          : ConversionSequence{std::nullopt};
+                           ? ConversionSequence{SBOVector<ConversionSequence::ConversionKind>{}}
+                           : ConversionSequence{std::nullopt};
           }
 
           [[nodiscard]] NonowningTypePointer CommonWith(NonowningTypePointer other) const override;

--- a/compiler/ecpps/src/TypeSystem/TypeBase.h
+++ b/compiler/ecpps/src/TypeSystem/TypeBase.h
@@ -72,9 +72,18 @@ namespace ecpps::typeSystem
                 _rejectionReason(std::move(rejectionReason))
           {
           }
-          [[nodiscard]] bool IsValid(void) const noexcept { return this->_isValid; }
-          [[nodiscard]] const SBOVector<ConversionKind>& Sequence(void) const noexcept { return this->_sequence; }
-          [[nodiscard]] bool SameAs(void) const noexcept { return this->_isValid && this->_sequence.Size() == 0; }
+          [[nodiscard]] bool IsValid(void) const noexcept
+          {
+               return this->_isValid;
+          }
+          [[nodiscard]] const SBOVector<ConversionKind>& Sequence(void) const noexcept
+          {
+               return this->_sequence;
+          }
+          [[nodiscard]] bool SameAs(void) const noexcept
+          {
+               return this->_isValid && this->_sequence.Size() == 0;
+          }
 
      private:
           bool _isValid;
@@ -93,8 +102,14 @@ namespace ecpps::typeSystem
           {
                return this->_traits.test(static_cast<std::size_t>(trait));
           }
-          void Set(const TypeTraitEnum trait) { this->_traits.set(static_cast<std::size_t>(trait)); }
-          void Remove(const TypeTraitEnum trait) { this->_traits.reset(static_cast<std::size_t>(trait)); }
+          void Set(const TypeTraitEnum trait)
+          {
+               this->_traits.set(static_cast<std::size_t>(trait));
+          }
+          void Remove(const TypeTraitEnum trait)
+          {
+               this->_traits.reset(static_cast<std::size_t>(trait));
+          }
 
      private:
           std::bitset<static_cast<std::size_t>(TypeTraitEnum::Count)> _traits{};
@@ -113,7 +128,9 @@ namespace ecpps::typeSystem
      class TypeBase : ir::Entity
      {
      public:
-          explicit TypeBase(std::string name) : ir::Entity(ir::EntityKind::Type, std::move(name)) {}
+          explicit TypeBase(std::string name) : ir::Entity(ir::EntityKind::Type, std::move(name))
+          {
+          }
           [[nodiscard]] const std::string& Name(void) const noexcept
           {
                runtime_assert(this->ir::Entity::Name().has_value(), "Nameless types don't exist");
@@ -208,7 +225,10 @@ namespace ecpps::typeSystem
           {
                return std::hash<std::string>{}(ptr->RawName());
           }
-          std::size_t operator()(const std::string& str) const noexcept { return std::hash<std::string>{}(str); }
+          std::size_t operator()(const std::string& str) const noexcept
+          {
+               return std::hash<std::string>{}(str);
+          }
      };
      struct TypePointerEqual
      {
@@ -304,8 +324,14 @@ namespace ecpps::typeSystem
                return TypeTraits{TypeTraitEnum::Incomplete};
           }
 
-          [[nodiscard]] std::size_t Size(void) const noexcept override { return 0; }
-          [[nodiscard]] std::size_t Alignment(void) const noexcept override { return 0; }
+          [[nodiscard]] std::size_t Size(void) const noexcept override
+          {
+               return 0;
+          }
+          [[nodiscard]] std::size_t Alignment(void) const noexcept override
+          {
+               return 0;
+          }
 
           [[nodiscard]] ConversionSequence CompareTo(NonowningTypePointer other) const override
           {

--- a/compiler/ecpps/src/cli/main.cpp
+++ b/compiler/ecpps/src/cli/main.cpp
@@ -76,7 +76,7 @@ enum struct FileIterationStatus : bool
           std::chrono::year_month_day ymd{std::chrono::floor<std::chrono::days>(now)};
           macros.emplace_back("__DATE__", std::nullopt, std::format("\"{:%b %e %Y}\"", ymd), false);
           std::chrono::hh_mm_ss hms{
-              std::chrono::floor<std::chrono::seconds>(now - std::chrono::floor<std::chrono::days>(now))};
+               std::chrono::floor<std::chrono::seconds>(now - std::chrono::floor<std::chrono::days>(now))};
           macros.emplace_back("__TIME__", std::nullopt, std::format("\"{:%T}\"", hms), false);
           // TODO: __STDC_HOSTED__
           // TODO: __STDCPP_DEFAULT_NEW_ALIGNMENT__
@@ -97,7 +97,7 @@ enum struct FileIterationStatus : bool
           std::set<std::filesystem::path> includedFiles;
           ecpps::Preprocessor preprocessor{};
           const auto ppTokens =
-              preprocessor.Parse(source.contents, macros, source.name, includedFiles, config.includeDirectories);
+               preprocessor.Parse(source.contents, macros, source.name, includedFiles, config.includeDirectories);
           std::ranges::move(preprocessor.diagnostics, std::back_inserter(source.diagnostics.diagnosticsList));
           const auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
           if (isExtraVerbose) std::println();
@@ -176,14 +176,14 @@ enum struct FileIterationStatus : bool
 
                     std::size_t start = std::min(routineOffset, generatedMachineCode.size());
                     std::size_t end = (i + 1 < ordered.size())
-                                          ? std::min(ordered[i + 1].second, generatedMachineCode.size())
-                                          : generatedMachineCode.size();
+                                           ? std::min(ordered[i + 1].second, generatedMachineCode.size())
+                                           : generatedMachineCode.size();
 
                     if (start >= end) continue;
 
                     auto machineCode =
-                        std::ranges::subrange(generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(start),
-                                              generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(end));
+                         std::ranges::subrange(generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(start),
+                                               generatedMachineCode.begin() + static_cast<std::ptrdiff_t>(end));
 
                     constexpr std::size_t RowSize = 8; // in bytes
                     const auto rows = (machineCode.size() + RowSize - 1) / RowSize;
@@ -199,7 +199,7 @@ enum struct FileIterationStatus : bool
                               if (byteOffset >= machineCode.size()) std::print("   ");
                               else
                                    std::print("{:02x} ", static_cast<std::size_t>(
-                                                             machineCode[static_cast<std::ptrdiff_t>(byteOffset)]));
+                                                              machineCode[static_cast<std::ptrdiff_t>(byteOffset)]));
                          }
                          std::println("|");
                     }
@@ -398,15 +398,15 @@ int main(int argc, char* argv[])
           config.stringArray.emplace_back(u8'\0');
 
           std::vector<std::byte> imageBytes = ecpps::linker::Linker::SelectAndLink(
-              config, generatedMachineCode, functions, mainOffset, emitter->linkerForwardedRelocations, codeSection,
-              emitter->_stringRelocation, 4,
-              config.stringArray |
-                  std::views::transform(
-                      [](const char8_t character)
-                      {
-                           return static_cast<std::byte>(character);
-                      }) |
-                  std::ranges::to<std::vector>());
+               config, generatedMachineCode, functions, mainOffset, emitter->linkerForwardedRelocations, codeSection,
+               emitter->_stringRelocation, 4,
+               config.stringArray |
+                    std::views::transform(
+                         [](const char8_t character)
+                         {
+                              return static_cast<std::byte>(character);
+                         }) |
+                    std::ranges::to<std::vector>());
 
           if (imageBytes.empty())
           {

--- a/compiler/ecpps/src/cli/main.cpp
+++ b/compiler/ecpps/src/cli/main.cpp
@@ -401,7 +401,11 @@ int main(int argc, char* argv[])
               config, generatedMachineCode, functions, mainOffset, emitter->linkerForwardedRelocations, codeSection,
               emitter->_stringRelocation, 4,
               config.stringArray |
-                  std::views::transform([](const char8_t character) { return static_cast<std::byte>(character); }) |
+                  std::views::transform(
+                      [](const char8_t character)
+                      {
+                           return static_cast<std::byte>(character);
+                      }) |
                   std::ranges::to<std::vector>());
 
           if (imageBytes.empty())

--- a/compiler/platformlib/include/platformlib/identify.h
+++ b/compiler/platformlib/include/platformlib/identify.h
@@ -21,7 +21,9 @@ namespace ecpps::platformlib
      struct PlatformIdentity
      {
           ArchitectureBitness bitness;
-          explicit PlatformIdentity(const ArchitectureBitness bitness) : bitness(bitness) {}
+          explicit PlatformIdentity(const ArchitectureBitness bitness) : bitness(bitness)
+          {
+          }
 
           /// <summary>
           /// Calling this from other platform than x86 is undefined

--- a/compiler/platformlib/include/platformlib/platformlib.h
+++ b/compiler/platformlib/include/platformlib/platformlib.h
@@ -9,7 +9,9 @@ namespace ecpps::platformlib
 {
      struct NativeException : std::runtime_error
      {
-          explicit NativeException(const std::string& message) : runtime_error(message) {}
+          explicit NativeException(const std::string& message) : runtime_error(message)
+          {
+          }
      };
      template <typename TFrom, typename TTo> struct PointerInterconvertibility
      {
@@ -64,5 +66,8 @@ namespace ecpps::platformlib
           std::vector<void*> WalkTrace(DebuggerContext* defaultContext);
      } // namespace debugger
 
-     inline ecpps::platformlib::DebuggerContext::~DebuggerContext(void) { debugger::Delete(this); }
+     inline ecpps::platformlib::DebuggerContext::~DebuggerContext(void)
+     {
+          debugger::Delete(this);
+     }
 } // namespace ecpps::platformlib

--- a/compiler/platformlib/src/identify.cpp
+++ b/compiler/platformlib/src/identify.cpp
@@ -32,7 +32,7 @@ ecpps::platformlib::PlatformIdentity ecpps::platformlib::PlatformIdentity::Ident
           case IMAGE_FILE_MACHINE_I386: bitness = ecpps::platformlib::ArchitectureBitness::x86_32; break;
           default:
                throw ecpps::platformlib::NativeException(
-                   std::format("Unknown native architecture: 0x{:X}", nativeMachine));
+                    std::format("Unknown native architecture: 0x{:X}", nativeMachine));
           }
      }
      else
@@ -43,7 +43,7 @@ ecpps::platformlib::PlatformIdentity ecpps::platformlib::PlatformIdentity::Ident
           case IMAGE_FILE_MACHINE_AMD64: bitness = ecpps::platformlib::ArchitectureBitness::x86_64; break;
           default:
                throw ecpps::platformlib::NativeException(
-                   std::format("Unsupported WOW64 native arch: 0x{:X}", nativeMachine));
+                    std::format("Unsupported WOW64 native arch: 0x{:X}", nativeMachine));
           }
      }
 #else

--- a/compiler/utilitieslib/include/utilitieslib/Numbers.h
+++ b/compiler/utilitieslib/include/utilitieslib/Numbers.h
@@ -8,15 +8,23 @@ namespace ecpps
      {
           TUnderlying value;
 
-          [[nodiscard]] TUnderlying& Value(void) noexcept { return this->value; }
-          [[nodiscard]] TUnderlying Value(void) const noexcept { return this->value; }
+          [[nodiscard]] TUnderlying& Value(void) noexcept
+          {
+               return this->value;
+          }
+          [[nodiscard]] TUnderlying Value(void) const noexcept
+          {
+               return this->value;
+          }
 
           [[nodiscard]] friend bool operator==(const Number& lhs, const Number& rhs) noexcept
           {
                return lhs.Value() == rhs.Value();
           }
 
-          explicit(false) constexpr Number(const TUnderlying value) : value(value) {}
+          explicit(false) constexpr Number(const TUnderlying value) : value(value)
+          {
+          }
      };
 
 #define define_number(name, underlying)                                                                                \
@@ -24,7 +32,10 @@ namespace ecpps
      {                                                                                                                 \
           using Number::Number;                                                                                        \
      };                                                                                                                \
-     [[nodiscard]] consteval name operator""_##name(const unsigned long long value) { return name{value}; }            \
+     [[nodiscard]] consteval name operator""_##name(const unsigned long long value)                                    \
+     {                                                                                                                 \
+          return name{value};                                                                                          \
+     }                                                                                                                 \
      template <> struct std::hash<name>                                                                                \
      {                                                                                                                 \
           [[nodiscard]] static underlying operator()(const name number) noexcept                                       \

--- a/compiler/utilitieslib/include/utilitieslib/Queue.h
+++ b/compiler/utilitieslib/include/utilitieslib/Queue.h
@@ -16,7 +16,7 @@ namespace ecpps
           union BufferUnion
           {
                alignas(T) std::byte // NOLINT(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
-                   sbo[sizeof(T) * SBOSize];
+                    sbo[sizeof(T) * SBOSize];
                struct
                {
                     T* begin{};
@@ -272,18 +272,19 @@ namespace ecpps
                return UseSBO() ? std::launder(reinterpret_cast<
                                               T(&)[TNSBOSize / sizeof(T)]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
                                                                             // modernize-avoid-c-arrays)
-                                     this->_buffer.sbo))
+                                      this->_buffer.sbo))
                                : this->_buffer.noSbo.begin;
           }
 
           const T* StoragePtr(void) const noexcept
           {
                return UseSBO()
-                          ? std::launder(reinterpret_cast<
-                                         const T(&)[TNSBOSize / sizeof(T)]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                             // modernize-avoid-c-arrays)
-                                this->_buffer.sbo))
-                          : _buffer.noSbo.begin;
+                           ? std::launder(
+                                  reinterpret_cast<
+                                       const T(&)[TNSBOSize / sizeof(T)]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                           // modernize-avoid-c-arrays)
+                                       this->_buffer.sbo))
+                           : _buffer.noSbo.begin;
           }
 
           T& operator[](std::size_t index)

--- a/compiler/utilitieslib/include/utilitieslib/Queue.h
+++ b/compiler/utilitieslib/include/utilitieslib/Queue.h
@@ -23,12 +23,19 @@ namespace ecpps
                     std::size_t capacity{};
                } noSbo;
 
-               explicit BufferUnion(void) noexcept {} // NOLINT(cppcoreguidelines-pro-type-member-init)
-               ~BufferUnion(void) noexcept {}
+               explicit BufferUnion(void) noexcept
+               {
+               } // NOLINT(cppcoreguidelines-pro-type-member-init)
+               ~BufferUnion(void) noexcept
+               {
+               }
           };
 
      public:
-          SBOQueue(void) noexcept { new (_buffer.sbo) std::byte[sizeof(T) * SBOSize]; }
+          SBOQueue(void) noexcept
+          {
+               new (_buffer.sbo) std::byte[sizeof(T) * SBOSize];
+          }
 
           ~SBOQueue(void)
           {
@@ -41,8 +48,14 @@ namespace ecpps
                }
           }
 
-          void Push(const T& value) { Emplace(value); }
-          void Push(T&& value) { Emplace(std::move(value)); }
+          void Push(const T& value)
+          {
+               Emplace(value);
+          }
+          void Push(T&& value)
+          {
+               Emplace(std::move(value));
+          }
 
           void Pop(void)
           {
@@ -52,14 +65,32 @@ namespace ecpps
                this->_size--;
           }
 
-          T& Front(void) { return *FrontPtr(); }
-          const T& Front(void) const { return *FrontPtr(); }
+          T& Front(void)
+          {
+               return *FrontPtr();
+          }
+          const T& Front(void) const
+          {
+               return *FrontPtr();
+          }
 
-          T& Back(void) { return *BackPtr(); }
-          const T& Back(void) const { return *BackPtr(); }
+          T& Back(void)
+          {
+               return *BackPtr();
+          }
+          const T& Back(void) const
+          {
+               return *BackPtr();
+          }
 
-          std::size_t Size(void) const noexcept { return this->_size; }
-          bool Empty(void) const noexcept { return this->_size == 0; }
+          std::size_t Size(void) const noexcept
+          {
+               return this->_size;
+          }
+          bool Empty(void) const noexcept
+          {
+               return this->_size == 0;
+          }
 
           class iterator // NOLINT
           {
@@ -70,10 +101,18 @@ namespace ecpps
                using pointer = T*;
                using iterator_category = std::bidirectional_iterator_tag;
 
-               iterator(SBOQueue* queue, const std::size_t index) : _queue(queue), _index(index) {}
+               iterator(SBOQueue* queue, const std::size_t index) : _queue(queue), _index(index)
+               {
+               }
 
-               reference operator*(void) const { return (*this->_queue)[this->_index]; }
-               pointer operator->(void) const { return &(*this->_queue)[this->_index]; }
+               reference operator*(void) const
+               {
+                    return (*this->_queue)[this->_index];
+               }
+               pointer operator->(void) const
+               {
+                    return &(*this->_queue)[this->_index];
+               }
 
                iterator& operator++(void)
                {
@@ -107,7 +146,10 @@ namespace ecpps
                {
                     return a._queue == b._queue && a._index == b._index;
                }
-               friend bool operator!=(const iterator& a, const iterator& b) { return !(a == b); }
+               friend bool operator!=(const iterator& a, const iterator& b)
+               {
+                    return !(a == b);
+               }
 
           private:
                SBOQueue* _queue;
@@ -119,7 +161,10 @@ namespace ecpps
                if (this->_size == 0) return end();
                return iterator(this, this->_tail == 0 ? Capacity() - 1 : this->_tail - 1);
           }
-          iterator end(void) { return iterator(this, this->_head == 0 ? Capacity() - 1 : this->_head - 1); } // NOLINT
+          iterator end(void)
+          {
+               return iterator(this, this->_head == 0 ? Capacity() - 1 : this->_head - 1);
+          } // NOLINT
 
           SBOQueue(const SBOQueue& other)
           {
@@ -179,8 +224,14 @@ namespace ecpps
                return *this;
           }
 
-          void Emplace(const T& value) { EmplaceImpl(value); }
-          void Emplace(T&& value) { EmplaceImpl(std::move(value)); }
+          void Emplace(const T& value)
+          {
+               EmplaceImpl(value);
+          }
+          void Emplace(T&& value)
+          {
+               EmplaceImpl(std::move(value));
+          }
 
           template <typename U> void EmplaceImpl(U&& value)
           {
@@ -235,13 +286,28 @@ namespace ecpps
                           : _buffer.noSbo.begin;
           }
 
-          T& operator[](std::size_t index) { return *(StoragePtr() + index); }
-          const T& operator[](std::size_t index) const { return *(StoragePtr() + index); }
+          T& operator[](std::size_t index)
+          {
+               return *(StoragePtr() + index);
+          }
+          const T& operator[](std::size_t index) const
+          {
+               return *(StoragePtr() + index);
+          }
 
-          T* FrontPtr(void) noexcept { return StoragePtr() + this->_head; }
-          const T* FrontPtr(void) const noexcept { return StoragePtr() + this->_head; }
+          T* FrontPtr(void) noexcept
+          {
+               return StoragePtr() + this->_head;
+          }
+          const T* FrontPtr(void) const noexcept
+          {
+               return StoragePtr() + this->_head;
+          }
 
-          T* BackPtr(void) noexcept { return StoragePtr() + (this->_tail == 0 ? Capacity() - 1 : this->_tail - 1); }
+          T* BackPtr(void) noexcept
+          {
+               return StoragePtr() + (this->_tail == 0 ? Capacity() - 1 : this->_tail - 1);
+          }
           const T* BackPtr(void) const noexcept
           {
                return StoragePtr() + (this->_tail == 0 ? Capacity() - 1 : this->_tail - 1);
@@ -252,7 +318,10 @@ namespace ecpps
                return UseSBO() ? SBOSize : this->_buffer.noSbo.capacity;
           }
 
-          [[nodiscard]] bool UseSBO(void) const noexcept { return this->_size <= SBOSize; }
+          [[nodiscard]] bool UseSBO(void) const noexcept
+          {
+               return this->_size <= SBOSize;
+          }
 
      private:
           BufferUnion _buffer;

--- a/compiler/utilitieslib/include/utilitieslib/SBOVector.h
+++ b/compiler/utilitieslib/include/utilitieslib/SBOVector.h
@@ -52,8 +52,14 @@ template <typename T> void UFillN(T&& value, T* to, std::size_t size)
 }
 #endif
 #else
-template <typename T> void UCopyN(const T* from, T* to, std::size_t size) { std::uninitialized_copy_n(from, size, to); }
-template <typename T> void UMoveN(T* from, T* to, std::size_t size) { std::uninitialized_move_n(from, size, to); }
+template <typename T> void UCopyN(const T* from, T* to, std::size_t size)
+{
+     std::uninitialized_copy_n(from, size, to);
+}
+template <typename T> void UMoveN(T* from, T* to, std::size_t size)
+{
+     std::uninitialized_move_n(from, size, to);
+}
 template <typename T> void UFillN(const T& value, T* to, std::size_t size)
 {
      std::uninitialized_fill_n(to, size, value);
@@ -91,12 +97,19 @@ namespace ecpps
                std::byte sbo[sizeof(TElement) * SBOSize]; // NOLINT(cppcoreguidelines-avoid-c-arrays)
                NoSBO noSbo;
 
-               explicit BufferUnion(void) {} // NOLINT(cppcoreguidelines-pro-type-member-init)
-               ~BufferUnion(void) {}
+               explicit BufferUnion(void)
+               {
+               } // NOLINT(cppcoreguidelines-pro-type-member-init)
+               ~BufferUnion(void)
+               {
+               }
           };
 
      public:
-          explicit SBOVector(void) { new (this->_buffer.sbo) std::byte[sizeof(TElement) * SBOSize]; }
+          explicit SBOVector(void)
+          {
+               new (this->_buffer.sbo) std::byte[sizeof(TElement) * SBOSize];
+          }
 
           SBOVector(std::size_t count, const TElement& value = TElement{}) : _size(count)
           {
@@ -276,7 +289,10 @@ namespace ecpps
                          const std::size_t newCap = oldCap * 2;
                          TElement* newBuf = allocator.allocate(newCap);
                          UMoveN(this->_buffer.noSbo.begin, newBuf, index);
-                         for (std::size_t i = 0; i < index; i++) { std::destroy_at(this->_buffer.noSbo.begin + i); }
+                         for (std::size_t i = 0; i < index; i++)
+                         {
+                              std::destroy_at(this->_buffer.noSbo.begin + i);
+                         }
                          allocator.deallocate(std::exchange(_buffer.noSbo.begin, newBuf), oldCap);
                          this->_buffer.noSbo.capacity = newCap;
                     }
@@ -338,8 +354,14 @@ namespace ecpps
                return *std::construct_at(reinterpret_cast<TElement*>(_buffer.sbo) + index, std::move(value));
           }
 
-          constexpr std::size_t Size(void) const noexcept { return this->_size; }
-          constexpr bool UseSBO(void) const noexcept { return this->_size <= SBOSize; }
+          constexpr std::size_t Size(void) const noexcept
+          {
+               return this->_size;
+          }
+          constexpr bool UseSBO(void) const noexcept
+          {
+               return this->_size <= SBOSize;
+          }
 
      private:
           BufferUnion _buffer;

--- a/compiler/utilitieslib/include/utilitieslib/SBOVector.h
+++ b/compiler/utilitieslib/include/utilitieslib/SBOVector.h
@@ -90,7 +90,7 @@ namespace ecpps
           /// In elements, not bytes
           /// </summary>
           static constexpr std::size_t SBOSize =
-              std::max<std::size_t>(1, Align(TNSBOSize / sizeof(TElement), sizeof(TElement)));
+               std::max<std::size_t>(1, Align(TNSBOSize / sizeof(TElement), sizeof(TElement)));
 
           union BufferUnion
           {
@@ -116,10 +116,10 @@ namespace ecpps
                const bool sbo = UseSBO();
                if (sbo)
                {
-                    auto* destination =
-                        std::launder(reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                             // modernize-avoid-c-arrays)
-                            this->_buffer.sbo));
+                    auto* destination = std::launder(
+                         reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                 // modernize-avoid-c-arrays)
+                              this->_buffer.sbo));
                     UFillN(value, destination, count);
                }
                else
@@ -185,9 +185,9 @@ namespace ecpps
           {
                if (UseSBO())
                     return std::launder(
-                        reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                // modernize-avoid-c-arrays)
-                            this->_buffer.sbo)); // NOLINT(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
+                         reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                 // modernize-avoid-c-arrays)
+                              this->_buffer.sbo)); // NOLINT(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
                return this->_buffer.noSbo.begin;
           }
 
@@ -195,31 +195,32 @@ namespace ecpps
           {
                if (UseSBO())
                     return std::launder(
-                        reinterpret_cast<const TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                      // modernize-avoid-c-arrays)
-                            this->_buffer.sbo)); // NOLINT(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
+                         reinterpret_cast<const TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                       // modernize-avoid-c-arrays)
+                              this->_buffer.sbo)); // NOLINT(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
                return this->_buffer.noSbo.begin;
           }
 
           TElement* end(void) // NOLINT(readability-identifier-naming)
           {
-               return UseSBO() ? std::launder(
-                                     this->_size +
-                                     reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                             // modernize-avoid-c-arrays)
-                                         this->_buffer.sbo))
-                               : (this->begin() + this->_size);
+               return UseSBO()
+                           ? std::launder(
+                                  this->_size +
+                                  reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                          // modernize-avoid-c-arrays)
+                                       this->_buffer.sbo))
+                           : (this->begin() + this->_size);
           }
 
           const TElement* end(void) const // NOLINT(readability-identifier-naming)
           {
                return UseSBO()
-                          ? std::launder(this->_size +
-                                         reinterpret_cast<
-                                             const TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                          // modernize-avoid-c-arrays)
-                                             this->_buffer.sbo))
-                          : (this->begin() + this->_size);
+                           ? std::launder(this->_size +
+                                          reinterpret_cast<
+                                               const TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                            // modernize-avoid-c-arrays)
+                                               this->_buffer.sbo))
+                           : (this->begin() + this->_size);
           }
           template <typename... TArgs> TElement& EmplaceBack(TArgs&&... args)
           {
@@ -236,7 +237,7 @@ namespace ecpps
                          for (std::size_t i = 0; i < SBOSize; i++)
                          {
                               new (newBuffer + i)
-                                  TElement(std::move(reinterpret_cast<TElement*>(this->_buffer.sbo)[i]));
+                                   TElement(std::move(reinterpret_cast<TElement*>(this->_buffer.sbo)[i]));
                               reinterpret_cast<TElement*>(this->_buffer.sbo)[i].~TElement();
                          }
                          _buffer.noSbo.begin = newBuffer;
@@ -300,11 +301,11 @@ namespace ecpps
                     return *std::construct_at(_buffer.noSbo.begin + index, value);
                }
                return *std::construct_at(
-                   std::launder(reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                        // modernize-avoid-c-arrays)
-                       this->_buffer.sbo)) +
-                       index,
-                   value);
+                    std::launder(reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                         // modernize-avoid-c-arrays)
+                         this->_buffer.sbo)) +
+                         index,
+                    value);
           }
 
           TElement& Push(TElement&& value)
@@ -319,9 +320,9 @@ namespace ecpps
                          const std::size_t cap = SBOSize * 2;
                          TElement* newBuf = allocator.allocate(cap);
                          TElement* sboPtr = std::launder(
-                             reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
-                                                                     // modernize-avoid-c-arrays)
-                                 _buffer.sbo));
+                              reinterpret_cast<TElement(&)[SBOSize]>( // NOLINT(cppcoreguidelines-avoid-c-arrays,
+                                                                      // modernize-avoid-c-arrays)
+                                   _buffer.sbo));
 
                          for (std::size_t i = 0; i < index; i++)
                          {

--- a/stdlib/include/__ecpps/sysvars.h
+++ b/stdlib/include/__ecpps/sysvars.h
@@ -46,9 +46,18 @@ _DLLIMPORT(ReadConsoleA)
 _BOOL __ReadConsoleA(_HANDLE __hConsole, char* __lpBuffer, _DWORD __nNumberOfCharsToRead, _DWORD* __lpNumberOfCharsRead,
                      _QWORD q);
 
-_HANDLE __std_stdin_handle() { return __GetStdHandle(0 - 10); }
-_HANDLE __std_stdout_handle() { return __GetStdHandle(0 - 11); }
-_HANDLE __std_stderr_handle() { return __GetStdHandle(0 - 12); }
+_HANDLE __std_stdin_handle()
+{
+     return __GetStdHandle(0 - 10);
+}
+_HANDLE __std_stdout_handle()
+{
+     return __GetStdHandle(0 - 11);
+}
+_HANDLE __std_stderr_handle()
+{
+     return __GetStdHandle(0 - 12);
+}
 _DWORD __std_console_write(_HANDLE __hConsole, const char* __buffer, _DWORD __length)
 {
      _DWORD __numberOfCharsWritten;
@@ -63,7 +72,10 @@ char __std_console_read(_HANDLE __hConsole)
      return __buffer;
 }
 
-int __std_strlen(const char* __string) { return __lstrlenA(__string); }
+int __std_strlen(const char* __string)
+{
+     return __lstrlenA(__string);
+}
 
 int __std_cwrite(const char* __buffer)
 {
@@ -75,7 +87,10 @@ int __std_cwrite(const char* __buffer)
 // stub
 int main();
 #ifdef __ecpps_version
-extern "C" void _EntryPoint() { __ExitProcess(main()); }
+extern "C" void _EntryPoint()
+{
+     __ExitProcess(main());
+}
 #endif
 
 // NOLINTEND

--- a/testing/compiler/fixtures/BumpAllocatorFixture.h
+++ b/testing/compiler/fixtures/BumpAllocatorFixture.h
@@ -38,14 +38,32 @@ namespace TestHelpers
           BumpAllocatorFixture(BumpAllocatorFixture&&) = default;
           BumpAllocatorFixture& operator=(BumpAllocatorFixture&&) = default;
 
-          ecpps::BumpAllocator& get() { return *allocator_; }
-          const ecpps::BumpAllocator& get() const { return *allocator_; }
+          ecpps::BumpAllocator& get()
+          {
+               return *allocator_;
+          }
+          const ecpps::BumpAllocator& get() const
+          {
+               return *allocator_;
+          }
 
-          ecpps::BumpAllocator& operator*() { return *allocator_; }
-          const ecpps::BumpAllocator& operator*() const { return *allocator_; }
+          ecpps::BumpAllocator& operator*()
+          {
+               return *allocator_;
+          }
+          const ecpps::BumpAllocator& operator*() const
+          {
+               return *allocator_;
+          }
 
-          ecpps::BumpAllocator* operator->() { return allocator_.get(); }
-          const ecpps::BumpAllocator* operator->() const { return allocator_.get(); }
+          ecpps::BumpAllocator* operator->()
+          {
+               return allocator_.get();
+          }
+          const ecpps::BumpAllocator* operator->() const
+          {
+               return allocator_.get();
+          }
      };
 
 } // namespace TestHelpers

--- a/testing/compiler/fixtures/TestHelpers.h
+++ b/testing/compiler/fixtures/TestHelpers.h
@@ -61,8 +61,8 @@ namespace TestHelpers
      inline std::filesystem::path CreateTempSourceFile(std::string_view content, std::string_view extension = ".cpp")
      {
           auto tempPath =
-              std::filesystem::temp_directory_path() /
-              ("ecpps_test_" + std::to_string(std::hash<std::string_view>{}(content)) + std::string{extension});
+               std::filesystem::temp_directory_path() /
+               ("ecpps_test_" + std::to_string(std::hash<std::string_view>{}(content)) + std::string{extension});
 
           std::ofstream file(tempPath);
           file << content;

--- a/testing/compiler/fixtures/TestHelpers.h
+++ b/testing/compiler/fixtures/TestHelpers.h
@@ -16,15 +16,24 @@ namespace TestHelpers
 {
 
      /// Create a diagnostics instance for testing
-     inline auto MakeDiagnostics() { return ecpps::Diagnostics{}; }
+     inline auto MakeDiagnostics()
+     {
+          return ecpps::Diagnostics{};
+     }
 
      /// Create a BumpAllocator with specified initial size
-     inline auto MakeAllocator(std::size_t initialSize = 1024 * 64) { return ecpps::BumpAllocator{initialSize}; }
+     inline auto MakeAllocator(std::size_t initialSize = 1024 * 64)
+     {
+          return ecpps::BumpAllocator{initialSize};
+     }
 
      /// Compare two byte sequences and return true if equal
      inline bool CompareBytes(std::span<const std::byte> left, std::span<const std::byte> right)
      {
-          if (left.size() != right.size()) { return false; }
+          if (left.size() != right.size())
+          {
+               return false;
+          }
 
           return std::equal(left.begin(), left.end(), right.begin());
      }
@@ -79,8 +88,14 @@ namespace TestHelpers
                std::filesystem::remove(path_, ec);
           }
 
-          const std::filesystem::path& path() const { return path_; }
-          operator std::filesystem::path() const { return path_; }
+          const std::filesystem::path& path() const
+          {
+               return path_;
+          }
+          operator std::filesystem::path() const
+          {
+               return path_;
+          }
      };
 
      /// Compare two AST nodes recursively (basic implementation)
@@ -104,14 +119,20 @@ namespace TestHelpers
      }
 
      /// User-defined literal for byte arrays: 0x48_b, 0x89_b, etc.
-     inline constexpr std::byte operator""_b(unsigned long long value) { return static_cast<std::byte>(value); }
+     inline constexpr std::byte operator""_b(unsigned long long value)
+     {
+          return static_cast<std::byte>(value);
+     }
 
      /// Helper to create a vector of bytes from initializer list
      inline std::vector<std::byte> MakeBytes(std::initializer_list<unsigned char> bytes)
      {
           std::vector<std::byte> result;
           result.reserve(bytes.size());
-          for (auto b : bytes) { result.push_back(static_cast<std::byte>(b)); }
+          for (auto b : bytes)
+          {
+               result.push_back(static_cast<std::byte>(b));
+          }
           return result;
      }
 

--- a/testing/compiler/sources/playground.cpp
+++ b/testing/compiler/sources/playground.cpp
@@ -1,2 +1,5 @@
 #include <cstdio>
-int main() { return 0; }
+int main()
+{
+     return 0;
+}

--- a/testing/compiler/tests/integration/test_ast.cpp
+++ b/testing/compiler/tests/integration/test_ast.cpp
@@ -1,1 +1,4 @@
-int main() { return 0; }
+int main()
+{
+     return 0;
+}

--- a/testing/compiler/tests/regression/test_pointer_arithmetic.cpp
+++ b/testing/compiler/tests/regression/test_pointer_arithmetic.cpp
@@ -20,31 +20,31 @@ TEST_CASE("Pointer arithmetic - Basic operations", "[regression][pointer-arithme
      SECTION("Pointer + integer")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Pointer + integer addition should compile");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Pointer + integer addition should compile");
+               }());
      }
 
      SECTION("Pointer - integer")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Pointer - integer subtraction should compile");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Pointer - integer subtraction should compile");
+               }());
      }
 
      SECTION("Pointer - pointer yields ptrdiff_t")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Pointer - pointer should yield ptrdiff_t");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Pointer - pointer should yield ptrdiff_t");
+               }());
      }
 }
 
@@ -55,11 +55,11 @@ TEST_CASE("Pointer arithmetic - Array subscript equivalence", "[regression][poin
      SECTION("arr[i] should be equivalent to *(arr + i)")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Array subscript should be equivalent to pointer arithmetic");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Array subscript should be equivalent to pointer arithmetic");
+               }());
      }
 }
 
@@ -70,21 +70,21 @@ TEST_CASE("Pointer arithmetic - Comparison operators", "[regression][pointer-ari
      SECTION("Pointer less than comparison")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Pointer < comparison should compile");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Pointer < comparison should compile");
+               }());
      }
 
      SECTION("Pointer equality comparison")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Pointer == comparison should compile");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Pointer == comparison should compile");
+               }());
      }
 }
 
@@ -95,31 +95,31 @@ TEST_CASE("Pointer arithmetic - Type-specific scaling", "[regression][pointer-ar
      SECTION("char* increments by 1 byte")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("char* should scale by 1 byte");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("char* should scale by 1 byte");
+               }());
      }
 
      SECTION("int* increments by 4 bytes (on typical platforms)")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("int* should scale by sizeof(int) bytes");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("int* should scale by sizeof(int) bytes");
+               }());
      }
 
      SECTION("long long* increments by 8 bytes")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("long long* should scale by sizeof(long long) bytes");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("long long* should scale by sizeof(long long) bytes");
+               }());
      }
 }
 
@@ -130,41 +130,41 @@ TEST_CASE("Pointer arithmetic - Pre/post increment and decrement", "[regression]
      SECTION("Post-increment p++")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Post-increment should compile and return original value");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Post-increment should compile and return original value");
+               }());
      }
 
      SECTION("Pre-increment ++p")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Pre-increment should compile and return incremented value");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Pre-increment should compile and return incremented value");
+               }());
      }
 
      SECTION("Post-decrement p--")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Post-decrement should compile");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Post-decrement should compile");
+               }());
      }
 
      SECTION("Pre-decrement --p")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Pre-decrement should compile");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Pre-decrement should compile");
+               }());
      }
 }
 
@@ -175,31 +175,31 @@ TEST_CASE("Pointer arithmetic - Edge cases", "[regression][pointer-arithmetic]")
      SECTION("nullptr arithmetic (defined behavior in expressions)")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("nullptr + 0 should be valid");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("nullptr + 0 should be valid");
+               }());
      }
 
      SECTION("Zero offset")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Adding zero offset should be identity operation");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Adding zero offset should be identity operation");
+               }());
      }
 
      SECTION("Large offset")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Large offsets should compile (runtime validity is separate)");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Large offsets should compile (runtime validity is separate)");
+               }());
      }
 }
 
@@ -210,20 +210,20 @@ TEST_CASE("Pointer arithmetic - Compound assignment", "[regression][pointer-arit
      SECTION("Compound addition +=")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Compound addition += should compile");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Compound addition += should compile");
+               }());
      }
 
      SECTION("Compound subtraction -=")
      {
           REQUIRE_NOTHROW(
-              [&]()
-              {
-                   auto alloc = MakeAllocator();
-                   INFO("Compound subtraction -= should compile");
-              }());
+               [&]()
+               {
+                    auto alloc = MakeAllocator();
+                    INFO("Compound subtraction -= should compile");
+               }());
      }
 }

--- a/testing/compiler/tests/unit/parsing/test_pp_tokens.cpp
+++ b/testing/compiler/tests/unit/parsing/test_pp_tokens.cpp
@@ -17,8 +17,12 @@ TEST_CASE("Preprocessor - Identifiers", "[parsing][identifiers]")
      SECTION("Simple identifiers")
      {
           auto tokens = preprocessor.Parse("int main() {}", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
 
           REQUIRE((identifierCount == 2));
           REQUIRE(tokens[0].value == "int");
@@ -48,8 +52,12 @@ TEST_CASE("Preprocessor - Identifiers", "[parsing][identifiers]")
      SECTION("Identifiers with underscores and digits")
      {
           auto tokens = preprocessor.Parse("variable _private count123 __internal", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
 
           REQUIRE((identifierCount == 4));
           REQUIRE(tokens[0].value == "variable");
@@ -68,40 +76,55 @@ TEST_CASE("Preprocessor - operator-or-punctuators", "[parsing][operators-or-punc
      {
           auto tokens = preprocessor.Parse("+ - * / %", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                    });
           REQUIRE((operatorCount == 5));
      }
      SECTION("Bitwise operators")
      {
           auto tokens = preprocessor.Parse("<< >> & | ^", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                    });
           REQUIRE((operatorCount == 5));
      }
      SECTION("Comparison operators")
      {
           auto tokens = preprocessor.Parse("== != < > <= >=", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                    });
           REQUIRE((operatorCount == 6));
      }
      SECTION("Assignment operators")
      {
           auto tokens = preprocessor.Parse("= += -= *= /= %=", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                    });
           REQUIRE((operatorCount == 6));
      }
      SECTION("Increment and decrement")
      {
           auto tokens = preprocessor.Parse("++ --", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                    });
           REQUIRE((operatorCount == 2));
      }
 
@@ -109,8 +132,11 @@ TEST_CASE("Preprocessor - operator-or-punctuators", "[parsing][operators-or-punc
      {
           auto tokens = preprocessor.Parse("& && | ||", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                    });
           REQUIRE((operatorCount == 4));
           REQUIRE(tokens[0].value == "&");
           REQUIRE(tokens[1].value == "&&");
@@ -130,8 +156,12 @@ TEST_CASE("Preprocessor - Literals", "[parsing][literals]")
           auto tokens = preprocessor.Parse(
               "0 42 123 9999 0x00 0xFF 0xDEADBEEF 0b0 0b1 0b1010 0b11111111 0 07 077 0777 1'000 1'000'000", macros,
               "tests.cpp");
-          SignedSize literalCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Number; });
+          SignedSize literalCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Number;
+                                    });
           REQUIRE(literalCount == 17);
           REQUIRE(tokens[0].value == "0");
           REQUIRE(tokens[1].value == "42");
@@ -154,8 +184,12 @@ TEST_CASE("Preprocessor - Literals", "[parsing][literals]")
      SECTION("Floating point literals")
      {
           auto tokens = preprocessor.Parse("3.14 2.718 0.5 1e10 3.14f 2.718F 1.0l 2.0L", macros, "tests.cpp");
-          SignedSize literalCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Number; });
+          SignedSize literalCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Number;
+                                    });
           REQUIRE(literalCount == 8);
           REQUIRE(tokens[0].value == "3.14");
           REQUIRE(tokens[1].value == "2.718");
@@ -169,8 +203,12 @@ TEST_CASE("Preprocessor - Literals", "[parsing][literals]")
      SECTION("Character literals")
      {
           auto tokens = preprocessor.Parse("'a' '\\n' '\\''", macros, "tests.cpp");
-          SignedSize literalCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::CharacterLiteral; });
+          SignedSize literalCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::CharacterLiteral;
+                                    });
           REQUIRE(literalCount == 3);
           REQUIRE(tokens[0].value == "a");
           REQUIRE(tokens[1].value == "\n");
@@ -181,8 +219,12 @@ TEST_CASE("Preprocessor - Literals", "[parsing][literals]")
      {
           auto tokens =
               preprocessor.Parse(R"("Hello, World!" "Line 1\nLine 2" "She said, \"Hello!\"")", macros, "tests.cpp");
-          SignedSize literalCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::StringLiteral; });
+          SignedSize literalCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::StringLiteral;
+                                    });
           REQUIRE(literalCount == 3);
           REQUIRE(tokens[0].value == "Hello, World!");
           REQUIRE(tokens[1].value == "Line 1\nLine 2");
@@ -198,10 +240,18 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
      {
           macros.emplace_back("PI", std::nullopt, "3.14", false);
           auto tokens = preprocessor.Parse("double pi = PI;", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
-          SignedSize numberCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Number; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
+          SignedSize numberCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Number;
+                                    });
           REQUIRE(identifierCount == 2);
           REQUIRE(numberCount == 1);
           REQUIRE(tokens[0].value == "double");
@@ -215,10 +265,18 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
      {
           macros.emplace_back("SQUARE", std::vector<std::string>{"x"}, "((x) * (x))", false);
           auto tokens = preprocessor.Parse("int result = SQUARE(5);", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
-          SignedSize numberCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Number; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
+          SignedSize numberCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Number;
+                                    });
           REQUIRE(identifierCount == 2);
           REQUIRE(numberCount == 2);
           REQUIRE(tokens.size() == 13);
@@ -242,10 +300,18 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
           macros.emplace_back("PI", std::nullopt, "3.14", false);
           macros.emplace_back("CIRCLE_AREA", std::vector<std::string>{"r"}, "(PI * (r) * (r))", false);
           auto tokens = preprocessor.Parse("double area = CIRCLE_AREA(5);", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
-          SignedSize numberCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Number; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
+          SignedSize numberCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Number;
+                                    });
           REQUIRE(identifierCount == 2);
           REQUIRE(numberCount == 3);
           REQUIRE(tokens.size() == 15);
@@ -270,8 +336,12 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
      {
           macros.emplace_back("CONCAT", std::vector<std::string>{"a", "b"}, "a##b", false);
           auto tokens = preprocessor.Parse("int xy = CONCAT(x, y);", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(identifierCount == 3);
           REQUIRE(tokens.size() == 5);
           REQUIRE(tokens[0].value == "int");
@@ -285,10 +355,18 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
      {
           macros.emplace_back("STRINGIFY", std::vector<std::string>{"x"}, "#x", false);
           auto tokens = preprocessor.Parse("const char* str = STRINGIFY(Hello kitten!);", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
-          SignedSize stringLiteralCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::StringLiteral; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
+          SignedSize stringLiteralCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::StringLiteral;
+                                    });
           REQUIRE(identifierCount == 3);
           REQUIRE(stringLiteralCount == 1);
           REQUIRE(tokens.size() == 7);
@@ -305,10 +383,18 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
      {
           macros.emplace_back("LOG", std::vector<std::string>{}, "printf(__VA_ARGS__)", true);
           auto tokens = preprocessor.Parse("LOG(\"Error: %d\", errorCode);", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
-          SignedSize stringLiteralCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::StringLiteral; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
+          SignedSize stringLiteralCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::StringLiteral;
+                                    });
           REQUIRE(identifierCount == 2);
           REQUIRE(stringLiteralCount == 1);
           REQUIRE(tokens.size() == 7);
@@ -358,8 +444,12 @@ TEST_CASE("Preprocessor - Comments", "[parsing][comments]")
      SECTION("Single-line comments")
      {
           auto tokens = preprocessor.Parse("int x = 42; // This is a comment\nint y = 24;", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(identifierCount == 4);
           REQUIRE(tokens[0].value == "int");
           REQUIRE(tokens[1].value == "x");
@@ -375,8 +465,12 @@ TEST_CASE("Preprocessor - Comments", "[parsing][comments]")
      SECTION("Multi-line comments")
      {
           auto tokens = preprocessor.Parse("/* This is a\nmulti-line comment */\nint z = 100;", macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
           REQUIRE(tokens[1].value == "z");
@@ -406,8 +500,12 @@ int c;
 #endif
 )",
               macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(tokens.size() == 6);
           REQUIRE(identifierCount == 4);
           REQUIRE(tokens[0].value == "int");
@@ -433,8 +531,12 @@ int d;
 #endif
 )",
               macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -457,8 +559,12 @@ int d;
 #endif
 )",
               macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -481,8 +587,12 @@ int d;
 #endif
 )",
               macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -505,8 +615,12 @@ int d;
 #endif
 )",
               macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -528,8 +642,12 @@ int b;
 #endif
 )",
               macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -551,8 +669,12 @@ int c;
 #endif
 )",
               macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -574,8 +696,12 @@ int c;
 #endif
 )",
               macros, "tests.cpp");
-          SignedSize identifierCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::PreprocessingTokenType::Identifier; });
+          SignedSize identifierCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                    });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");

--- a/testing/compiler/tests/unit/parsing/test_pp_tokens.cpp
+++ b/testing/compiler/tests/unit/parsing/test_pp_tokens.cpp
@@ -18,11 +18,11 @@ TEST_CASE("Preprocessor - Identifiers", "[parsing][identifiers]")
      {
           auto tokens = preprocessor.Parse("int main() {}", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
 
           REQUIRE((identifierCount == 2));
           REQUIRE(tokens[0].value == "int");
@@ -53,11 +53,11 @@ TEST_CASE("Preprocessor - Identifiers", "[parsing][identifiers]")
      {
           auto tokens = preprocessor.Parse("variable _private count123 __internal", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
 
           REQUIRE((identifierCount == 4));
           REQUIRE(tokens[0].value == "variable");
@@ -76,55 +76,55 @@ TEST_CASE("Preprocessor - operator-or-punctuators", "[parsing][operators-or-punc
      {
           auto tokens = preprocessor.Parse("+ - * / %", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                     });
           REQUIRE((operatorCount == 5));
      }
      SECTION("Bitwise operators")
      {
           auto tokens = preprocessor.Parse("<< >> & | ^", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                     });
           REQUIRE((operatorCount == 5));
      }
      SECTION("Comparison operators")
      {
           auto tokens = preprocessor.Parse("== != < > <= >=", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                     });
           REQUIRE((operatorCount == 6));
      }
      SECTION("Assignment operators")
      {
           auto tokens = preprocessor.Parse("= += -= *= /= %=", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                     });
           REQUIRE((operatorCount == 6));
      }
      SECTION("Increment and decrement")
      {
           auto tokens = preprocessor.Parse("++ --", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                     });
           REQUIRE((operatorCount == 2));
      }
 
@@ -132,11 +132,11 @@ TEST_CASE("Preprocessor - operator-or-punctuators", "[parsing][operators-or-punc
      {
           auto tokens = preprocessor.Parse("& && | ||", macros, "tests.cpp");
           SignedSize operatorCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::OperatorOrPunctuator;
+                                     });
           REQUIRE((operatorCount == 4));
           REQUIRE(tokens[0].value == "&");
           REQUIRE(tokens[1].value == "&&");
@@ -154,14 +154,14 @@ TEST_CASE("Preprocessor - Literals", "[parsing][literals]")
      SECTION("Integer literals")
      {
           auto tokens = preprocessor.Parse(
-              "0 42 123 9999 0x00 0xFF 0xDEADBEEF 0b0 0b1 0b1010 0b11111111 0 07 077 0777 1'000 1'000'000", macros,
-              "tests.cpp");
+               "0 42 123 9999 0x00 0xFF 0xDEADBEEF 0b0 0b1 0b1010 0b11111111 0 07 077 0777 1'000 1'000'000", macros,
+               "tests.cpp");
           SignedSize literalCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Number;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Number;
+                                     });
           REQUIRE(literalCount == 17);
           REQUIRE(tokens[0].value == "0");
           REQUIRE(tokens[1].value == "42");
@@ -185,11 +185,11 @@ TEST_CASE("Preprocessor - Literals", "[parsing][literals]")
      {
           auto tokens = preprocessor.Parse("3.14 2.718 0.5 1e10 3.14f 2.718F 1.0l 2.0L", macros, "tests.cpp");
           SignedSize literalCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Number;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Number;
+                                     });
           REQUIRE(literalCount == 8);
           REQUIRE(tokens[0].value == "3.14");
           REQUIRE(tokens[1].value == "2.718");
@@ -204,11 +204,11 @@ TEST_CASE("Preprocessor - Literals", "[parsing][literals]")
      {
           auto tokens = preprocessor.Parse("'a' '\\n' '\\''", macros, "tests.cpp");
           SignedSize literalCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::CharacterLiteral;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::CharacterLiteral;
+                                     });
           REQUIRE(literalCount == 3);
           REQUIRE(tokens[0].value == "a");
           REQUIRE(tokens[1].value == "\n");
@@ -218,13 +218,13 @@ TEST_CASE("Preprocessor - Literals", "[parsing][literals]")
      SECTION("String literals")
      {
           auto tokens =
-              preprocessor.Parse(R"("Hello, World!" "Line 1\nLine 2" "She said, \"Hello!\"")", macros, "tests.cpp");
+               preprocessor.Parse(R"("Hello, World!" "Line 1\nLine 2" "She said, \"Hello!\"")", macros, "tests.cpp");
           SignedSize literalCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::StringLiteral;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::StringLiteral;
+                                     });
           REQUIRE(literalCount == 3);
           REQUIRE(tokens[0].value == "Hello, World!");
           REQUIRE(tokens[1].value == "Line 1\nLine 2");
@@ -241,17 +241,17 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
           macros.emplace_back("PI", std::nullopt, "3.14", false);
           auto tokens = preprocessor.Parse("double pi = PI;", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           SignedSize numberCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Number;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Number;
+                                     });
           REQUIRE(identifierCount == 2);
           REQUIRE(numberCount == 1);
           REQUIRE(tokens[0].value == "double");
@@ -266,17 +266,17 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
           macros.emplace_back("SQUARE", std::vector<std::string>{"x"}, "((x) * (x))", false);
           auto tokens = preprocessor.Parse("int result = SQUARE(5);", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           SignedSize numberCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Number;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Number;
+                                     });
           REQUIRE(identifierCount == 2);
           REQUIRE(numberCount == 2);
           REQUIRE(tokens.size() == 13);
@@ -301,17 +301,17 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
           macros.emplace_back("CIRCLE_AREA", std::vector<std::string>{"r"}, "(PI * (r) * (r))", false);
           auto tokens = preprocessor.Parse("double area = CIRCLE_AREA(5);", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           SignedSize numberCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Number;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Number;
+                                     });
           REQUIRE(identifierCount == 2);
           REQUIRE(numberCount == 3);
           REQUIRE(tokens.size() == 15);
@@ -337,11 +337,11 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
           macros.emplace_back("CONCAT", std::vector<std::string>{"a", "b"}, "a##b", false);
           auto tokens = preprocessor.Parse("int xy = CONCAT(x, y);", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(identifierCount == 3);
           REQUIRE(tokens.size() == 5);
           REQUIRE(tokens[0].value == "int");
@@ -356,17 +356,17 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
           macros.emplace_back("STRINGIFY", std::vector<std::string>{"x"}, "#x", false);
           auto tokens = preprocessor.Parse("const char* str = STRINGIFY(Hello kitten!);", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           SignedSize stringLiteralCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::StringLiteral;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::StringLiteral;
+                                     });
           REQUIRE(identifierCount == 3);
           REQUIRE(stringLiteralCount == 1);
           REQUIRE(tokens.size() == 7);
@@ -384,17 +384,17 @@ TEST_CASE("Preprocessor - Macros", "[parsing][macros]")
           macros.emplace_back("LOG", std::vector<std::string>{}, "printf(__VA_ARGS__)", true);
           auto tokens = preprocessor.Parse("LOG(\"Error: %d\", errorCode);", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           SignedSize stringLiteralCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::StringLiteral;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::StringLiteral;
+                                     });
           REQUIRE(identifierCount == 2);
           REQUIRE(stringLiteralCount == 1);
           REQUIRE(tokens.size() == 7);
@@ -445,11 +445,11 @@ TEST_CASE("Preprocessor - Comments", "[parsing][comments]")
      {
           auto tokens = preprocessor.Parse("int x = 42; // This is a comment\nint y = 24;", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(identifierCount == 4);
           REQUIRE(tokens[0].value == "int");
           REQUIRE(tokens[1].value == "x");
@@ -466,11 +466,11 @@ TEST_CASE("Preprocessor - Comments", "[parsing][comments]")
      {
           auto tokens = preprocessor.Parse("/* This is a\nmulti-line comment */\nint z = 100;", macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
           REQUIRE(tokens[1].value == "z");
@@ -489,7 +489,7 @@ TEST_CASE("Preprocessor - preprocessing directives", "[parsing][directives]")
      SECTION("ifdef and ifndef")
      {
           auto tokens = preprocessor.Parse(
-              R"(
+               R"(
 #ifdef DEFINED_MACRO
 int a;
 #else
@@ -499,13 +499,13 @@ int b;
 int c;
 #endif
 )",
-              macros, "tests.cpp");
+               macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(tokens.size() == 6);
           REQUIRE(identifierCount == 4);
           REQUIRE(tokens[0].value == "int");
@@ -519,7 +519,7 @@ int c;
      SECTION("elifdef, elifndef, else - happy")
      {
           auto tokens = preprocessor.Parse(
-              R"(
+               R"(
 #ifdef DEFINED_MACRO
 int a;
 #elifdef DEFINED_MACRO
@@ -530,13 +530,13 @@ int c;
 int d;
 #endif
 )",
-              macros, "tests.cpp");
+               macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -547,7 +547,7 @@ int d;
      SECTION("elifdef, elifndef, else - unhappy 1")
      {
           auto tokens = preprocessor.Parse(
-              R"(
+               R"(
 #ifdef UNDEFINED_MACRO
 int a;
 #elifdef DEFINED_MACRO
@@ -558,13 +558,13 @@ int c;
 int d;
 #endif
 )",
-              macros, "tests.cpp");
+               macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -575,7 +575,7 @@ int d;
      SECTION("elifdef, elifndef, else - unhappy 2")
      {
           auto tokens = preprocessor.Parse(
-              R"(
+               R"(
 #ifdef UNDEFINED_MACRO
 int a;
 #elifdef UNDEFINED_MACRO
@@ -586,13 +586,13 @@ int c;
 int d;
 #endif
 )",
-              macros, "tests.cpp");
+               macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -603,7 +603,7 @@ int d;
      SECTION("elifdef, elifndef, else - unhappy 3")
      {
           auto tokens = preprocessor.Parse(
-              R"(
+               R"(
 #ifdef UNDEFINED_MACRO
 int a;
 #elifdef UNDEFINED_MACRO
@@ -614,13 +614,13 @@ int c;
 int d;
 #endif
 )",
-              macros, "tests.cpp");
+               macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -631,7 +631,7 @@ int d;
      SECTION("else - additional directives")
      {
           auto tokens = preprocessor.Parse(
-              R"(
+               R"(
 #ifdef UNDEFINED_MACRO
 int a;
 #
@@ -641,13 +641,13 @@ int b;
 #
 #endif
 )",
-              macros, "tests.cpp");
+               macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -658,7 +658,7 @@ int b;
      SECTION("if/elif/else - definitions")
      {
           auto tokens = preprocessor.Parse(
-              R"(
+               R"(
 #ifdef UNDEFINED_MACRO
 int a;
 #define UNDEFINED_MACRO 2
@@ -668,13 +668,13 @@ int b;
 int c;
 #endif
 )",
-              macros, "tests.cpp");
+               macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");
@@ -685,7 +685,7 @@ int c;
      SECTION("if/elif/else - definitions")
      {
           auto tokens = preprocessor.Parse(
-              R"(
+               R"(
 #ifdef UNDEFINED_MACRO
 int a;
 #define UNDEFINED_MACRO 2
@@ -695,13 +695,13 @@ int b;
 int c;
 #endif
 )",
-              macros, "tests.cpp");
+               macros, "tests.cpp");
           SignedSize identifierCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::PreprocessingTokenType::Identifier;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::PreprocessingTokenType::Identifier;
+                                     });
           REQUIRE(tokens.size() == 3);
           REQUIRE(identifierCount == 2);
           REQUIRE(tokens[0].value == "int");

--- a/testing/compiler/tests/unit/parsing/test_tokenise.cpp
+++ b/testing/compiler/tests/unit/parsing/test_tokenise.cpp
@@ -64,7 +64,10 @@ TEST_CASE("Tokeniser - Identifiers", "[parsing][tokeniser]")
           int identifier_count = 0;
           for (const auto& token : tokens)
           {
-               if (token.type == TokenType::Identifier) { identifier_count++; }
+               if (token.type == TokenType::Identifier)
+               {
+                    identifier_count++;
+               }
           }
 
           REQUIRE((identifier_count >= 4));
@@ -125,7 +128,10 @@ TEST_CASE("Tokeniser - Integer literals", "[parsing][tokeniser]")
           int literal_count = 0;
           for (const auto& token : tokens)
           {
-               if (token.type == TokenType::Literal) { literal_count++; }
+               if (token.type == TokenType::Literal)
+               {
+                    literal_count++;
+               }
           }
 
           REQUIRE((literal_count >= 4));

--- a/testing/compiler/tests/unit/parsing/test_tokens.cpp
+++ b/testing/compiler/tests/unit/parsing/test_tokens.cpp
@@ -27,8 +27,11 @@ TEST_CASE("Tokeniser - Identifiers", "[parsing][tokeniser]")
               ConstructIdentifier("variable"), ConstructIdentifier("_private"), ConstructIdentifier("count123"),
               ConstructIdentifier("__internal")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-          SignedSize identifierCount = std::ranges::count_if(tokens, [](const auto& token)
-                                                             { return token.type == ecpps::TokenType::Identifier; });
+          SignedSize identifierCount = std::ranges::count_if(tokens,
+                                                             [](const auto& token)
+                                                             {
+                                                                  return token.type == ecpps::TokenType::Identifier;
+                                                             });
           REQUIRE(ppTokens.size() == 4);
           REQUIRE(static_cast<std::size_t>(identifierCount) == ppTokens.size());
           REQUIRE(tokens[0].AsIdentifier() == "variable");
@@ -43,8 +46,11 @@ TEST_CASE("Tokeniser - Identifiers", "[parsing][tokeniser]")
               ConstructIdentifier("variable123"), ConstructIdentifier("count"), ConstructOperator("+"),
               ConstructIdentifier("_private"),    ConstructOperator("-"),       ConstructIdentifier("__internal")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-          SignedSize identifierCount = std::ranges::count_if(tokens, [](const auto& token)
-                                                             { return token.type == ecpps::TokenType::Identifier; });
+          SignedSize identifierCount = std::ranges::count_if(tokens,
+                                                             [](const auto& token)
+                                                             {
+                                                                  return token.type == ecpps::TokenType::Identifier;
+                                                             });
           REQUIRE(ppTokens.size() == 6);
           REQUIRE(identifierCount == 4);
           REQUIRE(tokens[0].AsIdentifier() == "variable123");
@@ -61,8 +67,11 @@ TEST_CASE("Tokeniser - Keywords", "[parsing][tokeniser]")
      std::vector<ecpps::PreprocessingToken> ppTokens = {ConstructIdentifier("if"), ConstructIdentifier("else"),
                                                         ConstructIdentifier("while"), ConstructIdentifier("for")};
      auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-     SignedSize keywordCount =
-         std::ranges::count_if(tokens, [](const auto& token) { return token.type == ecpps::TokenType::Keyword; });
+     SignedSize keywordCount = std::ranges::count_if(tokens,
+                                                     [](const auto& token)
+                                                     {
+                                                          return token.type == ecpps::TokenType::Keyword;
+                                                     });
      REQUIRE(ppTokens.size() == 4);
      REQUIRE(static_cast<std::size_t>(keywordCount) == ppTokens.size());
      REQUIRE(tokens[0].AsKeyword() == "if");
@@ -78,8 +87,11 @@ TEST_CASE("Tokeniser - Operators", "[parsing][tokeniser]")
           std::vector<ecpps::PreprocessingToken> ppTokens = {ConstructOperator("+"), ConstructOperator("-"),
                                                              ConstructOperator("*"), ConstructOperator("/")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-          SignedSize operatorCount =
-              std::ranges::count_if(tokens, [](const auto& token) { return token.type == ecpps::TokenType::Operator; });
+          SignedSize operatorCount = std::ranges::count_if(tokens,
+                                                           [](const auto& token)
+                                                           {
+                                                                return token.type == ecpps::TokenType::Operator;
+                                                           });
           REQUIRE(ppTokens.size() == 4);
           REQUIRE(static_cast<std::size_t>(operatorCount) == ppTokens.size());
           REQUIRE(tokens[0].AsOperator() == "+");
@@ -95,8 +107,11 @@ TEST_CASE("Tokeniser - Operators", "[parsing][tokeniser]")
                                                              ConstructOperator("*"), ConstructIdentifier("B"),
                                                              ConstructOperator("/")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-          SignedSize operatorCount =
-              std::ranges::count_if(tokens, [](const auto& token) { return token.type == ecpps::TokenType::Operator; });
+          SignedSize operatorCount = std::ranges::count_if(tokens,
+                                                           [](const auto& token)
+                                                           {
+                                                                return token.type == ecpps::TokenType::Operator;
+                                                           });
           REQUIRE(ppTokens.size() == 5);
           REQUIRE(operatorCount == 3);
           REQUIRE(tokens[0].AsOperator() == "+");
@@ -113,11 +128,17 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
           std::vector<ecpps::PreprocessingToken> ppTokens = {ConstructOperator(";"), ConstructOperator(","),
                                                              ConstructOperator("."), ConstructOperator("->")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-          SignedSize semiColonCount = std::ranges::count_if(tokens, [](const auto& token)
-                                                            { return token.type == ecpps::TokenType::SemiColon; });
+          SignedSize semiColonCount = std::ranges::count_if(tokens,
+                                                            [](const auto& token)
+                                                            {
+                                                                 return token.type == ecpps::TokenType::SemiColon;
+                                                            });
           SignedSize commaCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::TokenType::Operator && token.AsOperator() == ","; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == ",";
+                                    });
           REQUIRE(ppTokens.size() == 4);
           REQUIRE(semiColonCount == 1);
           REQUIRE(commaCount == 1);
@@ -132,11 +153,17 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
                                                              ConstructOperator(","), ConstructIdentifier("B"),
                                                              ConstructOperator(".")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-          SignedSize semiColonCount = std::ranges::count_if(tokens, [](const auto& token)
-                                                            { return token.type == ecpps::TokenType::SemiColon; });
+          SignedSize semiColonCount = std::ranges::count_if(tokens,
+                                                            [](const auto& token)
+                                                            {
+                                                                 return token.type == ecpps::TokenType::SemiColon;
+                                                            });
           SignedSize commaCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::TokenType::Operator && token.AsOperator() == ","; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == ",";
+                                    });
           REQUIRE(ppTokens.size() == 5);
           REQUIRE(semiColonCount == 1);
           REQUIRE(commaCount == 1);
@@ -154,14 +181,23 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
                                                              ConstructOperator("...")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
           SignedSize arrowCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::TokenType::Operator && token.AsOperator() == "->"; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == "->";
+                                    });
           SignedSize scopeResolutionCount =
-              std::ranges::count_if(tokens, [](const auto& token)
-                                    { return token.type == ecpps::TokenType::Operator && token.AsOperator() == "::"; });
-          SignedSize ellipsisCount = std::ranges::count_if(
-              tokens, [](const auto& token)
-              { return token.type == ecpps::TokenType::Operator && token.AsOperator() == "..."; });
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == "::";
+                                    });
+          SignedSize ellipsisCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == "...";
+                                    });
           REQUIRE(ppTokens.size() == 5);
           REQUIRE(arrowCount == 1);
           REQUIRE(scopeResolutionCount == 1);
@@ -179,12 +215,22 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
                                                              ConstructOperator(")"), ConstructIdentifier("B"),
                                                              ConstructOperator("[")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
-          SignedSize leftParenCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::TokenType::LeftParenthesis; });
-          SignedSize rightParenCount = std::ranges::count_if(
-              tokens, [](const auto& token) { return token.type == ecpps::TokenType::RightParenthesis; });
-          SignedSize leftBracketCount = std::ranges::count_if(tokens, [](const auto& token)
-                                                              { return token.type == ecpps::TokenType::LeftBracket; });
+          SignedSize leftParenCount = std::ranges::count_if(tokens,
+                                                            [](const auto& token)
+                                                            {
+                                                                 return token.type == ecpps::TokenType::LeftParenthesis;
+                                                            });
+          SignedSize rightParenCount =
+              std::ranges::count_if(tokens,
+                                    [](const auto& token)
+                                    {
+                                         return token.type == ecpps::TokenType::RightParenthesis;
+                                    });
+          SignedSize leftBracketCount = std::ranges::count_if(tokens,
+                                                              [](const auto& token)
+                                                              {
+                                                                   return token.type == ecpps::TokenType::LeftBracket;
+                                                              });
           REQUIRE(ppTokens.size() == 5);
           REQUIRE(leftParenCount == 1);
           REQUIRE(rightParenCount == 1);
@@ -212,9 +258,12 @@ TEST_CASE("Literals", "[parsing][tokeniser]")
                                     return token.type == ecpps::TokenType::Literal &&
                                            std::holds_alternative<ecpps::IntegerLiteral>(token.value);
                                });
-     SignedSize charLiteralCount = std::ranges::count_if(
-         tokens, [](const auto& token)
-         { return token.type == ecpps::TokenType::Literal && std::holds_alternative<char>(token.value); });
+     SignedSize charLiteralCount = std::ranges::count_if(tokens,
+                                                         [](const auto& token)
+                                                         {
+                                                              return token.type == ecpps::TokenType::Literal &&
+                                                                     std::holds_alternative<char>(token.value);
+                                                         });
      SignedSize stringLiteralCount =
          std::ranges::count_if(tokens,
                                [](const auto& token)

--- a/testing/compiler/tests/unit/parsing/test_tokens.cpp
+++ b/testing/compiler/tests/unit/parsing/test_tokens.cpp
@@ -24,8 +24,8 @@ TEST_CASE("Tokeniser - Identifiers", "[parsing][tokeniser]")
      SECTION("Mapping identifiers")
      {
           std::vector<ecpps::PreprocessingToken> ppTokens = {
-              ConstructIdentifier("variable"), ConstructIdentifier("_private"), ConstructIdentifier("count123"),
-              ConstructIdentifier("__internal")};
+               ConstructIdentifier("variable"), ConstructIdentifier("_private"), ConstructIdentifier("count123"),
+               ConstructIdentifier("__internal")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
           SignedSize identifierCount = std::ranges::count_if(tokens,
                                                              [](const auto& token)
@@ -43,8 +43,8 @@ TEST_CASE("Tokeniser - Identifiers", "[parsing][tokeniser]")
      SECTION("Separating identifiers")
      {
           std::vector<ecpps::PreprocessingToken> ppTokens = {
-              ConstructIdentifier("variable123"), ConstructIdentifier("count"), ConstructOperator("+"),
-              ConstructIdentifier("_private"),    ConstructOperator("-"),       ConstructIdentifier("__internal")};
+               ConstructIdentifier("variable123"), ConstructIdentifier("count"), ConstructOperator("+"),
+               ConstructIdentifier("_private"),    ConstructOperator("-"),       ConstructIdentifier("__internal")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
           SignedSize identifierCount = std::ranges::count_if(tokens,
                                                              [](const auto& token)
@@ -134,11 +134,11 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
                                                                  return token.type == ecpps::TokenType::SemiColon;
                                                             });
           SignedSize commaCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == ",";
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::TokenType::Operator && token.AsOperator() == ",";
+                                     });
           REQUIRE(ppTokens.size() == 4);
           REQUIRE(semiColonCount == 1);
           REQUIRE(commaCount == 1);
@@ -159,11 +159,11 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
                                                                  return token.type == ecpps::TokenType::SemiColon;
                                                             });
           SignedSize commaCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == ",";
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::TokenType::Operator && token.AsOperator() == ",";
+                                     });
           REQUIRE(ppTokens.size() == 5);
           REQUIRE(semiColonCount == 1);
           REQUIRE(commaCount == 1);
@@ -181,23 +181,23 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
                                                              ConstructOperator("...")};
           auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
           SignedSize arrowCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == "->";
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::TokenType::Operator && token.AsOperator() == "->";
+                                     });
           SignedSize scopeResolutionCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == "::";
-                                    });
-          SignedSize ellipsisCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::TokenType::Operator && token.AsOperator() == "...";
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::TokenType::Operator && token.AsOperator() == "::";
+                                     });
+          SignedSize ellipsisCount = std::ranges::count_if(tokens,
+                                                           [](const auto& token)
+                                                           {
+                                                                return token.type == ecpps::TokenType::Operator &&
+                                                                       token.AsOperator() == "...";
+                                                           });
           REQUIRE(ppTokens.size() == 5);
           REQUIRE(arrowCount == 1);
           REQUIRE(scopeResolutionCount == 1);
@@ -221,11 +221,11 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
                                                                  return token.type == ecpps::TokenType::LeftParenthesis;
                                                             });
           SignedSize rightParenCount =
-              std::ranges::count_if(tokens,
-                                    [](const auto& token)
-                                    {
-                                         return token.type == ecpps::TokenType::RightParenthesis;
-                                    });
+               std::ranges::count_if(tokens,
+                                     [](const auto& token)
+                                     {
+                                          return token.type == ecpps::TokenType::RightParenthesis;
+                                     });
           SignedSize leftBracketCount = std::ranges::count_if(tokens,
                                                               [](const auto& token)
                                                               {
@@ -246,18 +246,18 @@ TEST_CASE("Tokeniser - Punctuators", "[parsing][tokeniser]")
 TEST_CASE("Literals", "[parsing][tokeniser]")
 {
      std::vector<ecpps::PreprocessingToken> ppTokens = {
-         ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Number, "42", ecpps::Location{0, 0, 0}},
-         ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::CharacterLiteral, "a", ecpps::Location{0, 0, 0}},
-         ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::StringLiteral, "Hello, World!",
-                                   ecpps::Location{0, 0, 0}}};
+          ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Number, "42", ecpps::Location{0, 0, 0}},
+          ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::CharacterLiteral, "a", ecpps::Location{0, 0, 0}},
+          ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::StringLiteral, "Hello, World!",
+                                    ecpps::Location{0, 0, 0}}};
      auto tokens = ecpps::Tokeniser::Tokenise(ppTokens);
      SignedSize numberCount =
-         std::ranges::count_if(tokens,
-                               [](const auto& token)
-                               {
-                                    return token.type == ecpps::TokenType::Literal &&
-                                           std::holds_alternative<ecpps::IntegerLiteral>(token.value);
-                               });
+          std::ranges::count_if(tokens,
+                                [](const auto& token)
+                                {
+                                     return token.type == ecpps::TokenType::Literal &&
+                                            std::holds_alternative<ecpps::IntegerLiteral>(token.value);
+                                });
      SignedSize charLiteralCount = std::ranges::count_if(tokens,
                                                          [](const auto& token)
                                                          {
@@ -265,12 +265,12 @@ TEST_CASE("Literals", "[parsing][tokeniser]")
                                                                      std::holds_alternative<char>(token.value);
                                                          });
      SignedSize stringLiteralCount =
-         std::ranges::count_if(tokens,
-                               [](const auto& token)
-                               {
-                                    return token.type == ecpps::TokenType::Literal &&
-                                           std::holds_alternative<ecpps::StringLiteral>(token.value);
-                               });
+          std::ranges::count_if(tokens,
+                                [](const auto& token)
+                                {
+                                     return token.type == ecpps::TokenType::Literal &&
+                                            std::holds_alternative<ecpps::StringLiteral>(token.value);
+                                });
      REQUIRE(ppTokens.size() == 3);
      REQUIRE(numberCount == 1);
      REQUIRE(charLiteralCount == 1);

--- a/testing/compiler/tests/unit/test_tokenise.cpp
+++ b/testing/compiler/tests/unit/test_tokenise.cpp
@@ -27,25 +27,26 @@ int main() { return 0; }
 )";
      std::vector<ecpps::MacroReplacement> macros{};
      const auto ppTokens = ecpps::Preprocessor{}.Parse(source, macros, "");
-     if (!AssertTokens(
-             ppTokens,
-             std::vector<ecpps::PreprocessingToken>{
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Identifier, "int", ecpps::Location{0, 0, 0}},
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Identifier, "main", ecpps::Location{0, 0, 0}},
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator, "(",
-                                           ecpps::Location{0, 0, 0}},
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator, ")",
-                                           ecpps::Location{0, 0, 0}},
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator, "{",
-                                           ecpps::Location{0, 0, 0}},
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Identifier, "return",
-                                           ecpps::Location{0, 0, 0}},
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Number, "0", ecpps::Location{0, 0, 0}},
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator, ";",
-                                           ecpps::Location{0, 0, 0}},
-                 ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator, "}",
-                                           ecpps::Location{0, 0, 0}},
-             }))
+     if (!AssertTokens(ppTokens, std::vector<ecpps::PreprocessingToken>{
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Identifier, "int",
+                                                                ecpps::Location{0, 0, 0}},
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Identifier, "main",
+                                                                ecpps::Location{0, 0, 0}},
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator,
+                                                                "(", ecpps::Location{0, 0, 0}},
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator,
+                                                                ")", ecpps::Location{0, 0, 0}},
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator,
+                                                                "{", ecpps::Location{0, 0, 0}},
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Identifier, "return",
+                                                                ecpps::Location{0, 0, 0}},
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::Number, "0",
+                                                                ecpps::Location{0, 0, 0}},
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator,
+                                                                ";", ecpps::Location{0, 0, 0}},
+                                      ecpps::PreprocessingToken{ecpps::PreprocessingTokenType::OperatorOrPunctuator,
+                                                                "}", ecpps::Location{0, 0, 0}},
+                                 }))
           return -1;
 
      return 0;

--- a/testing/compiler/tests/unit/typesystem/test_arithmetic_types.cpp
+++ b/testing/compiler/tests/unit/typesystem/test_arithmetic_types.cpp
@@ -15,10 +15,10 @@ TEST_CASE("ArithmeticTypes - Integral type sizes", "[typesystem][arithmetic_type
      SECTION("Char type - 1 byte")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                               .signedness = Signedness::Signed}};
           const auto* charType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((charType->Size() == 1));
      }
@@ -26,10 +26,10 @@ TEST_CASE("ArithmeticTypes - Integral type sizes", "[typesystem][arithmetic_type
      SECTION("Short type - 2 bytes")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Short,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Short,
+                                                               .signedness = Signedness::Signed}};
           const auto* shortType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((shortType->Size() == 2));
      }
@@ -37,10 +37,10 @@ TEST_CASE("ArithmeticTypes - Integral type sizes", "[typesystem][arithmetic_type
      SECTION("Int type - 4 bytes")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Signed}};
           const auto* intType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((intType->Size() == 4));
      }
@@ -48,10 +48,10 @@ TEST_CASE("ArithmeticTypes - Integral type sizes", "[typesystem][arithmetic_type
      SECTION("Long type - 4 bytes (Windows x64)")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Long,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Long,
+                                                               .signedness = Signedness::Signed}};
           const auto* longType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((longType->Size() == 4));
      }
@@ -59,10 +59,10 @@ TEST_CASE("ArithmeticTypes - Integral type sizes", "[typesystem][arithmetic_type
      SECTION("LongLong type - 8 bytes")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::LongLong,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::LongLong,
+                                                               .signedness = Signedness::Signed}};
           const auto* longlongType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((longlongType->Size() == 8));
      }
@@ -73,10 +73,10 @@ TEST_CASE("ArithmeticTypes - Signedness", "[typesystem][arithmetic_types]")
      SECTION("Signed int")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Signed}};
           const auto* signedInt = ecpps::ir::GetTypeContext().Get(request);
           auto name = signedInt->RawName();
           INFO("Signed int name: " << name);
@@ -86,10 +86,10 @@ TEST_CASE("ArithmeticTypes - Signedness", "[typesystem][arithmetic_types]")
      SECTION("Unsigned int")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Unsigned}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Unsigned}};
           const auto* unsignedInt = ecpps::ir::GetTypeContext().Get(request);
           auto name = unsignedInt->RawName();
           INFO("Unsigned int name: " << name);
@@ -99,15 +99,15 @@ TEST_CASE("ArithmeticTypes - Signedness", "[typesystem][arithmetic_types]")
      SECTION("Signed vs unsigned are different types")
      {
           ecpps::ir::TypeRequest signedRequest{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Signed}};
           ecpps::ir::TypeRequest unsignedRequest{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Unsigned}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Unsigned}};
           const auto* signedInt = ecpps::ir::GetTypeContext().Get(signedRequest);
           const auto* unsignedInt = ecpps::ir::GetTypeContext().Get(unsignedRequest);
 
@@ -120,10 +120,10 @@ TEST_CASE("ArithmeticTypes - Alignment", "[typesystem][arithmetic_types]")
      SECTION("Char alignment")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                               .signedness = Signedness::Signed}};
           const auto* charType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((charType->Alignment() >= 1));
      }
@@ -131,10 +131,10 @@ TEST_CASE("ArithmeticTypes - Alignment", "[typesystem][arithmetic_types]")
      SECTION("Int alignment")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Signed}};
           const auto* intType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((intType->Alignment() >= 4));
      }
@@ -142,10 +142,10 @@ TEST_CASE("ArithmeticTypes - Alignment", "[typesystem][arithmetic_types]")
      SECTION("LongLong alignment")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::LongLong,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::LongLong,
+                                                               .signedness = Signedness::Signed}};
           const auto* longlongType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((longlongType->Alignment() >= 8));
      }
@@ -156,7 +156,7 @@ TEST_CASE("ArithmeticTypes - Type traits", "[typesystem][arithmetic_types]")
      ecpps::ir::TypeRequest request{.kind = ecpps::ir::TypeKind::Fundamental,
                                     .qualifiers = Qualifiers::None,
                                     .data = ecpps::ir::StandardSignedIntegerRequest{
-                                        .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+                                         .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
      const auto* intType = ecpps::ir::GetTypeContext().Get(request);
      auto traits = intType->Traits();
 
@@ -191,11 +191,11 @@ TEST_CASE("ArithmeticTypes - Character types", "[typesystem][arithmetic_types]")
      SECTION("char type")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                              .signedness = Signedness::Signed,
-                                                              .isCharWithoutSign = true}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                               .signedness = Signedness::Signed,
+                                                               .isCharWithoutSign = true}};
           const auto* charType = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((charType->Size() == 1));
           REQUIRE(charType->Traits().Has(TypeTraitEnum::Character));
@@ -204,10 +204,10 @@ TEST_CASE("ArithmeticTypes - Character types", "[typesystem][arithmetic_types]")
      SECTION("signed char")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                               .signedness = Signedness::Signed}};
           const auto* signedChar = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((signedChar->Size() == 1));
      }
@@ -215,10 +215,10 @@ TEST_CASE("ArithmeticTypes - Character types", "[typesystem][arithmetic_types]")
      SECTION("unsigned char")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                              .signedness = Signedness::Unsigned}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                               .signedness = Signedness::Unsigned}};
           const auto* unsignedChar = ecpps::ir::GetTypeContext().Get(request);
           REQUIRE((unsignedChar->Size() == 1));
      }
@@ -226,10 +226,11 @@ TEST_CASE("ArithmeticTypes - Character types", "[typesystem][arithmetic_types]")
 
 TEST_CASE("ArithmeticTypes - Pointer types", "[typesystem][arithmetic_types]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
 
      SECTION("Pointer size matches platform")
@@ -250,11 +251,11 @@ TEST_CASE("ArithmeticTypes - Pointer types", "[typesystem][arithmetic_types]")
      SECTION("Pointer to char")
      {
           ecpps::ir::TypeRequest charRequest{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                              .signedness = Signedness::Signed,
-                                                              .isCharWithoutSign = true}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                               .signedness = Signedness::Signed,
+                                                               .isCharWithoutSign = true}};
           const auto* charType = ecpps::ir::GetTypeContext().Get(charRequest);
           ecpps::ir::TypeRequest ptrRequest{.kind = ecpps::ir::TypeKind::Compound,
                                             .qualifiers = Qualifiers::None,
@@ -286,10 +287,10 @@ TEST_CASE("ArithmeticTypes - Type names", "[typesystem][arithmetic_types]")
      SECTION("Int type name")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Signed}};
           const auto* intType = ecpps::ir::GetTypeContext().Get(request);
           auto name = intType->RawName();
           REQUIRE(!name.empty());
@@ -299,10 +300,10 @@ TEST_CASE("ArithmeticTypes - Type names", "[typesystem][arithmetic_types]")
      SECTION("Unsigned int type name")
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Unsigned}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Unsigned}};
           const auto* uintType = ecpps::ir::GetTypeContext().Get(request);
           auto name = uintType->RawName();
           REQUIRE(!name.empty());
@@ -312,10 +313,10 @@ TEST_CASE("ArithmeticTypes - Type names", "[typesystem][arithmetic_types]")
      SECTION("Pointer type name")
      {
           ecpps::ir::TypeRequest intRequest{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                              .signedness = Signedness::Signed}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                               .signedness = Signedness::Signed}};
           const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
           ecpps::ir::TypeRequest ptrRequest{.kind = ecpps::ir::TypeKind::Compound,
                                             .qualifiers = Qualifiers::None,
@@ -337,23 +338,23 @@ TEST_CASE("ArithmeticTypes - All integral type combinations", "[typesystem][arit
      };
 
      constexpr auto types =
-         std::to_array<TypeSpec>({{.kind = ecpps::typeSystem::TypeKind::Char, .sign = Signedness::Signed},
-                                  {.kind = ecpps::typeSystem::TypeKind::Char, .sign = Signedness::Unsigned},
-                                  {.kind = ecpps::typeSystem::TypeKind::Short, .sign = Signedness::Signed},
-                                  {.kind = ecpps::typeSystem::TypeKind::Short, .sign = Signedness::Unsigned},
-                                  {.kind = ecpps::typeSystem::TypeKind::Int, .sign = Signedness::Signed},
-                                  {.kind = ecpps::typeSystem::TypeKind::Int, .sign = Signedness::Unsigned},
-                                  {.kind = ecpps::typeSystem::TypeKind::Long, .sign = Signedness::Signed},
-                                  {.kind = ecpps::typeSystem::TypeKind::Long, .sign = Signedness::Unsigned},
-                                  {.kind = ecpps::typeSystem::TypeKind::LongLong, .sign = Signedness::Signed},
-                                  {.kind = ecpps::typeSystem::TypeKind::LongLong, .sign = Signedness::Unsigned}});
+          std::to_array<TypeSpec>({{.kind = ecpps::typeSystem::TypeKind::Char, .sign = Signedness::Signed},
+                                   {.kind = ecpps::typeSystem::TypeKind::Char, .sign = Signedness::Unsigned},
+                                   {.kind = ecpps::typeSystem::TypeKind::Short, .sign = Signedness::Signed},
+                                   {.kind = ecpps::typeSystem::TypeKind::Short, .sign = Signedness::Unsigned},
+                                   {.kind = ecpps::typeSystem::TypeKind::Int, .sign = Signedness::Signed},
+                                   {.kind = ecpps::typeSystem::TypeKind::Int, .sign = Signedness::Unsigned},
+                                   {.kind = ecpps::typeSystem::TypeKind::Long, .sign = Signedness::Signed},
+                                   {.kind = ecpps::typeSystem::TypeKind::Long, .sign = Signedness::Unsigned},
+                                   {.kind = ecpps::typeSystem::TypeKind::LongLong, .sign = Signedness::Signed},
+                                   {.kind = ecpps::typeSystem::TypeKind::LongLong, .sign = Signedness::Unsigned}});
 
      for (const auto& spec : types)
      {
           ecpps::ir::TypeRequest request{
-              .kind = ecpps::ir::TypeKind::Fundamental,
-              .qualifiers = Qualifiers::None,
-              .data = ecpps::ir::StandardSignedIntegerRequest{.size = spec.kind, .signedness = spec.sign}};
+               .kind = ecpps::ir::TypeKind::Fundamental,
+               .qualifiers = Qualifiers::None,
+               .data = ecpps::ir::StandardSignedIntegerRequest{.size = spec.kind, .signedness = spec.sign}};
           const auto* type = ecpps::ir::GetTypeContext().Get(request);
 
           INFO("Testing " << type->RawName());

--- a/testing/compiler/tests/unit/typesystem/test_arithmetic_types.cpp
+++ b/testing/compiler/tests/unit/typesystem/test_arithmetic_types.cpp
@@ -160,15 +160,30 @@ TEST_CASE("ArithmeticTypes - Type traits", "[typesystem][arithmetic_types]")
      const auto* intType = ecpps::ir::GetTypeContext().Get(request);
      auto traits = intType->Traits();
 
-     SECTION("Has Arithmetic trait") { REQUIRE(traits.Has(TypeTraitEnum::Arithmetic)); }
+     SECTION("Has Arithmetic trait")
+     {
+          REQUIRE(traits.Has(TypeTraitEnum::Arithmetic));
+     }
 
-     SECTION("Has Integral trait") { REQUIRE(traits.Has(TypeTraitEnum::Integral)); }
+     SECTION("Has Integral trait")
+     {
+          REQUIRE(traits.Has(TypeTraitEnum::Integral));
+     }
 
-     SECTION("Has Scalar trait") { REQUIRE(traits.Has(TypeTraitEnum::Scalar)); }
+     SECTION("Has Scalar trait")
+     {
+          REQUIRE(traits.Has(TypeTraitEnum::Scalar));
+     }
 
-     SECTION("Does not have FloatingPoint trait") { REQUIRE_FALSE(traits.Has(TypeTraitEnum::FloatingPoint)); }
+     SECTION("Does not have FloatingPoint trait")
+     {
+          REQUIRE_FALSE(traits.Has(TypeTraitEnum::FloatingPoint));
+     }
 
-     SECTION("Does not have Pointer trait") { REQUIRE_FALSE(traits.Has(TypeTraitEnum::Pointer)); }
+     SECTION("Does not have Pointer trait")
+     {
+          REQUIRE_FALSE(traits.Has(TypeTraitEnum::Pointer));
+     }
 }
 
 TEST_CASE("ArithmeticTypes - Character types", "[typesystem][arithmetic_types]")

--- a/testing/compiler/tests/unit/typesystem/test_type_comparison.cpp
+++ b/testing/compiler/tests/unit/typesystem/test_type_comparison.cpp
@@ -194,11 +194,20 @@ TEST_CASE("Type Comparison - Pointer type comparisons", "[typesystem][type_compa
      const auto* intPtr2 = ecpps::ir::GetTypeContext().Get(intPtr2Request);
      const auto* charPtr = ecpps::ir::GetTypeContext().Get(charPtrRequest);
 
-     SECTION("Pointers to same type are equal") { REQUIRE((*intPtr == intPtr2)); }
+     SECTION("Pointers to same type are equal")
+     {
+          REQUIRE((*intPtr == intPtr2));
+     }
 
-     SECTION("Pointers to different types are not equal") { REQUIRE_FALSE((*intPtr == charPtr)); }
+     SECTION("Pointers to different types are not equal")
+     {
+          REQUIRE_FALSE((*intPtr == charPtr));
+     }
 
-     SECTION("Pointer comparison with non-pointer") { REQUIRE_FALSE((*intPtr == intType)); }
+     SECTION("Pointer comparison with non-pointer")
+     {
+          REQUIRE_FALSE((*intPtr == intType));
+     }
 }
 
 TEST_CASE("Type Comparison - Array type comparisons", "[typesystem][type_comparison]")
@@ -227,9 +236,15 @@ TEST_CASE("Type Comparison - Array type comparisons", "[typesystem][type_compari
      const auto* intArray10Dup = ecpps::ir::GetTypeContext().Get(intArray10DupRequest);
      const auto* intArray20 = ecpps::ir::GetTypeContext().Get(intArray20Request);
 
-     SECTION("Arrays of same type and size are equal") { REQUIRE((*intArray10 == intArray10Dup)); }
+     SECTION("Arrays of same type and size are equal")
+     {
+          REQUIRE((*intArray10 == intArray10Dup));
+     }
 
-     SECTION("Arrays of same type but different size are not equal") { REQUIRE_FALSE((*intArray10 == intArray20)); }
+     SECTION("Arrays of same type but different size are not equal")
+     {
+          REQUIRE_FALSE((*intArray10 == intArray20));
+     }
 }
 
 TEST_CASE("Type Comparison - Multi-level pointer comparisons", "[typesystem][type_comparison]")
@@ -266,11 +281,20 @@ TEST_CASE("Type Comparison - Multi-level pointer comparisons", "[typesystem][typ
                                               .data = ecpps::ir::PointerRequest{.elementType = intPtr2}};
      const auto* intPtrPtr2 = ecpps::ir::GetTypeContext().Get(intPtrPtr2Request);
 
-     SECTION("int* != int**") { REQUIRE_FALSE((*intPtr == intPtrPtr)); }
+     SECTION("int* != int**")
+     {
+          REQUIRE_FALSE((*intPtr == intPtrPtr));
+     }
 
-     SECTION("int** == int** (same levels)") { REQUIRE((*intPtrPtr == intPtrPtr2)); }
+     SECTION("int** == int** (same levels)")
+     {
+          REQUIRE((*intPtrPtr == intPtrPtr2));
+     }
 
-     SECTION("int** != int***") { REQUIRE_FALSE((*intPtrPtr == intPtrPtrPtr)); }
+     SECTION("int** != int***")
+     {
+          REQUIRE_FALSE((*intPtrPtr == intPtrPtrPtr));
+     }
 }
 
 TEST_CASE("Type Comparison - Const qualifiers", "[typesystem][type_comparison]")
@@ -306,11 +330,20 @@ TEST_CASE("Type Comparison - Conversion sequence ranking", "[typesystem][type_co
                    static_cast<int>(ConversionKind::IntegralConversion)));
      }
 
-     SECTION("LvalueToRValue ranks highest") { REQUIRE((static_cast<int>(ConversionKind::LvalueToRValue) == 16)); }
+     SECTION("LvalueToRValue ranks highest")
+     {
+          REQUIRE((static_cast<int>(ConversionKind::LvalueToRValue) == 16));
+     }
 
-     SECTION("Ellipsis (variadic) ranks lowest") { REQUIRE((static_cast<int>(ConversionKind::Ellipsis) == 1)); }
+     SECTION("Ellipsis (variadic) ranks lowest")
+     {
+          REQUIRE((static_cast<int>(ConversionKind::Ellipsis) == 1));
+     }
 
-     SECTION("UserDefined ranks low") { REQUIRE((static_cast<int>(ConversionKind::UserDefined) == 2)); }
+     SECTION("UserDefined ranks low")
+     {
+          REQUIRE((static_cast<int>(ConversionKind::UserDefined) == 2));
+     }
 }
 
 TEST_CASE("Type Comparison - Cross-category comparisons", "[typesystem][type_comparison]")
@@ -331,11 +364,20 @@ TEST_CASE("Type Comparison - Cross-category comparisons", "[typesystem][type_com
                                             .data = ecpps::ir::BoundedArrayRequest{.elementType = intType, .size = 10}};
      const auto* intArray = ecpps::ir::GetTypeContext().Get(intArrayRequest);
 
-     SECTION("int != int*") { REQUIRE_FALSE((*intType == intPtr)); }
+     SECTION("int != int*")
+     {
+          REQUIRE_FALSE((*intType == intPtr));
+     }
 
-     SECTION("int != int[]") { REQUIRE_FALSE((*intType == intArray)); }
+     SECTION("int != int[]")
+     {
+          REQUIRE_FALSE((*intType == intArray));
+     }
 
-     SECTION("int* != int[]") { REQUIRE_FALSE((*intPtr == intArray)); }
+     SECTION("int* != int[]")
+     {
+          REQUIRE_FALSE((*intPtr == intArray));
+     }
 }
 
 TEST_CASE("Type Comparison - Nullptr and void* conversions", "[typesystem][type_comparison]")
@@ -415,9 +457,15 @@ TEST_CASE("Type Comparison - Type traits affect comparison", "[typesystem][type_
 
      auto traits = intType->Traits();
 
-     SECTION("Integral types have Arithmetic trait") { REQUIRE(traits.Has(TypeTraitEnum::Arithmetic)); }
+     SECTION("Integral types have Arithmetic trait")
+     {
+          REQUIRE(traits.Has(TypeTraitEnum::Arithmetic));
+     }
 
-     SECTION("Integral types have Integral trait") { REQUIRE(traits.Has(TypeTraitEnum::Integral)); }
+     SECTION("Integral types have Integral trait")
+     {
+          REQUIRE(traits.Has(TypeTraitEnum::Integral));
+     }
 
      SECTION("Pointer types have Pointer trait")
      {

--- a/testing/compiler/tests/unit/typesystem/test_type_comparison.cpp
+++ b/testing/compiler/tests/unit/typesystem/test_type_comparison.cpp
@@ -15,25 +15,25 @@ TEST_CASE("Type Comparison - operator==", "[typesystem][type_comparison]")
 {
      // Create some test types for comparison
      ecpps::ir::TypeRequest int32RequestA{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      ecpps::ir::TypeRequest int32RequestB{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      ecpps::ir::TypeRequest uint32Request{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                         .signedness = Signedness::Unsigned}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Unsigned}};
      ecpps::ir::TypeRequest int64Request{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::LongLong,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::LongLong,
+                                                          .signedness = Signedness::Signed}};
 
      const auto* int32A = ecpps::ir::GetTypeContext().Get(int32RequestA);
      const auto* int32B = ecpps::ir::GetTypeContext().Get(int32RequestB);
@@ -68,25 +68,25 @@ TEST_CASE("Type Comparison - operator==", "[typesystem][type_comparison]")
 TEST_CASE("Type Comparison - CompareTo conversion sequences", "[typesystem][type_comparison]")
 {
      ecpps::ir::TypeRequest int32SignedRequest{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      ecpps::ir::TypeRequest int32UnsignedRequest{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                         .signedness = Signedness::Unsigned}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Unsigned}};
      ecpps::ir::TypeRequest charRequest{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                          .signedness = Signedness::Signed}};
      ecpps::ir::TypeRequest shortRequest{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Short,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Short,
+                                                          .signedness = Signedness::Signed}};
 
      const auto* int32Signed = ecpps::ir::GetTypeContext().Get(int32SignedRequest);
      const auto* int32Unsigned = ecpps::ir::GetTypeContext().Get(int32UnsignedRequest);
@@ -124,20 +124,20 @@ TEST_CASE("Type Comparison - CompareTo conversion sequences", "[typesystem][type
 TEST_CASE("Type Comparison - CommonWith for binary operators", "[typesystem][type_comparison]")
 {
      ecpps::ir::TypeRequest int32Request{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      ecpps::ir::TypeRequest int64Request{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::LongLong,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::LongLong,
+                                                          .signedness = Signedness::Signed}};
      ecpps::ir::TypeRequest charRequest{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                          .signedness = Signedness::Signed}};
 
      const auto* int32 = ecpps::ir::GetTypeContext().Get(int32Request);
      const auto* int64 = ecpps::ir::GetTypeContext().Get(int64Request);
@@ -167,15 +167,16 @@ TEST_CASE("Type Comparison - CommonWith for binary operators", "[typesystem][typ
 
 TEST_CASE("Type Comparison - Pointer type comparisons", "[typesystem][type_comparison]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      ecpps::ir::TypeRequest charRequest{
-         .kind = ecpps::ir::TypeKind::Fundamental,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
-                                                         .signedness = Signedness::Signed}};
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Char,
+                                                          .signedness = Signedness::Signed}};
 
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
      const auto* charType = ecpps::ir::GetTypeContext().Get(charRequest);
@@ -212,25 +213,26 @@ TEST_CASE("Type Comparison - Pointer type comparisons", "[typesystem][type_compa
 
 TEST_CASE("Type Comparison - Array type comparisons", "[typesystem][type_comparison]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
 
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
 
      ecpps::ir::TypeRequest intArray10Request{.kind = ecpps::ir::TypeKind::Compound,
                                               .qualifiers = Qualifiers::None,
                                               .data =
-                                                  ecpps::ir::BoundedArrayRequest{.elementType = intType, .size = 10}};
+                                                   ecpps::ir::BoundedArrayRequest{.elementType = intType, .size = 10}};
      ecpps::ir::TypeRequest intArray10DupRequest{
-         .kind = ecpps::ir::TypeKind::Compound,
-         .qualifiers = Qualifiers::None,
-         .data = ecpps::ir::BoundedArrayRequest{.elementType = intType, .size = 10}};
+          .kind = ecpps::ir::TypeKind::Compound,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::BoundedArrayRequest{.elementType = intType, .size = 10}};
      ecpps::ir::TypeRequest intArray20Request{.kind = ecpps::ir::TypeKind::Compound,
                                               .qualifiers = Qualifiers::None,
                                               .data =
-                                                  ecpps::ir::BoundedArrayRequest{.elementType = intType, .size = 20}};
+                                                   ecpps::ir::BoundedArrayRequest{.elementType = intType, .size = 20}};
 
      const auto* intArray10 = ecpps::ir::GetTypeContext().Get(intArray10Request);
      const auto* intArray10Dup = ecpps::ir::GetTypeContext().Get(intArray10DupRequest);
@@ -249,10 +251,11 @@ TEST_CASE("Type Comparison - Array type comparisons", "[typesystem][type_compari
 
 TEST_CASE("Type Comparison - Multi-level pointer comparisons", "[typesystem][type_comparison]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
 
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
 
@@ -299,10 +302,11 @@ TEST_CASE("Type Comparison - Multi-level pointer comparisons", "[typesystem][typ
 
 TEST_CASE("Type Comparison - Const qualifiers", "[typesystem][type_comparison]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
 
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
 
@@ -348,10 +352,11 @@ TEST_CASE("Type Comparison - Conversion sequence ranking", "[typesystem][type_co
 
 TEST_CASE("Type Comparison - Cross-category comparisons", "[typesystem][type_comparison]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
 
      ecpps::ir::TypeRequest intPtrRequest{.kind = ecpps::ir::TypeKind::Compound,
@@ -382,10 +387,11 @@ TEST_CASE("Type Comparison - Cross-category comparisons", "[typesystem][type_com
 
 TEST_CASE("Type Comparison - Nullptr and void* conversions", "[typesystem][type_comparison]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
 
      ecpps::ir::TypeRequest intPtrRequest{.kind = ecpps::ir::TypeKind::Compound,
@@ -403,10 +409,11 @@ TEST_CASE("Type Comparison - Nullptr and void* conversions", "[typesystem][type_
 
 TEST_CASE("Type Comparison - Array decay to pointer", "[typesystem][type_comparison]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
 
      ecpps::ir::TypeRequest intArrayRequest{.kind = ecpps::ir::TypeKind::Compound,
@@ -449,10 +456,11 @@ TEST_CASE("Type Comparison - Floating point comparisons", "[typesystem][type_com
 
 TEST_CASE("Type Comparison - Type traits affect comparison", "[typesystem][type_comparison]")
 {
-     ecpps::ir::TypeRequest intRequest{.kind = ecpps::ir::TypeKind::Fundamental,
-                                       .qualifiers = Qualifiers::None,
-                                       .data = ecpps::ir::StandardSignedIntegerRequest{
-                                           .size = ecpps::typeSystem::TypeKind::Int, .signedness = Signedness::Signed}};
+     ecpps::ir::TypeRequest intRequest{
+          .kind = ecpps::ir::TypeKind::Fundamental,
+          .qualifiers = Qualifiers::None,
+          .data = ecpps::ir::StandardSignedIntegerRequest{.size = ecpps::typeSystem::TypeKind::Int,
+                                                          .signedness = Signedness::Signed}};
      const auto* intType = ecpps::ir::GetTypeContext().Get(intRequest);
 
      auto traits = intType->Traits();

--- a/testing/compiler/tests/unit/utilities/test_sbo_vector.cpp
+++ b/testing/compiler/tests/unit/utilities/test_sbo_vector.cpp
@@ -25,7 +25,10 @@ TEST_CASE("SBOVector - Construction", "[utilities][sbo_vector]")
      {
           SBOVector<std::size_t> vec(5, 42);
           REQUIRE((vec.Size() == 5));
-          for (std::size_t i = 0; i < vec.Size(); i++) { REQUIRE((vec.begin()[i] == 42)); }
+          for (std::size_t i = 0; i < vec.Size(); i++)
+          {
+               REQUIRE((vec.begin()[i] == 42));
+          }
      }
 
      SECTION("Push elements to construct")
@@ -50,7 +53,10 @@ TEST_CASE("SBOVector - Capacity transitions", "[utilities][sbo_vector]")
      SECTION("Inline storage - stays on stack")
      {
           // Add elements up to inline capacity
-          for (std::size_t i = 0; i < 8; i++) { vec.Push(i); }
+          for (std::size_t i = 0; i < 8; i++)
+          {
+               vec.Push(i);
+          }
           REQUIRE((vec.Size() == 8));
           REQUIRE(vec.UseSBO()); // Should still use SBO
      }
@@ -58,12 +64,18 @@ TEST_CASE("SBOVector - Capacity transitions", "[utilities][sbo_vector]")
      SECTION("Transition to heap")
      {
           // Add many elements to force heap allocation
-          for (std::size_t i = 0; i < 100; i++) { vec.Push(i); }
+          for (std::size_t i = 0; i < 100; i++)
+          {
+               vec.Push(i);
+          }
           REQUIRE((vec.Size() == 100));
           REQUIRE(!vec.UseSBO()); // Should have transitioned to heap
 
           // Verify all elements
-          for (std::size_t i = 0; i < 100; i++) { REQUIRE((vec.begin()[i] == i)); }
+          for (std::size_t i = 0; i < 100; i++)
+          {
+               REQUIRE((vec.begin()[i] == i));
+          }
      }
 }
 
@@ -91,24 +103,36 @@ TEST_CASE("SBOVector - Copy semantics", "[utilities][sbo_vector]")
      SECTION("Copy heap vector")
      {
           SBOVector<std::size_t> vec1;
-          for (std::size_t i = 0; i < 100; i++) { vec1.Push(i); }
+          for (std::size_t i = 0; i < 100; i++)
+          {
+               vec1.Push(i);
+          }
 
           SBOVector<std::size_t> vec2 = vec1;
           REQUIRE((vec2.Size() == 100));
 
-          for (std::size_t i = 0; i < 100; i++) { REQUIRE((vec2.begin()[i] == i)); }
+          for (std::size_t i = 0; i < 100; i++)
+          {
+               REQUIRE((vec2.begin()[i] == i));
+          }
      }
 
      SECTION("Copy assignment")
      {
           SBOVector<std::size_t> vec1;
-          for (std::size_t i = 1; i <= 5; i++) { vec1.Push(i); }
+          for (std::size_t i = 1; i <= 5; i++)
+          {
+               vec1.Push(i);
+          }
 
           SBOVector<std::size_t> vec2;
           vec2 = vec1;
 
           REQUIRE((vec2.Size() == 5));
-          for (std::size_t i = 0; i < vec2.Size(); i++) { REQUIRE((vec2.begin()[i] == vec1.begin()[i])); }
+          for (std::size_t i = 0; i < vec2.Size(); i++)
+          {
+               REQUIRE((vec2.begin()[i] == vec1.begin()[i]));
+          }
      }
 }
 
@@ -132,18 +156,27 @@ TEST_CASE("SBOVector - Move semantics", "[utilities][sbo_vector]")
      SECTION("Move heap vector")
      {
           SBOVector<std::size_t> vec1;
-          for (std::size_t i = 0; i < 100; i++) { vec1.Push(i); }
+          for (std::size_t i = 0; i < 100; i++)
+          {
+               vec1.Push(i);
+          }
 
           SBOVector<std::size_t> vec2 = std::move(vec1);
           REQUIRE((vec2.Size() == 100));
 
-          for (std::size_t i = 0; i < 100; i++) { REQUIRE((vec2.begin()[i] == i)); }
+          for (std::size_t i = 0; i < 100; i++)
+          {
+               REQUIRE((vec2.begin()[i] == i));
+          }
      }
 
      SECTION("Move assignment")
      {
           SBOVector<std::size_t> vec1;
-          for (std::size_t i = 1; i <= 5; i++) { vec1.Push(i); }
+          for (std::size_t i = 1; i <= 5; i++)
+          {
+               vec1.Push(i);
+          }
 
           SBOVector<std::size_t> vec2;
           vec2 = std::move(vec1);
@@ -164,7 +197,10 @@ TEST_CASE("SBOVector - Iterator correctness", "[utilities][sbo_vector]")
      SECTION("Range-based for loop")
      {
           std::vector<std::size_t> values;
-          for (auto val : vec) { values.push_back(val); }
+          for (auto val : vec)
+          {
+               values.push_back(val);
+          }
           REQUIRE((values.size() == 5));
           REQUIRE((values[0] == 10));
           REQUIRE((values[4] == 50));
@@ -174,7 +210,10 @@ TEST_CASE("SBOVector - Iterator correctness", "[utilities][sbo_vector]")
      {
           const auto& constVec = vec;
           int count = 0;
-          for (const auto* it = constVec.begin(); it != constVec.end(); ++it) { ++count; }
+          for (const auto* it = constVec.begin(); it != constVec.end(); ++it)
+          {
+               ++count;
+          }
           REQUIRE((count == 5));
      }
 }
@@ -207,12 +246,18 @@ TEST_CASE("SBOVector - Modifiers", "[utilities][sbo_vector]")
 
      SECTION("Push many elements")
      {
-          for (std::size_t i = 0; i < 50; i++) { vec.Push(i * 2); }
+          for (std::size_t i = 0; i < 50; i++)
+          {
+               vec.Push(i * 2);
+          }
 
           REQUIRE((vec.Size() == 50));
 
           // Verify elements
-          for (std::size_t i = 0; i < 50; i++) { REQUIRE((vec.begin()[i] == i * 2)); }
+          for (std::size_t i = 0; i < 50; i++)
+          {
+               REQUIRE((vec.begin()[i] == i * 2));
+          }
      }
 }
 
@@ -254,7 +299,9 @@ TEST_CASE("SBOVector - Complex types", "[utilities][sbo_vector]")
           int value;
           std::string name;
 
-          ComplexType(int v, std::string n) : value(v), name(std::move(n)) {}
+          ComplexType(int v, std::string n) : value(v), name(std::move(n))
+          {
+          }
      };
 
      SBOVector<ComplexType> vec;
@@ -300,7 +347,10 @@ TEST_CASE("SBOVector - Size tracking", "[utilities][sbo_vector]")
           vec.Push(2);
           REQUIRE((vec.Size() == 2));
 
-          for (std::size_t i = 0; i < 10; i++) { vec.Push(i); }
+          for (std::size_t i = 0; i < 10; i++)
+          {
+               vec.Push(i);
+          }
           REQUIRE((vec.Size() == 12));
      }
 
@@ -326,7 +376,10 @@ TEST_CASE("SBOVector - UseSBO flag", "[utilities][sbo_vector]")
 
      SECTION("Large vectors don't use SBO")
      {
-          for (std::size_t i = 0; i < 200; i++) { vec.Push(i); }
+          for (std::size_t i = 0; i < 200; i++)
+          {
+               vec.Push(i);
+          }
 
           REQUIRE(!vec.UseSBO());
      }

--- a/testing/stdlib/test_stdlib.cpp
+++ b/testing/stdlib/test_stdlib.cpp
@@ -1,1 +1,3 @@
-int main(void) {}
+int main(void)
+{
+}


### PR DESCRIPTION
Increase readability of functions by enforcing a clang-format rule to break blocks
```diff
- AllowShortFunctionsOnASingleLine: All
- AllowShortLambdasOnASingleLine: All
- AllowShortBlocksOnASingleLine: Always
+ AllowShortFunctionsOnASingleLine: None
+ AllowShortLambdasOnASingleLine: None
+ AllowShortBlocksOnASingleLine: Never
```
Configuration diff

Fixes #233 