### PR TITLE
Use the proper diagnostics api in the preprocessor

### DIFF
--- a/compiler/ecpps/src/FileSystem/SourceScanner.cpp
+++ b/compiler/ecpps/src/FileSystem/SourceScanner.cpp
@@ -24,7 +24,7 @@ const std::filesystem::path& ecpps::fs::SourceScanner::ResolveInclude(const std:
           const auto& localPath = currentPath.parent_path() / name;
           if (std::filesystem::exists(localPath)) return cache.try_emplace(name, canonical(localPath)).first->second;
      }
-     throw std::runtime_error("Include file not found: " + name);
+     throw FileNotFoundException{.name = name};
 }
 
 const std::string& ecpps::fs::SourceScanner::GetFileContents(const std::filesystem::path& path)

--- a/compiler/ecpps/src/FileSystem/SourceScanner.h
+++ b/compiler/ecpps/src/FileSystem/SourceScanner.h
@@ -7,6 +7,10 @@
 
 namespace ecpps::fs
 {
+     struct FileNotFoundException
+     {
+          std::string name;
+     };
      struct IncludeCache
      {
           std::unordered_map<std::string, std::filesystem::path> cache;

--- a/compiler/ecpps/src/Parsing/Preprocessor.cpp
+++ b/compiler/ecpps/src/Parsing/Preprocessor.cpp
@@ -160,15 +160,24 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                          if (sourceIterator != source.end()) ++sourceIterator; // skip closing delimiter
                     }
 
-                    std::filesystem::path resolvedPath = ecpps::fs::GetSourceScanner().ResolveInclude(
-                         fileName, header,
-                         (delimiter == '"') ? ecpps::fs::IncludeType::Local : ecpps::fs::IncludeType::System);
-                    if (std::ranges::find(includedFiles, resolvedPath) == includedFiles.end())
+                    try
                     {
-                         const auto& includedSource = ecpps::fs::GetSourceScanner().GetFileContents(resolvedPath);
 
-                         tokens.append_range(
-                              Parse(includedSource, macros, resolvedPath.string(), includedFiles, includeDirectories));
+                         std::filesystem::path resolvedPath = ecpps::fs::GetSourceScanner().ResolveInclude(
+                              fileName, header,
+                              (delimiter == '"') ? ecpps::fs::IncludeType::Local : ecpps::fs::IncludeType::System);
+                         if (std::ranges::find(includedFiles, resolvedPath) == includedFiles.end())
+                         {
+                              const auto& includedSource = ecpps::fs::GetSourceScanner().GetFileContents(resolvedPath);
+
+                              tokens.append_range(Parse(includedSource, macros, resolvedPath.string(), includedFiles,
+                                                        includeDirectories));
+                         }
+                    }
+                    catch (const fs::FileNotFoundException& fileNotFound)
+                    {
+                         this->diagnostics.push_back(std::make_unique<diagnostics::SyntaxError>(
+                              std::format("Unable to include file '{}'", fileNotFound.name), location));
                     }
                }
                else if (directive == "define")

--- a/compiler/ecpps/src/Parsing/Preprocessor.cpp
+++ b/compiler/ecpps/src/Parsing/Preprocessor.cpp
@@ -8,6 +8,7 @@
 #include <print>
 #include <unordered_map>
 #include <unordered_set>
+#include "Shared/Error.h"
 
 static std::string ReadEscapedLiteral(std::string::const_iterator& it, const std::string::const_iterator& end,
                                       char delimiter)
@@ -390,10 +391,12 @@ std::vector<ecpps::PreprocessingToken> ecpps::Preprocessor::Parse(const std::str
                          errorMessage += *sourceIterator;
                          Advance(sourceIterator);
                     }
-                    throw std::runtime_error("preprocessor error: " + errorMessage);
+                    this->diagnostics.push_back(std::make_unique<diagnostics::SyntaxError>(
+                         std::format("preprocessor error: {}", errorMessage), location));
                }
                else
-                    throw std::runtime_error(std::format("unknown preprocessor directive: {}", directive));
+                    this->diagnostics.push_back(std::make_unique<diagnostics::SyntaxError>(
+                         std::format("unknown preprocessor directive: {}", directive), location));
 
                if (sourceIterator != source.begin()) --sourceIterator;
                location.position = 0;


### PR DESCRIPTION
Instead of throwing on error, use the diagnostics APIs for showing the error to the user.